### PR TITLE
Refactor: Make ETH_BLOCK_NUMBER optional in tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 ETH_RPC_URL=https://rpc.gnosis.gateway.fm
-ETH_BLOCK_NUMBER=32661487
+# ETH_BLOCK_NUMBER is optional - if not provided, tests will use the latest block
+# ETH_BLOCK_NUMBER=32661487

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,6 @@ jobs:
       - name: Run Forge tests
         run: |
           forge test -vvv
+        env:
+          ETH_RPC_URL: ${{ vars.ETH_RPC_URL }}
         id: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,5 +41,5 @@ jobs:
         run: |
           forge test -vvv
         env:
-          ETH_RPC_URL: ${{ vars.ETH_RPC_URL }}
+          ETH_RPC_URL: ${{ secrets.ETH_RPC_URL || vars.ETH_RPC_URL || 'https://rpc.gnosis.gateway.fm' }}
         id: test

--- a/test/TestWrapper.sol
+++ b/test/TestWrapper.sol
@@ -6,7 +6,7 @@ import "forge-std/Test.sol";
 contract TestWrapper is Test {
     constructor() {
         string memory rpcUrl = vm.envString("ETH_RPC_URL");
-        
+
         // Try to use ETH_BLOCK_NUMBER from env if provided, otherwise use latest
         uint256 blockNumber;
         try vm.envUint("ETH_BLOCK_NUMBER") returns (uint256 envBlockNumber) {
@@ -15,7 +15,7 @@ contract TestWrapper is Test {
             // If ETH_BLOCK_NUMBER is not set, fork at the latest block
             blockNumber = 0; // 0 means latest block in Foundry
         }
-        
+
         if (blockNumber == 0) {
             // Fork at latest block
             vm.createSelectFork(rpcUrl);

--- a/test/TestWrapper.sol
+++ b/test/TestWrapper.sol
@@ -5,7 +5,24 @@ import "forge-std/Test.sol";
 
 contract TestWrapper is Test {
     constructor() {
-        vm.createSelectFork(vm.envString("ETH_RPC_URL"), vm.envUint("ETH_BLOCK_NUMBER"));
+        string memory rpcUrl = vm.envString("ETH_RPC_URL");
+        
+        // Try to use ETH_BLOCK_NUMBER from env if provided, otherwise use latest
+        uint256 blockNumber;
+        try vm.envUint("ETH_BLOCK_NUMBER") returns (uint256 envBlockNumber) {
+            blockNumber = envBlockNumber;
+        } catch {
+            // If ETH_BLOCK_NUMBER is not set, fork at the latest block
+            blockNumber = 0; // 0 means latest block in Foundry
+        }
+        
+        if (blockNumber == 0) {
+            // Fork at latest block
+            vm.createSelectFork(rpcUrl);
+        } else {
+            // Fork at specific block
+            vm.createSelectFork(rpcUrl, blockNumber);
+        }
     }
 
     function _reset(string memory url_, uint256 blockNumber) internal {


### PR DESCRIPTION
## Summary
- Refactored test infrastructure to automatically use the latest block from the fork when `ETH_BLOCK_NUMBER` is not provided
- Maintains backward compatibility for users who want to test against specific block numbers
- Updates `.env.example` with clear documentation about the optional nature of `ETH_BLOCK_NUMBER`

## Changes
1. **Modified `TestWrapper.sol`**: 
   - Added logic to check if `ETH_BLOCK_NUMBER` is provided
   - Falls back to latest block (by omitting block number in `vm.createSelectFork()`) when not set
   - Preserves ability to use specific block numbers when provided

2. **Updated `.env.example`**:
   - Added comments explaining that `ETH_BLOCK_NUMBER` is now optional
   - Commented out the block number by default to demonstrate the new behavior

## Test plan
- [x] Tested with `ETH_BLOCK_NUMBER` not set - uses latest block ✅
- [x] Tested with `ETH_BLOCK_NUMBER=32661487` - uses specific block ✅
- [x] All existing tests pass without modification ✅

🤖 Generated with [Claude Code](https://claude.ai/code)