### PR TITLE
fix: allow zero-voter distributions (#77)

### DIFF
--- a/src/base/MultiStrategyDistributionManager.sol
+++ b/src/base/MultiStrategyDistributionManager.sol
@@ -73,13 +73,13 @@ contract MultiStrategyDistributionManager is AbstractDistributionManager {
     }
 
     /// @notice Checks if distribution is ready based on cycle completion, votes, recipients, strategies, and yield
-    /// @return ready True if cycle is complete, there are votes, recipients, configured strategies, and sufficient yield
+    /// @return ready True if cycle is complete, there are recipients, configured strategies, and sufficient yield
+    /// @dev Allows zero-voter distributions for small communities (matches breadchain contracts)
     function isDistributionReady() public view override returns (bool ready) {
         if (!cycleManager().isCycleComplete()) return false;
 
-        uint256 totalVotes = getTotalCurrentVotingPower();
-        if (totalVotes == 0) return false;
-
+        // Allow zero-voter distributions — small communities may legitimately have no votes
+        // but still want to distribute to recipients (e.g., fixed grants).
         uint256 recipientCount = recipientRegistry().getRecipientCount();
         if (recipientCount == 0) return false;
 

--- a/src/interfaces/IDistributionManager.sol
+++ b/src/interfaces/IDistributionManager.sol
@@ -9,7 +9,9 @@ interface IDistributionManager {
     error ZeroAddress();
 
     /// @notice Thrown when distribution conditions are not met
-    /// @dev Distribution is not ready when voting power is 0 or yield < recipient count
+    /// @dev Distribution is not ready when cycle is incomplete, there are no recipients,
+    ///      or yield is insufficient. Note: MultiStrategyDistributionManager allows
+    ///      zero-voter distributions for fixed-grant use cases.
     error DistributionNotReady();
 
     /// @notice Thrown when there is no yield available to distribute


### PR DESCRIPTION
## Summary
- Removes the `totalVotes == 0` early return from `MultiStrategyDistributionManager.isDistributionReady()`
- Updates NatSpec in both implementation and `IDistributionManager` interface
- Enables fixed-grant distribution for small communities with no active voters

Closes #77

## Test plan
- [ ] Verify `isDistributionReady()` returns true when votes are 0 but cycle is complete, recipients exist, strategies are configured, and yield is sufficient
- [ ] Run full test suite — 191 tests pass