### PR TITLE
fix: make test suite runnable without ETH_RPC_URL

### DIFF
--- a/test/BreadKitTest.t.sol
+++ b/test/BreadKitTest.t.sol
@@ -19,6 +19,13 @@ contract BreadKitTest is TestWrapper {
     address public constant RANDOM_EOA = 0x000000000000000000000000000000000000dEaD;
 
     function setUp() public {
+        // BreadKitTest needs ETH_RPC_URL for mainnet token addresses.
+        // Skip if not configured (e.g. in CI without mainnet fork).
+        try vm.envString("ETH_RPC_URL") returns (string memory) {
+            _requireFork();
+        } catch {
+            vm.skip(true); // No ETH_RPC_URL — skip all tests in this contract
+        }
         factory = new CrowdStakeFactory(address(this));
 
         /// @dev this is how we deploy and whitelist a new token type

--- a/test/TestWrapper.sol
+++ b/test/TestWrapper.sol
@@ -4,24 +4,36 @@ pragma solidity ^0.8.20;
 import {Test} from "forge-std/Test.sol";
 
 contract TestWrapper is Test {
+    bool private _forked;
+
     constructor() {
-        string memory rpcUrl = vm.envString("ETH_RPC_URL");
-
-        // Try to use ETH_BLOCK_NUMBER from env if provided, otherwise use latest
-        uint256 blockNumber;
-        try vm.envUint("ETH_BLOCK_NUMBER") returns (uint256 envBlockNumber) {
-            blockNumber = envBlockNumber;
+        // Only fork if ETH_RPC_URL is provided.
+        // Tests that need mainnet state (e.g. BreadKitTest) should call _requireFork() in setUp.
+        // Tests that only use mocks can run without any fork.
+        try vm.envString("ETH_RPC_URL") returns (string memory rpcUrl) {
+            uint256 blockNumber = 0;
+            try vm.envUint("ETH_BLOCK_NUMBER") returns (uint256 envBlockNumber) {
+                blockNumber = envBlockNumber;
+            } catch {
+                // Use latest block
+            }
+            if (blockNumber == 0) {
+                vm.createSelectFork(rpcUrl);
+            } else {
+                vm.createSelectFork(rpcUrl, blockNumber);
+            }
+            _forked = true;
         } catch {
-            // If ETH_BLOCK_NUMBER is not set, fork at the latest block
-            blockNumber = 0; // 0 means latest block in Foundry
+            // No ETH_RPC_URL — tests will run without a fork
+            _forked = false;
         }
+    }
 
-        if (blockNumber == 0) {
-            // Fork at latest block
+    /// @dev Call in setUp() if the test requires mainnet state
+    function _requireFork() internal {
+        if (!_forked) {
+            string memory rpcUrl = vm.envString("ETH_RPC_URL");
             vm.createSelectFork(rpcUrl);
-        } else {
-            // Fork at specific block
-            vm.createSelectFork(rpcUrl, blockNumber);
         }
     }
 


### PR DESCRIPTION
## Summary
- `TestWrapper` constructor now gracefully handles missing `ETH_RPC_URL` instead of reverting
- `BreadKitTest` skips via `vm.skip(true)` when no RPC URL is configured
- Tests that only use mocks run without any fork; tests needing mainnet state call `_requireFork()` in setUp

## Test plan
- [ ] Run `forge test` without `ETH_RPC_URL` set — all non-fork tests pass, `BreadKitTest` skips
- [ ] Run `forge test` with `ETH_RPC_URL` set — all 191 tests pass including `BreadKitTest`