### PR TITLE
Refactor all modules to factory pattern (fixes #36)

### DIFF
--- a/src/CrowdStakeFactory.sol
+++ b/src/CrowdStakeFactory.sol
@@ -72,10 +72,7 @@ contract CrowdStakeFactory is Ownable {
         emit CreateYieldDistributor(yieldClaimer, token_, initialRecipients_, percentVoted_, owner_);
     }
 
-    function createModule(address beacon_, bytes calldata payload_, bytes32 salt_)
-        external
-        returns (address module)
-    {
+    function createModule(address beacon_, bytes calldata payload_, bytes32 salt_) external returns (address module) {
         if (!_beacons.contains(beacon_)) {
             revert NotWhitelistedBeacon();
         }

--- a/src/CrowdStakeFactory.sol
+++ b/src/CrowdStakeFactory.sol
@@ -17,6 +17,7 @@ contract CrowdStakeFactory is Ownable {
     event WhitelistBeacons(address[] beacons);
     event BlacklistBeacons(address[] beacons);
     event CreateToken(address token, address beacon, bytes payload);
+    event CreateModule(address module, address beacon, bytes payload);
     event CreateYieldDistributor(
         address yieldClaimer, address token, address[] initialRecipients, uint256 percentVoted, address owner
     );
@@ -39,7 +40,7 @@ contract CrowdStakeFactory is Ownable {
             mstore(add(ptr, 0x20), salt_)
             salt := keccak256(ptr, 0x40)
         }
-        bytes memory bytecode = _getTokenInitCode(beacon_, payload_);
+        bytes memory bytecode = _getBeaconProxyInitCode(beacon_, payload_);
         assembly {
             token := create2(0, add(bytecode, 0x20), mload(bytecode), salt)
         }
@@ -69,6 +70,46 @@ contract CrowdStakeFactory is Ownable {
         if (yieldClaimer == address(0)) revert Create2Failed();
 
         emit CreateYieldDistributor(yieldClaimer, token_, initialRecipients_, percentVoted_, owner_);
+    }
+
+    function createModule(address beacon_, bytes calldata payload_, bytes32 salt_)
+        external
+        returns (address module)
+    {
+        if (!_beacons.contains(beacon_)) {
+            revert NotWhitelistedBeacon();
+        }
+
+        bytes32 salt;
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, caller())
+            mstore(add(ptr, 0x20), salt_)
+            salt := keccak256(ptr, 0x40)
+        }
+        bytes memory bytecode = _getBeaconProxyInitCode(beacon_, payload_);
+        assembly {
+            module := create2(0, add(bytecode, 0x20), mload(bytecode), salt)
+        }
+        if (module == address(0)) revert Create2Failed();
+
+        emit CreateModule(module, beacon_, payload_);
+    }
+
+    function computeModuleAddress(address beacon_, bytes calldata payload_, bytes32 salt_)
+        external
+        view
+        returns (address module)
+    {
+        bytes memory bytecode = _getBeaconProxyInitCode(beacon_, payload_);
+        bytes32 salt;
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, caller())
+            mstore(add(ptr, 0x20), salt_)
+            salt := keccak256(ptr, 0x40)
+        }
+        module = _getCreate2Address(salt, keccak256(bytecode));
     }
 
     function whitelistBeacons(address[] calldata beacons_) external onlyOwner {
@@ -117,7 +158,7 @@ contract CrowdStakeFactory is Ownable {
         view
         returns (address token)
     {
-        bytes memory bytecode = _getTokenInitCode(beacon_, payload_);
+        bytes memory bytecode = _getBeaconProxyInitCode(beacon_, payload_);
         bytes32 salt;
         assembly {
             let ptr := mload(0x40)
@@ -146,7 +187,7 @@ contract CrowdStakeFactory is Ownable {
         yieldClaimer = _getCreate2Address(salt, keccak256(bytecode));
     }
 
-    function _getTokenInitCode(address beacon_, bytes calldata payload_) internal pure returns (bytes memory) {
+    function _getBeaconProxyInitCode(address beacon_, bytes calldata payload_) internal pure returns (bytes memory) {
         return abi.encodePacked(type(BeaconProxy).creationCode, abi.encode(beacon_, payload_));
     }
 

--- a/src/abstract/AbstractCycleModule.sol
+++ b/src/abstract/AbstractCycleModule.sol
@@ -63,6 +63,8 @@ abstract contract AbstractCycleModule is Initializable, ICycleModule {
     /// @notice Error thrown when module is not initialized
     error NotInitialized();
 
+    error ZeroAddress();
+
     // ============ Events ============
 
     /// @notice Emitted when a new cycle starts
@@ -126,6 +128,9 @@ abstract contract AbstractCycleModule is Initializable, ICycleModule {
     function initialize(uint256 _cycleLength, address _authorized) external initializer {
         if (_cycleLength == 0) {
             revert InvalidCycleLength();
+        }
+        if (_authorized == address(0)) {
+            revert ZeroAddress();
         }
 
         AbstractCycleModuleStorage storage $ = _getAbstractCycleModuleStorage();

--- a/src/abstract/AbstractCycleModule.sol
+++ b/src/abstract/AbstractCycleModule.sol
@@ -2,25 +2,54 @@
 pragma solidity ^0.8.20;
 
 import {ICycleModule} from "../interfaces/ICycleModule.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 /// @title AbstractCycleModule
 /// @notice Abstract contract providing core cycle functionality with fixed cycle implementation
-/// @dev All cycle utilities merged into a single abstract module
-abstract contract AbstractCycleModule is ICycleModule {
-    /// @notice The length of each cycle in blocks
-    uint256 public cycleLength;
+/// @dev All cycle utilities merged into a single abstract module. Uses EIP-7201 namespaced storage for proxy compatibility.
+abstract contract AbstractCycleModule is Initializable, ICycleModule {
+    // ============ EIP-7201 Namespaced Storage ============
 
-    /// @notice The current cycle number
-    uint256 public currentCycle;
+    /// @custom:storage-location erc7201:crowdstake.storage.AbstractCycleModule
+    struct AbstractCycleModuleStorage {
+        /// @notice The length of each cycle in blocks
+        uint256 cycleLength;
+        /// @notice The current cycle number
+        uint256 currentCycle;
+        /// @notice The block number when the current cycle started
+        uint256 lastCycleStartBlock;
+        /// @notice Addresses authorized to trigger cycle transitions
+        mapping(address => bool) authorized;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.AbstractCycleModule")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant ABSTRACT_CYCLE_MODULE_STORAGE =
+        0x9c8b48e7932311e94122d6adb2ad4f3b3618192da290ca37b1af1f4f2fb82200;
+
+    function _getAbstractCycleModuleStorage() internal pure returns (AbstractCycleModuleStorage storage $) {
+        assembly {
+            $.slot := ABSTRACT_CYCLE_MODULE_STORAGE
+        }
+    }
+
+    // ============ Public Getters ============
+
+    /// @notice The length of each cycle in blocks
+    function cycleLength() public view returns (uint256) {
+        return _getAbstractCycleModuleStorage().cycleLength;
+    }
 
     /// @notice The block number when the current cycle started
-    uint256 public lastCycleStartBlock;
+    function lastCycleStartBlock() public view returns (uint256) {
+        return _getAbstractCycleModuleStorage().lastCycleStartBlock;
+    }
 
     /// @notice Addresses authorized to trigger cycle transitions
-    mapping(address => bool) public authorized;
+    function authorized(address account) public view returns (bool) {
+        return _getAbstractCycleModuleStorage().authorized[account];
+    }
 
-    /// @notice Tracks whether the module has been initialized
-    bool public initialized;
+    // ============ Errors ============
 
     /// @notice Error thrown when caller is not authorized
     error NotAuthorized();
@@ -31,11 +60,10 @@ abstract contract AbstractCycleModule is ICycleModule {
     /// @notice Error thrown when cycle transition is invalid
     error InvalidCycleTransition();
 
-    /// @notice Error thrown when module is already initialized
-    error AlreadyInitialized();
-
     /// @notice Error thrown when module is not initialized
     error NotInitialized();
+
+    // ============ Events ============
 
     /// @notice Emitted when a new cycle starts
     /// @param cycleNumber The number of the new cycle
@@ -62,6 +90,8 @@ abstract contract AbstractCycleModule is ICycleModule {
     /// @param startBlock The starting block number
     event ModuleInitialized(uint256 cycleLength, uint256 startBlock);
 
+    // ============ Modifiers ============
+
     /// @notice Modifier to restrict access to authorized addresses
     modifier onlyAuthorized() {
         _onlyAuthorized();
@@ -76,41 +106,35 @@ abstract contract AbstractCycleModule is ICycleModule {
 
     /// @dev Reverts if the caller is not an authorized address
     function _onlyAuthorized() internal view {
-        if (!authorized[msg.sender]) {
+        if (!_getAbstractCycleModuleStorage().authorized[msg.sender]) {
             revert NotAuthorized();
         }
     }
 
     /// @dev Reverts if the module has not been initialized
     function _onlyInitialized() internal view {
-        if (!initialized) {
+        if (_getAbstractCycleModuleStorage().currentCycle == 0) {
             revert NotInitialized();
         }
     }
 
-    /// @notice Constructor sets up initial authorization
-    constructor() {
-        // Authorize the deployer
-        authorized[msg.sender] = true;
-        emit AuthorizationUpdated(msg.sender, true);
-    }
+    // ============ Initialization ============
 
     /// @notice Initializes the cycle module with fixed cycle parameters
     /// @param _cycleLength The length of each cycle in blocks
-    function initialize(uint256 _cycleLength) external onlyAuthorized {
-        if (initialized) {
-            revert AlreadyInitialized();
-        }
-
+    /// @param _authorized Address to authorize for cycle management
+    function initialize(uint256 _cycleLength, address _authorized) external initializer {
         if (_cycleLength == 0) {
             revert InvalidCycleLength();
         }
 
-        cycleLength = _cycleLength;
-        lastCycleStartBlock = block.number;
-        currentCycle = 1;
-        initialized = true;
+        AbstractCycleModuleStorage storage $ = _getAbstractCycleModuleStorage();
+        $.cycleLength = _cycleLength;
+        $.lastCycleStartBlock = block.number;
+        $.currentCycle = 1;
+        $.authorized[_authorized] = true;
 
+        emit AuthorizationUpdated(_authorized, true);
         emit ModuleInitialized(_cycleLength, block.number);
     }
 
@@ -118,20 +142,21 @@ abstract contract AbstractCycleModule is ICycleModule {
     /// @param account The address to update
     /// @param isAuthorized The authorization status to set
     function setAuthorization(address account, bool isAuthorized) external onlyAuthorized {
-        authorized[account] = isAuthorized;
+        _getAbstractCycleModuleStorage().authorized[account] = isAuthorized;
         emit AuthorizationUpdated(account, isAuthorized);
     }
 
     /// @notice Gets the current cycle number
     /// @return The current cycle number
     function getCurrentCycle() external view virtual onlyInitialized returns (uint256) {
-        return currentCycle;
+        return _getAbstractCycleModuleStorage().currentCycle;
     }
 
     /// @notice Checks if the cycle timing allows for distribution
     /// @return Whether the current cycle has completed
     function isCycleComplete() public view virtual onlyInitialized returns (bool) {
-        return block.number >= lastCycleStartBlock + cycleLength;
+        AbstractCycleModuleStorage storage $ = _getAbstractCycleModuleStorage();
+        return block.number >= $.lastCycleStartBlock + $.cycleLength;
     }
 
     /// @notice Starts a new cycle
@@ -141,18 +166,20 @@ abstract contract AbstractCycleModule is ICycleModule {
             revert InvalidCycleTransition();
         }
 
-        currentCycle++;
-        lastCycleStartBlock = block.number;
+        AbstractCycleModuleStorage storage $ = _getAbstractCycleModuleStorage();
+        $.currentCycle++;
+        $.lastCycleStartBlock = block.number;
 
-        uint256 endBlock = lastCycleStartBlock + cycleLength;
-        emit CycleStarted(currentCycle, lastCycleStartBlock, endBlock);
-        emit CycleTransitionValidated(currentCycle);
+        uint256 endBlock = $.lastCycleStartBlock + $.cycleLength;
+        emit CycleStarted($.currentCycle, $.lastCycleStartBlock, endBlock);
+        emit CycleTransitionValidated($.currentCycle);
     }
 
     /// @notice Gets the number of blocks until the next cycle
     /// @return The number of blocks remaining in the current cycle
     function getBlocksUntilNextCycle() external view virtual onlyInitialized returns (uint256) {
-        uint256 endBlock = lastCycleStartBlock + cycleLength;
+        AbstractCycleModuleStorage storage $ = _getAbstractCycleModuleStorage();
+        uint256 endBlock = $.lastCycleStartBlock + $.cycleLength;
         if (block.number >= endBlock) {
             return 0;
         }
@@ -162,11 +189,12 @@ abstract contract AbstractCycleModule is ICycleModule {
     /// @notice Gets the progress of the current cycle as a percentage
     /// @return The cycle progress (0-100)
     function getCycleProgress() external view virtual onlyInitialized returns (uint256) {
-        uint256 blocksElapsed = block.number - lastCycleStartBlock;
-        if (blocksElapsed >= cycleLength) {
+        AbstractCycleModuleStorage storage $ = _getAbstractCycleModuleStorage();
+        uint256 blocksElapsed = block.number - $.lastCycleStartBlock;
+        if (blocksElapsed >= $.cycleLength) {
             return 100;
         }
-        return (blocksElapsed * 100) / cycleLength;
+        return (blocksElapsed * 100) / $.cycleLength;
     }
 
     /// @notice Updates the cycle length for future cycles
@@ -176,8 +204,9 @@ abstract contract AbstractCycleModule is ICycleModule {
             revert InvalidCycleLength();
         }
 
-        uint256 oldLength = cycleLength;
-        cycleLength = newCycleLength;
+        AbstractCycleModuleStorage storage $ = _getAbstractCycleModuleStorage();
+        uint256 oldLength = $.cycleLength;
+        $.cycleLength = newCycleLength;
 
         emit CycleLengthUpdated(oldLength, newCycleLength);
     }

--- a/src/implementation/CycleModule.sol
+++ b/src/implementation/CycleModule.sol
@@ -5,8 +5,5 @@ import {AbstractCycleModule} from "../abstract/AbstractCycleModule.sol";
 
 /// @title CycleModule
 /// @notice Concrete implementation of the cycle module
-/// @dev Extends AbstractCycleModule with any protocol-specific logic
-contract CycleModule is AbstractCycleModule {
-    /// @notice Constructor only sets up authorization (via parent constructor)
-    constructor() AbstractCycleModule() {}
-}
+/// @dev Extends AbstractCycleModule. Deploy via CrowdStakeFactory using BeaconProxy pattern.
+contract CycleModule is AbstractCycleModule {}

--- a/test/CycleModule.t.sol
+++ b/test/CycleModule.t.sol
@@ -145,13 +145,16 @@ contract CycleModuleTest is Test {
         cycleModule.updateCycleLength(200);
     }
 
-    function testUnauthorizedCannotInitialize() public {
+    function testCannotDoubleInitialize() public {
         CycleModule newModule = new CycleModule();
 
-        // Anyone can call initialize on a fresh module since there's no authorization check before init
-        // The initializer modifier prevents double initialization
+        // First initialization succeeds
         newModule.initialize(100, user);
         assertTrue(newModule.authorized(user));
+
+        // Second initialization reverts due to initializer modifier
+        vm.expectRevert();
+        newModule.initialize(200, user);
     }
 
     function testMultipleCycles() public {

--- a/test/CycleModule.t.sol
+++ b/test/CycleModule.t.sol
@@ -16,7 +16,7 @@ contract CycleModuleTest is Test {
     function setUp() public {
         vm.roll(START_BLOCK);
         cycleModule = new CycleModule();
-        cycleModule.initialize(CYCLE_LENGTH);
+        cycleModule.initialize(CYCLE_LENGTH, owner);
     }
 
     function testInitialState() public view {
@@ -24,12 +24,11 @@ contract CycleModuleTest is Test {
         assertEq(cycleModule.cycleLength(), CYCLE_LENGTH);
         assertEq(cycleModule.lastCycleStartBlock(), START_BLOCK);
         assertTrue(cycleModule.authorized(owner));
-        assertTrue(cycleModule.initialized());
     }
 
     function testCannotReinitialize() public {
-        vm.expectRevert(AbstractCycleModule.AlreadyInitialized.selector);
-        cycleModule.initialize(200);
+        vm.expectRevert();
+        cycleModule.initialize(200, owner);
     }
 
     function testNotInitializedFunctions() public {
@@ -41,7 +40,8 @@ contract CycleModuleTest is Test {
         vm.expectRevert(AbstractCycleModule.NotInitialized.selector);
         uninitializedModule.isCycleComplete();
 
-        vm.expectRevert(AbstractCycleModule.NotInitialized.selector);
+        // startNewCycle and updateCycleLength check onlyAuthorized first
+        vm.expectRevert(AbstractCycleModule.NotAuthorized.selector);
         uninitializedModule.startNewCycle();
 
         vm.expectRevert(AbstractCycleModule.NotInitialized.selector);
@@ -50,7 +50,7 @@ contract CycleModuleTest is Test {
         vm.expectRevert(AbstractCycleModule.NotInitialized.selector);
         uninitializedModule.getCycleProgress();
 
-        vm.expectRevert(AbstractCycleModule.NotInitialized.selector);
+        vm.expectRevert(AbstractCycleModule.NotAuthorized.selector);
         uninitializedModule.updateCycleLength(200);
     }
 
@@ -148,9 +148,10 @@ contract CycleModuleTest is Test {
     function testUnauthorizedCannotInitialize() public {
         CycleModule newModule = new CycleModule();
 
-        vm.prank(user);
-        vm.expectRevert(AbstractCycleModule.NotAuthorized.selector);
-        newModule.initialize(100);
+        // Anyone can call initialize on a fresh module since there's no authorization check before init
+        // The initializer modifier prevents double initialization
+        newModule.initialize(100, user);
+        assertTrue(newModule.authorized(user));
     }
 
     function testMultipleCycles() public {

--- a/test/FactoryModuleDeployment.t.sol
+++ b/test/FactoryModuleDeployment.t.sol
@@ -130,7 +130,7 @@ contract FactoryModuleDeploymentTest is Test {
 
     // ============ Multiple Modules with Different Salts ============
 
-    function test_createMultipleModulesSameBaconDifferentSalts() public {
+    function test_createMultipleModulesSameBeaconDifferentSalts() public {
         address impl = address(new CycleModule());
         address beacon = address(new UpgradeableBeacon(impl, owner));
 

--- a/test/FactoryModuleDeployment.t.sol
+++ b/test/FactoryModuleDeployment.t.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {CrowdStakeFactory} from "../src/CrowdStakeFactory.sol";
+import {CycleModule} from "../src/implementation/CycleModule.sol";
+import {AbstractCycleModule} from "../src/abstract/AbstractCycleModule.sol";
+import {BasisPointsVotingModule} from "../src/base/BasisPointsVotingModule.sol";
+import {BaseDistributionManager} from "../src/base/BaseDistributionManager.sol";
+import {EqualDistributionStrategy} from "../src/implementation/strategies/EqualDistributionStrategy.sol";
+import {RecipientRegistry} from "../src/implementation/registries/RecipientRegistry.sol";
+import {AdminRecipientRegistry} from "../src/implementation/registries/AdminRecipientRegistry.sol";
+import {ICycleModule} from "../src/interfaces/ICycleModule.sol";
+
+contract FactoryModuleDeploymentTest is Test {
+    CrowdStakeFactory public factory;
+    address public owner;
+
+    function setUp() public {
+        owner = address(this);
+        factory = new CrowdStakeFactory(owner);
+    }
+
+    // ============ CycleModule via Factory ============
+
+    function test_createCycleModuleViaFactory() public {
+        // Deploy implementation and beacon
+        address impl = address(new CycleModule());
+        address beacon = address(new UpgradeableBeacon(impl, owner));
+
+        // Whitelist beacon
+        address[] memory beacons = new address[](1);
+        beacons[0] = beacon;
+        factory.whitelistBeacons(beacons);
+
+        // Create module via factory
+        bytes memory payload = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, 100, owner);
+        address module = factory.createModule(beacon, payload, keccak256("cycle-salt"));
+
+        // Verify module was deployed and initialized
+        assertTrue(module != address(0));
+        assertEq(ICycleModule(module).cycleLength(), 100);
+        assertEq(ICycleModule(module).getCurrentCycle(), 1);
+    }
+
+    function test_computeModuleAddress() public {
+        address impl = address(new CycleModule());
+        address beacon = address(new UpgradeableBeacon(impl, owner));
+
+        address[] memory beacons = new address[](1);
+        beacons[0] = beacon;
+        factory.whitelistBeacons(beacons);
+
+        bytes memory payload = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, 100, owner);
+        bytes32 salt = keccak256("cycle-salt");
+
+        // Compute address before deployment
+        address predicted = factory.computeModuleAddress(beacon, payload, salt);
+
+        // Deploy and verify
+        address actual = factory.createModule(beacon, payload, salt);
+        assertEq(predicted, actual);
+    }
+
+    function test_createModuleRevertsNotWhitelistedBeacon() public {
+        address impl = address(new CycleModule());
+        address beacon = address(new UpgradeableBeacon(impl, owner));
+
+        bytes memory payload = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, 100, owner);
+
+        vm.expectRevert(CrowdStakeFactory.NotWhitelistedBeacon.selector);
+        factory.createModule(beacon, payload, keccak256("salt"));
+    }
+
+    // ============ RecipientRegistry via Factory ============
+
+    function test_createRecipientRegistryViaFactory() public {
+        address impl = address(new RecipientRegistry());
+        address beacon = address(new UpgradeableBeacon(impl, owner));
+
+        address[] memory beacons = new address[](1);
+        beacons[0] = beacon;
+        factory.whitelistBeacons(beacons);
+
+        bytes memory payload = abi.encodeWithSelector(RecipientRegistry.initialize.selector, owner);
+        address module = factory.createModule(beacon, payload, keccak256("registry-salt"));
+
+        assertTrue(module != address(0));
+        assertTrue(module.code.length > 0);
+    }
+
+    function test_createAdminRecipientRegistryViaFactory() public {
+        address impl = address(new AdminRecipientRegistry());
+        address beacon = address(new UpgradeableBeacon(impl, owner));
+
+        address[] memory beacons = new address[](1);
+        beacons[0] = beacon;
+        factory.whitelistBeacons(beacons);
+
+        bytes memory payload = abi.encodeWithSelector(AdminRecipientRegistry.initialize.selector, owner);
+        address module = factory.createModule(beacon, payload, keccak256("admin-registry-salt"));
+
+        assertTrue(module != address(0));
+        assertTrue(module.code.length > 0);
+    }
+
+    // ============ EqualDistributionStrategy via Factory ============
+
+    function test_createEqualDistributionStrategyViaFactory() public {
+        address impl = address(new EqualDistributionStrategy());
+        address beacon = address(new UpgradeableBeacon(impl, owner));
+
+        address[] memory beacons = new address[](1);
+        beacons[0] = beacon;
+        factory.whitelistBeacons(beacons);
+
+        address yieldToken = address(0x111);
+        address recipientRegistry = address(0x222);
+        address distributionManager = address(0x333);
+
+        bytes memory payload = abi.encodeWithSelector(
+            EqualDistributionStrategy.initialize.selector, yieldToken, recipientRegistry, distributionManager
+        );
+        address module = factory.createModule(beacon, payload, keccak256("strategy-salt"));
+
+        assertTrue(module != address(0));
+        assertTrue(module.code.length > 0);
+    }
+
+    // ============ Multiple Modules with Different Salts ============
+
+    function test_createMultipleModulesSameBaconDifferentSalts() public {
+        address impl = address(new CycleModule());
+        address beacon = address(new UpgradeableBeacon(impl, owner));
+
+        address[] memory beacons = new address[](1);
+        beacons[0] = beacon;
+        factory.whitelistBeacons(beacons);
+
+        bytes memory payload1 = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, 100, owner);
+        bytes memory payload2 = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, 200, owner);
+
+        address module1 = factory.createModule(beacon, payload1, keccak256("salt-1"));
+        address module2 = factory.createModule(beacon, payload2, keccak256("salt-2"));
+
+        assertTrue(module1 != module2);
+        assertEq(ICycleModule(module1).cycleLength(), 100);
+        assertEq(ICycleModule(module2).cycleLength(), 200);
+    }
+
+    // ============ Beacon Upgrade Affects All Proxies ============
+
+    function test_beaconUpgradeAffectsAllProxies() public {
+        address impl = address(new CycleModule());
+        UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
+
+        address[] memory beacons = new address[](1);
+        beacons[0] = address(beacon);
+        factory.whitelistBeacons(beacons);
+
+        bytes memory payload = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, 100, owner);
+        address module = factory.createModule(address(beacon), payload, keccak256("salt"));
+
+        // Verify module works
+        assertEq(ICycleModule(module).cycleLength(), 100);
+
+        // Deploy new implementation and upgrade beacon
+        address newImpl = address(new CycleModule());
+        beacon.upgradeTo(newImpl);
+
+        // Module still works after upgrade (state preserved)
+        assertEq(ICycleModule(module).cycleLength(), 100);
+        assertEq(ICycleModule(module).getCurrentCycle(), 1);
+    }
+}

--- a/test/TimeWeightedVotingPower.t.sol
+++ b/test/TimeWeightedVotingPower.t.sol
@@ -54,7 +54,7 @@ contract TimeWeightedVotingPowerTest is Test {
 
         // Start at block 1 so getPastVotes works (can't query block 0)
         vm.roll(1);
-        cycleModule.initialize(CYCLE_LENGTH);
+        cycleModule.initialize(CYCLE_LENGTH, address(this));
 
         strategy = new TimeWeightedVotingPower(IVotesCheckpoints(address(token)), ICycleModule(address(cycleModule)));
     }

--- a/test/VotingModule.t.sol
+++ b/test/VotingModule.t.sol
@@ -100,7 +100,7 @@ contract VotingModuleTest is Test {
 
         // Deploy and initialize cycle module
         cycleModule = new CycleModule();
-        cycleModule.initialize(1000); // 1000 blocks per cycle
+        cycleModule.initialize(1000, address(this)); // 1000 blocks per cycle
 
         // Deploy mock distribution module
         distributionModule = new MockDistributionModule();

--- a/test/VotingModuleSimple.t.sol
+++ b/test/VotingModuleSimple.t.sol
@@ -148,7 +148,7 @@ contract VotingModuleSimpleTest is Test {
 
         // Deploy and initialize cycle module
         cycleModule = new CycleModule();
-        cycleModule.initialize(1000); // 1000 blocks per cycle
+        cycleModule.initialize(1000, address(this)); // 1000 blocks per cycle
 
         votingModule.initialize(
             MAX_POINTS, strategies, address(distributionModule), address(recipientRegistry), address(cycleModule)


### PR DESCRIPTION
## Summary
- Adds `createModule` and `computeModuleAddress` to `CrowdStakeFactory` for deploying any module as a BeaconProxy with CREATE2, matching the existing token deployment pattern.
- Refactors `AbstractCycleModule` to use EIP-7201 namespaced storage and OZ `Initializable`, making it proxy-compatible like all other modules.
- Renames internal `_getTokenInitCode` to `_getBeaconProxyInitCode` since it's now shared by both `createToken` and `createModule`.
- All existing modules (managers, strategies, registries, voting modules) that already use EIP-7201 + `Initializable` can now be deployed through `factory.createModule()`.

## Test plan
- [x] All 82 existing tests pass (4 pre-existing failures due to missing `ETH_RPC_URL`)
- [x] New `FactoryModuleDeployment.t.sol` covers: CycleModule, RecipientRegistry, AdminRecipientRegistry, EqualDistributionStrategy deployment via factory, address precomputation, beacon upgrades, error cases
- [x] Updated CycleModule, VotingModule, VotingModuleSimple, and TimeWeightedVotingPower tests for new `initialize` signature

Closes #36