### PR TITLE
feat: Auto-format code with forge fmt on PRs

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,53 @@
+name: Auto-format Code
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format:
+    name: Auto-format with forge fmt
+    runs-on: ubuntu-latest
+    
+    # Skip if the last commit was from this action to avoid loops
+    if: github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.head_commit.message, '[auto-format]')
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+      
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      
+      - name: Run forge fmt
+        run: forge fmt
+      
+      - name: Check for changes
+        id: git-check
+        run: |
+          if git diff --exit-code; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No formatting changes needed"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Formatting changes detected"
+          fi
+      
+      - name: Commit and push changes
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add -A
+          git commit -m "chore: auto-format code with forge fmt [auto-format]"
+          git push origin HEAD:${{ github.head_ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Auto-format Code"]
+    types:
+      - completed
 
 env:
   FOUNDRY_PROFILE: ci
@@ -27,7 +31,9 @@ jobs:
         run: |
           forge --version
 
+      # Skip format check on PRs since auto-format workflow handles it
       - name: Run Forge fmt
+        if: github.event_name != 'pull_request'
         run: |
           forge fmt --check
         id: fmt


### PR DESCRIPTION
## Summary
Implements automatic code formatting with `forge fmt` on pull requests to reduce developer friction and ensure consistent code style.

## Changes
- ✨ Added new `auto-format.yml` workflow that:
  - Triggers on PR events (opened, synchronize, reopened)
  - Runs `forge fmt` automatically
  - Commits formatting changes back to the PR branch
  - Includes loop prevention with `[auto-format]` commit tag
  
- 🔧 Updated `test.yml` workflow to:
  - Trigger after auto-format workflow completes
  - Skip format checking on PRs (since auto-format handles it)
  - Still check formatting on direct pushes to main

## Implementation Details
- Only runs on PRs from the same repository (not forks) for security
- Uses `github-actions[bot]` user for commits
- Skips if the last commit was already an auto-format to prevent loops
- Preserves all existing CI checks and tests

## Testing
The workflows have been validated for YAML syntax. Once merged, the auto-format will activate on the next PR.

## Closes
Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)