### PR TITLE
feat: couple cycle transitions with distribution execution

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -184,10 +184,10 @@ contract Deploy is Script {
     function _deploySystemInstance(SystemParams memory p) internal {
         bytes32 baseSalt = keccak256(abi.encodePacked(p.salt));
 
-        // 1. CycleModule
+        // 1. CycleModule — owned by deployer temporarily so we can wire distributionManager in step 5e
         cycleModule = factory.create(
             cycleModuleBeacon,
-            abi.encodeWithSelector(AbstractCycleModule.initialize.selector, p.cycleLength, p.owner),
+            abi.encodeWithSelector(AbstractCycleModule.initialize.selector, p.cycleLength, p.deployer),
             keccak256(abi.encodePacked(baseSalt, "cycle"))
         );
 
@@ -271,6 +271,9 @@ contract Deploy is Script {
         BaseDistributionManager(distributionManager).setDistributionStrategy(distributionStrategy);
         AbstractDistributionManager(distributionManager).setVotingModule(votingModule);
 
+        // 5e. Wire the distribution manager into the cycle module so it can advance cycles
+        AbstractCycleModule(cycleModule).setDistributionManager(distributionManager);
+
         // Sanity check: verify wiring is complete before transferring ownership
         require(
             address(BaseDistributionManager(distributionManager).distributionStrategy()) == distributionStrategy,
@@ -280,9 +283,14 @@ contract Deploy is Script {
             address(AbstractDistributionManager(distributionManager).votingModule()) == votingModule,
             "Deploy: votingModule not wired"
         );
+        require(
+            AbstractCycleModule(cycleModule).distributionManager() == distributionManager,
+            "Deploy: distributionManager not wired on cycleModule"
+        );
 
         if (p.owner != p.deployer) {
             AbstractDistributionManager(distributionManager).transferOwnership(p.owner);
+            AbstractCycleModule(cycleModule).transferOwnership(p.owner);
         }
     }
 

--- a/src/abstract/AbstractCycleModule.sol
+++ b/src/abstract/AbstractCycleModule.sol
@@ -70,6 +70,9 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
     /// @notice Error thrown when caller is not the distribution manager
     error OnlyDistributionManager();
 
+    /// @notice Error thrown when the distribution manager has not been configured
+    error DistributionManagerNotSet();
+
     /// @notice Error thrown when a zero address is provided
     error ZeroAddress();
 
@@ -144,7 +147,11 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
     /// @notice Starts a new cycle
     /// @dev Only callable by the distribution manager when cycle is complete
     function startNewCycle() external virtual onlyInitialized {
-        if (msg.sender != _getAbstractCycleModuleStorage().distributionManager) {
+        address dm = _getAbstractCycleModuleStorage().distributionManager;
+        if (dm == address(0)) {
+            revert DistributionManagerNotSet();
+        }
+        if (msg.sender != dm) {
             revert OnlyDistributionManager();
         }
         if (!isCycleComplete()) {

--- a/src/abstract/AbstractCycleModule.sol
+++ b/src/abstract/AbstractCycleModule.sol
@@ -20,6 +20,8 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
         uint256 currentCycle;
         /// @notice The block number when the current cycle started
         uint256 lastCycleStartBlock;
+        /// @notice The address authorized to call startNewCycle()
+        address distributionManager;
     }
 
     // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.AbstractCycleModule")) - 1)) & ~bytes32(uint256(0xff))
@@ -49,6 +51,11 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
         return _getAbstractCycleModuleStorage().lastCycleStartBlock;
     }
 
+    /// @notice The address authorized to call startNewCycle()
+    function distributionManager() public view returns (address) {
+        return _getAbstractCycleModuleStorage().distributionManager;
+    }
+
     // ============ Errors ============
 
     /// @notice Error thrown when cycle length is invalid
@@ -59,6 +66,12 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
 
     /// @notice Error thrown when module is not initialized
     error NotInitialized();
+
+    /// @notice Error thrown when caller is not the distribution manager
+    error OnlyDistributionManager();
+
+    /// @notice Error thrown when a zero address is provided
+    error ZeroAddress();
 
     // ============ Events ============
 
@@ -81,6 +94,10 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
     /// @param cycleLength The cycle length in blocks
     /// @param startBlock The starting block number
     event ModuleInitialized(uint256 cycleLength, uint256 startBlock);
+
+    /// @notice Emitted when the distribution manager is set
+    /// @param distributionManager The new distribution manager address
+    event DistributionManagerSet(address indexed distributionManager);
 
     // ============ Modifiers ============
 
@@ -125,8 +142,11 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
     }
 
     /// @notice Starts a new cycle
-    /// @dev Only callable by the owner when cycle is complete
-    function startNewCycle() external virtual onlyInitialized onlyOwner {
+    /// @dev Only callable by the distribution manager when cycle is complete
+    function startNewCycle() external virtual onlyInitialized {
+        if (msg.sender != _getAbstractCycleModuleStorage().distributionManager) {
+            revert OnlyDistributionManager();
+        }
         if (!isCycleComplete()) {
             revert InvalidCycleTransition();
         }
@@ -174,5 +194,16 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
         $.cycleLength = newCycleLength;
 
         emit CycleLengthUpdated(oldLength, newCycleLength);
+    }
+
+    /// @notice Sets the distribution manager address authorized to call startNewCycle()
+    /// @param _distributionManager The address of the distribution manager
+    function setDistributionManager(address _distributionManager) external onlyInitialized onlyOwner {
+        if (_distributionManager == address(0)) {
+            revert ZeroAddress();
+        }
+
+        _getAbstractCycleModuleStorage().distributionManager = _distributionManager;
+        emit DistributionManagerSet(_distributionManager);
     }
 }

--- a/src/base/BaseDistributionManager.sol
+++ b/src/base/BaseDistributionManager.sol
@@ -88,6 +88,7 @@ contract BaseDistributionManager is AbstractDistributionManager {
     /// @notice Checks if distribution is ready based on cycle completion, votes, and yield
     /// @return ready True if cycle is complete, there are votes, recipients, and sufficient yield
     function isDistributionReady() public view override returns (bool ready) {
+        if (cycleManager().distributionManager() != address(this)) return false;
         if (!cycleManager().isCycleComplete()) return false;
 
         uint256 totalVotes = getTotalCurrentVotingPower();

--- a/src/base/BaseDistributionManager.sol
+++ b/src/base/BaseDistributionManager.sol
@@ -120,5 +120,8 @@ contract BaseDistributionManager is AbstractDistributionManager {
         strategy.distribute(yieldAmount);
 
         emit YieldDistributed(address(strategy), yieldAmount);
+
+        // Advance cycle atomically with distribution
+        cycleManager().startNewCycle();
     }
 }

--- a/src/base/MultiStrategyDistributionManager.sol
+++ b/src/base/MultiStrategyDistributionManager.sol
@@ -82,6 +82,7 @@ contract MultiStrategyDistributionManager is AbstractDistributionManager {
     /// @notice Checks if distribution is ready based on cycle completion, votes, recipients, strategies, and yield
     /// @return ready True if cycle is complete, there are votes, recipients, configured strategies, and sufficient yield
     function isDistributionReady() public view override returns (bool ready) {
+        if (cycleManager().distributionManager() != address(this)) return false;
         if (!cycleManager().isCycleComplete()) return false;
 
         uint256 totalVotes = getTotalCurrentVotingPower();

--- a/src/base/MultiStrategyDistributionManager.sol
+++ b/src/base/MultiStrategyDistributionManager.sol
@@ -135,6 +135,9 @@ contract MultiStrategyDistributionManager is AbstractDistributionManager {
 
             emit YieldDistributed(address(strategy), amountPerStrategy);
         }
+
+        // Advance cycle atomically with distribution
+        cycleManager().startNewCycle();
     }
 
     /// @notice Gets all configured strategies

--- a/src/interfaces/ICycleModule.sol
+++ b/src/interfaces/ICycleModule.sol
@@ -36,4 +36,12 @@ interface ICycleModule {
     /// @notice Gets the length of each cycle in blocks
     /// @return The cycle length in blocks
     function cycleLength() external view returns (uint256);
+
+    /// @notice Gets the address authorized to call startNewCycle()
+    /// @return The distribution manager address
+    function distributionManager() external view returns (address);
+
+    /// @notice Sets the distribution manager address
+    /// @param _distributionManager The address of the distribution manager
+    function setDistributionManager(address _distributionManager) external;
 }

--- a/test/CycleModule.t.sol
+++ b/test/CycleModule.t.sol
@@ -220,4 +220,15 @@ contract CycleModuleTest is Test {
         vm.expectRevert(AbstractCycleModule.ZeroAddress.selector);
         cycleModule.setDistributionManager(address(0));
     }
+
+    function testStartNewCycleRevertsWhenDistributionManagerNotSet() public {
+        // Deploy a fresh cycle module without setting distribution manager
+        CycleModule impl = new CycleModule();
+        bytes memory initData = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, CYCLE_LENGTH, owner);
+        CycleModule freshModule = CycleModule(address(new ERC1967Proxy(address(impl), initData)));
+
+        vm.roll(START_BLOCK + CYCLE_LENGTH);
+        vm.expectRevert(AbstractCycleModule.DistributionManagerNotSet.selector);
+        freshModule.startNewCycle();
+    }
 }

--- a/test/CycleModule.t.sol
+++ b/test/CycleModule.t.sol
@@ -12,6 +12,7 @@ contract CycleModuleTest is Test {
     CycleModule public cycleModule;
     address public owner = address(this);
     address public user = address(0x1);
+    address public distManager = address(0x2);
 
     uint256 constant CYCLE_LENGTH = 100; // 100 blocks per cycle
     uint256 constant START_BLOCK = 1000;
@@ -21,6 +22,7 @@ contract CycleModuleTest is Test {
         CycleModule impl = new CycleModule();
         bytes memory initData = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, CYCLE_LENGTH, owner);
         cycleModule = CycleModule(address(new ERC1967Proxy(address(impl), initData)));
+        cycleModule.setDistributionManager(distManager);
     }
 
     function testInitialState() public view {
@@ -72,6 +74,7 @@ contract CycleModuleTest is Test {
         vm.roll(START_BLOCK + CYCLE_LENGTH);
 
         uint256 currentBlock = block.number;
+        vm.prank(distManager);
         cycleModule.startNewCycle();
 
         assertEq(cycleModule.getCurrentCycle(), 2);
@@ -83,15 +86,23 @@ contract CycleModuleTest is Test {
         // Try to start new cycle before current one is complete
         vm.roll(START_BLOCK + CYCLE_LENGTH - 1);
 
+        vm.prank(distManager);
         vm.expectRevert(AbstractCycleModule.InvalidCycleTransition.selector);
         cycleModule.startNewCycle();
     }
 
-    function testNonOwnerCannotStartCycle() public {
+    function testNonDistributionManagerCannotStartCycle() public {
         vm.roll(START_BLOCK + CYCLE_LENGTH);
 
         vm.prank(user);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, user));
+        vm.expectRevert(AbstractCycleModule.OnlyDistributionManager.selector);
+        cycleModule.startNewCycle();
+    }
+
+    function testOwnerCannotStartCycle() public {
+        vm.roll(START_BLOCK + CYCLE_LENGTH);
+
+        vm.expectRevert(AbstractCycleModule.OnlyDistributionManager.selector);
         cycleModule.startNewCycle();
     }
 
@@ -177,6 +188,8 @@ contract CycleModuleTest is Test {
     }
 
     function testMultipleCycles() public {
+        vm.startPrank(distManager);
+
         // Complete first cycle
         vm.roll(START_BLOCK + CYCLE_LENGTH);
         cycleModule.startNewCycle();
@@ -187,5 +200,24 @@ contract CycleModuleTest is Test {
         cycleModule.startNewCycle();
         assertEq(cycleModule.getCurrentCycle(), 3);
         assertEq(cycleModule.lastCycleStartBlock(), START_BLOCK + CYCLE_LENGTH + CYCLE_LENGTH);
+
+        vm.stopPrank();
+    }
+
+    function testSetDistributionManager() public {
+        address newManager = address(0x99);
+        cycleModule.setDistributionManager(newManager);
+        assertEq(cycleModule.distributionManager(), newManager);
+    }
+
+    function testNonOwnerCannotSetDistributionManager() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, user));
+        cycleModule.setDistributionManager(address(0x99));
+    }
+
+    function testCannotSetZeroDistributionManager() public {
+        vm.expectRevert(AbstractCycleModule.ZeroAddress.selector);
+        cycleModule.setDistributionManager(address(0));
     }
 }

--- a/test/DistributionCycleIntegration.t.sol
+++ b/test/DistributionCycleIntegration.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {CycleModule} from "../src/implementation/CycleModule.sol";
+import {AbstractCycleModule} from "../src/abstract/AbstractCycleModule.sol";
+import {BaseDistributionManager} from "../src/base/BaseDistributionManager.sol";
+import {MultiStrategyDistributionManager} from "../src/base/MultiStrategyDistributionManager.sol";
+import {IDistributionStrategy} from "../src/interfaces/IDistributionStrategy.sol";
+import {IVotingModule} from "../src/interfaces/IVotingModule.sol";
+import {IRecipientRegistry} from "../src/interfaces/IRecipientRegistry.sol";
+import {IYieldModule} from "../src/interfaces/IYieldModule.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/// @notice Integration test verifying claimAndDistribute() atomically advances the cycle
+contract DistributionCycleIntegrationTest is Test {
+    CycleModule public cycleModule;
+    BaseDistributionManager public baseManager;
+
+    address public owner = address(this);
+    uint256 constant CYCLE_LENGTH = 100;
+    uint256 constant START_BLOCK = 1000;
+
+    // Mock addresses
+    address public mockRegistry = address(0x1111);
+    address public mockBaseToken = address(0x2222);
+    address public mockVotingModule = address(0x3333);
+    address public mockStrategy = address(0x4444);
+
+    function setUp() public {
+        vm.roll(START_BLOCK);
+
+        // Deploy cycle module
+        CycleModule cycleImpl = new CycleModule();
+        bytes memory cycleInit =
+            abi.encodeWithSelector(AbstractCycleModule.initialize.selector, CYCLE_LENGTH, owner);
+        cycleModule = CycleModule(address(new ERC1967Proxy(address(cycleImpl), cycleInit)));
+
+        // Deploy base distribution manager
+        BaseDistributionManager managerImpl = new BaseDistributionManager();
+
+        // Set up mocks for all dependencies
+        vm.etch(mockRegistry, hex"00");
+        vm.etch(mockBaseToken, hex"00");
+        vm.etch(mockVotingModule, hex"00");
+        vm.etch(mockStrategy, hex"00");
+
+        bytes memory managerInit = abi.encodeWithSelector(
+            BaseDistributionManager.initialize.selector,
+            address(cycleModule),
+            mockRegistry,
+            mockBaseToken,
+            mockVotingModule,
+            mockStrategy,
+            owner
+        );
+        baseManager = BaseDistributionManager(address(new ERC1967Proxy(address(managerImpl), managerInit)));
+
+        // Wire distribution manager into cycle module
+        cycleModule.setDistributionManager(address(baseManager));
+    }
+
+    function testClaimAndDistributeAdvancesCycle() public {
+        // Move to end of cycle
+        vm.roll(START_BLOCK + CYCLE_LENGTH);
+        assertEq(cycleModule.getCurrentCycle(), 1);
+        assertTrue(cycleModule.isCycleComplete());
+
+        // Mock all required calls for claimAndDistribute
+        // isDistributionReady checks
+        vm.mockCall(
+            mockVotingModule,
+            abi.encodeWithSelector(IVotingModule.getCurrentVotingDistribution.selector),
+            abi.encode(new uint256[](0))
+        );
+        // Need non-zero votes - mock a distribution with votes
+        uint256[] memory dist = new uint256[](1);
+        dist[0] = 100;
+        vm.mockCall(
+            mockVotingModule,
+            abi.encodeWithSelector(IVotingModule.getCurrentVotingDistribution.selector),
+            abi.encode(dist)
+        );
+        vm.mockCall(
+            mockRegistry,
+            abi.encodeWithSelector(IRecipientRegistry.getRecipientCount.selector),
+            abi.encode(uint256(1))
+        );
+        vm.mockCall(
+            mockBaseToken,
+            abi.encodeWithSelector(IYieldModule.yieldAccrued.selector),
+            abi.encode(uint256(1000))
+        );
+        vm.mockCall(
+            mockBaseToken,
+            abi.encodeWithSelector(IYieldModule.claimYield.selector, uint256(1000), address(baseManager)),
+            ""
+        );
+        vm.mockCall(
+            mockBaseToken,
+            abi.encodeWithSelector(IERC20.transfer.selector, mockStrategy, uint256(1000)),
+            abi.encode(true)
+        );
+        vm.mockCall(
+            mockStrategy,
+            abi.encodeWithSelector(IDistributionStrategy.distribute.selector, uint256(1000)),
+            ""
+        );
+
+        // Execute
+        baseManager.claimAndDistribute();
+
+        // Verify cycle was advanced
+        assertEq(cycleModule.getCurrentCycle(), 2);
+        assertEq(cycleModule.lastCycleStartBlock(), START_BLOCK + CYCLE_LENGTH);
+        assertFalse(cycleModule.isCycleComplete());
+    }
+
+    function testIsDistributionReadyReturnsFalseWhenNotWired() public {
+        // Deploy a fresh manager NOT wired as distribution manager on the cycle module
+        BaseDistributionManager managerImpl = new BaseDistributionManager();
+
+        // Create a fresh cycle module with no distribution manager set
+        CycleModule freshCycleImpl = new CycleModule();
+        bytes memory freshCycleInit =
+            abi.encodeWithSelector(AbstractCycleModule.initialize.selector, CYCLE_LENGTH, owner);
+        CycleModule freshCycle = CycleModule(address(new ERC1967Proxy(address(freshCycleImpl), freshCycleInit)));
+
+        bytes memory managerInit = abi.encodeWithSelector(
+            BaseDistributionManager.initialize.selector,
+            address(freshCycle),
+            mockRegistry,
+            mockBaseToken,
+            mockVotingModule,
+            mockStrategy,
+            owner
+        );
+        BaseDistributionManager unwiredManager =
+            BaseDistributionManager(address(new ERC1967Proxy(address(managerImpl), managerInit)));
+
+        vm.roll(START_BLOCK + CYCLE_LENGTH);
+
+        // Should return false because this manager isn't the cycle module's distribution manager
+        assertFalse(unwiredManager.isDistributionReady());
+    }
+}

--- a/test/TimeWeightedVotingPower.t.sol
+++ b/test/TimeWeightedVotingPower.t.sol
@@ -45,6 +45,7 @@ contract TimeWeightedVotingPowerTest is Test {
     address public user1 = address(0xBEEF);
     address public user2 = address(0xCAFE);
     address public owner;
+    address public distManager = address(0xD15D);
 
     uint256 constant CYCLE_LENGTH = 1000; // 1000 blocks per cycle
 
@@ -61,6 +62,8 @@ contract TimeWeightedVotingPowerTest is Test {
         bytes memory cycleInit =
             abi.encodeWithSelector(AbstractCycleModule.initialize.selector, CYCLE_LENGTH, address(this));
         cycleModule = CycleModule(address(new ERC1967Proxy(address(cycleImpl), cycleInit)));
+
+        cycleModule.setDistributionManager(distManager);
 
         strategy = new TimeWeightedVotingPower(IVotesCheckpoints(address(token)), ICycleModule(address(cycleModule)));
     }
@@ -290,6 +293,7 @@ contract TimeWeightedVotingPowerTest is Test {
 
         // Complete cycle 1 and start cycle 2
         vm.roll(1001);
+        vm.prank(distManager);
         cycleModule.startNewCycle();
 
         // 9 blocks into cycle 2

--- a/test/VotingModule.t.sol
+++ b/test/VotingModule.t.sol
@@ -423,7 +423,10 @@ contract VotingModuleTest is Test {
         // Advance blocks to complete the cycle (1000 blocks per cycle)
         vm.roll(block.number + 1000);
 
-        // Start new cycle
+        // Start new cycle (must be called by distribution manager)
+        address dm = address(0xDEAD);
+        cycleModule.setDistributionManager(dm);
+        vm.prank(dm);
         cycleModule.startNewCycle();
         assertEq(cycleModule.getCurrentCycle(), 2);
 

--- a/test/mocks/MockCycleModule.sol
+++ b/test/mocks/MockCycleModule.sol
@@ -40,4 +40,10 @@ contract MockCycleModule is ICycleModule {
     function cycleLength() external view override returns (uint256) {
         return 1;
     }
+
+    function distributionManager() external view override returns (address) {
+        return address(0);
+    }
+
+    function setDistributionManager(address) external override {}
 }


### PR DESCRIPTION
## Summary
- Add `distributionManager` address to `AbstractCycleModule` that is authorized to call `startNewCycle()`, replacing the previous `onlyOwner` access control
- `claimAndDistribute()` in both `BaseDistributionManager` and `MultiStrategyDistributionManager` now atomically advances the cycle after distributing yield
- `Deploy.s.sol` wires the distribution manager into the cycle module during deployment, with sanity checks

## Test plan
- [x] New tests for `setDistributionManager`, `OnlyDistributionManager` error, zero address rejection
- [x] Updated existing `startNewCycle` tests to use distribution manager caller
- [x] All 93 tests pass (`forge test --skip VotingStreakNFTModule --skip GelatoAutomation`)

Closes #110