### PR TITLE
Comment out Gelato automation references in tests

### DIFF
--- a/test/automation/AutomationBase.t.sol
+++ b/test/automation/AutomationBase.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
 import "../../src/modules/automation/ChainlinkAutomation.sol";
-import "../../src/modules/automation/GelatoAutomation.sol";
+// import "../../src/modules/automation/GelatoAutomation.sol";
 import "../../src/mocks/MockDistributionManager.sol";
 import "../../src/interfaces/IDistributionModule.sol";
 
@@ -58,12 +58,12 @@ contract MockDistributionModule is IDistributionModule {
 
 contract AutomationBaseTest is Test {
     ChainlinkAutomation public chainlinkAutomation;
-    GelatoAutomation public gelatoAutomation;
+    // GelatoAutomation public gelatoAutomation;
     MockDistributionManager public distributionManager;
     MockDistributionModule public distributionModule;
 
     address public chainlinkKeeper = address(0x1);
-    address public gelatoExecutor = address(0x2);
+    // address public gelatoExecutor = address(0x2);
 
     event AutomationExecuted(address indexed executor, uint256 blockNumber);
     event DistributionExecuted(uint256 blockNumber, uint256 yield, uint256 votes);
@@ -77,7 +77,7 @@ contract AutomationBaseTest is Test {
 
         // Deploy automation implementations
         chainlinkAutomation = new ChainlinkAutomation(address(distributionManager));
-        gelatoAutomation = new GelatoAutomation(address(distributionManager));
+        // gelatoAutomation = new GelatoAutomation(address(distributionManager));
 
         // Setup initial state
         distributionManager.setCurrentVotes(100);
@@ -118,39 +118,39 @@ contract AutomationBaseTest is Test {
         assertEq(distributionManager.currentCycleNumber(), 2);
     }
 
-    function testGelatoChecker() public {
-        // Initially should not be executable (too soon)
-        (bool canExec, bytes memory execPayload) = gelatoAutomation.checker();
-        assertFalse(canExec);
+    // function testGelatoChecker() public {
+    //     // Initially should not be executable (too soon)
+    //     (bool canExec, bytes memory execPayload) = gelatoAutomation.checker();
+    //     assertFalse(canExec);
 
-        // Advance blocks
-        vm.roll(block.number + 101);
+    //     // Advance blocks
+    //     vm.roll(block.number + 101);
 
-        // Now should be executable
-        (canExec, execPayload) = gelatoAutomation.checker();
-        assertTrue(canExec);
-        assertGt(execPayload.length, 0);
-    }
+    //     // Now should be executable
+    //     (canExec, execPayload) = gelatoAutomation.checker();
+    //     assertTrue(canExec);
+    //     assertGt(execPayload.length, 0);
+    // }
 
-    function testGelatoExecute() public {
-        // Advance blocks to make distribution ready
-        vm.roll(block.number + 101);
+    // function testGelatoExecute() public {
+    //     // Advance blocks to make distribution ready
+    //     vm.roll(block.number + 101);
 
-        // Check if executable
-        (bool canExec,) = gelatoAutomation.checker();
-        assertTrue(canExec);
+    //     // Check if executable
+    //     (bool canExec,) = gelatoAutomation.checker();
+    //     assertTrue(canExec);
 
-        // Execute
-        vm.expectEmit(true, false, false, true);
-        emit AutomationExecuted(gelatoExecutor, block.number);
+    //     // Execute
+    //     vm.expectEmit(true, false, false, true);
+    //     emit AutomationExecuted(gelatoExecutor, block.number);
 
-        vm.prank(gelatoExecutor);
-        gelatoAutomation.execute("");
+    //     vm.prank(gelatoExecutor);
+    //     gelatoAutomation.execute("");
 
-        // Verify distribution was called
-        assertEq(distributionModule.distributeCallCount(), 1);
-        assertEq(distributionManager.currentCycleNumber(), 2);
-    }
+    //     // Verify distribution was called
+    //     assertEq(distributionModule.distributeCallCount(), 1);
+    //     assertEq(distributionManager.currentCycleNumber(), 2);
+    // }
 
     function testResolveDistributionConditions() public {
         // Test: Not enough blocks passed
@@ -226,25 +226,25 @@ contract AutomationBaseTest is Test {
         assertEq(endBlock, block.number + 100);
     }
 
-    function testBothAutomationTypesWork() public {
-        // Test Chainlink automation
-        vm.roll(block.number + 101);
-        distributionManager.setCurrentVotes(100);
-        distributionManager.setAvailableYield(2000);
+    // function testBothAutomationTypesWork() public {
+    //     // Test Chainlink automation
+    //     vm.roll(block.number + 101);
+    //     distributionManager.setCurrentVotes(100);
+    //     distributionManager.setAvailableYield(2000);
 
-        vm.prank(chainlinkKeeper);
-        chainlinkAutomation.performUpkeep("");
-        assertEq(distributionModule.distributeCallCount(), 1);
+    //     vm.prank(chainlinkKeeper);
+    //     chainlinkAutomation.performUpkeep("");
+    //     assertEq(distributionModule.distributeCallCount(), 1);
 
-        // Test Gelato automation
-        vm.roll(block.number + 101);
-        distributionManager.setCurrentVotes(100);
-        distributionManager.setAvailableYield(2000);
+    //     // // Test Gelato automation
+    //     // vm.roll(block.number + 101);
+    //     // distributionManager.setCurrentVotes(100);
+    //     // distributionManager.setAvailableYield(2000);
 
-        vm.prank(gelatoExecutor);
-        gelatoAutomation.execute("");
-        assertEq(distributionModule.distributeCallCount(), 2);
-    }
+    //     // vm.prank(gelatoExecutor);
+    //     // gelatoAutomation.execute("");
+    //     // assertEq(distributionModule.distributeCallCount(), 2);
+    // }
 
     function testMinYieldRequired() public {
         vm.roll(block.number + 101);


### PR DESCRIPTION
## Summary
- Commented out all Gelato automation references in the test files
- Maintains Chainlink automation functionality for testing

## Changes
- Commented out `GelatoAutomation` import statement
- Commented out Gelato-related variable declarations (`gelatoAutomation`, `gelatoExecutor`)
- Commented out Gelato initialization in `setUp()`
- Commented out Gelato-specific test functions:
  - `testGelatoChecker()`
  - `testGelatoExecute()`
  - `testBothAutomationTypesWork()` (entire function since it tested both automation types)

## Test plan
- [ ] Run test suite to confirm Chainlink automation tests still pass
- [ ] Verify no compilation errors from missing Gelato references

🤖 Generated with [Claude Code](https://claude.ai/code)