### PR TITLE
Fix: Throw YieldInsufficient error when yield is zero

### DIFF
--- a/src/BaseToken.sol
+++ b/src/BaseToken.sol
@@ -79,6 +79,7 @@ abstract contract BaseToken is ERC20VotesUpgradeable, Ownable, IBreadKitToken {
         if (msg.sender != yieldClaimer) revert OnlyClaimer();
         if (amount_ == 0) revert ClaimZero();
         uint256 yield = _yieldAccrued();
+        if (yield == 0) revert YieldInsufficient();
         if (yield < amount_) revert YieldInsufficient();
 
         _mint(receiver_, amount_);


### PR DESCRIPTION
## Summary
- Added explicit check to throw `YieldInsufficient()` error when `_yieldAccrued()` returns 0
- Prevents zero-yield claims in the `claimYield` function

## Changes
Modified `src/BaseToken.sol` to add a check that reverts with `YieldInsufficient()` when the calculated yield is zero, before checking if yield is less than the requested amount.

## Test plan
- [x] Run existing test suite with `forge test`
- [x] Verify that the new check doesn't break existing functionality

Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)