### PR TITLE
refactor: replace queue mappings with sorted-array invariant

### DIFF
--- a/src/abstract/AbstractRecipientRegistry.sol
+++ b/src/abstract/AbstractRecipientRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Arrays} from "@openzeppelin/contracts/utils/Arrays.sol";
 import {IRecipientRegistry} from "../interfaces/IRecipientRegistry.sol";
 
 /// @title AbstractRecipientRegistry
@@ -238,26 +239,25 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         return _binarySearch(_getAbstractRecipientRegistryStorage().queuedRecipientsForRemoval, recipient);
     }
 
-    /// @dev Binary search on a sorted address array
+    /// @dev Membership test on a sorted address array via OpenZeppelin's `Arrays.lowerBound`.
+    ///      The queue is reinterpreted as a `uint256[]` so the audited binary search can be
+    ///      reused (see `_asUint256Array`), then `lowerBound`'s insertion index is checked for
+    ///      an exact match.
     function _binarySearch(address[] storage arr, address target) internal view returns (bool) {
-        uint256 len = arr.length;
-        if (len == 0) return false;
-
-        uint256 low = 0;
-        uint256 high = len;
+        uint256[] storage casted = _asUint256Array(arr);
         uint256 targetUint = uint160(target);
+        uint256 idx = Arrays.lowerBound(casted, targetUint);
+        return idx < casted.length && casted[idx] == targetUint;
+    }
 
-        while (low < high) {
-            uint256 mid = low + (high - low) / 2;
-            uint256 midVal = uint160(arr[mid]);
-            if (midVal == targetUint) return true;
-            if (midVal < targetUint) {
-                low = mid + 1;
-            } else {
-                high = mid;
-            }
+    /// @dev Reinterprets a storage `address[]` as a `uint256[]` so it can be passed to
+    ///      OpenZeppelin's `Arrays` binary-search helpers, which are only typed for `uint256[]`.
+    ///      Safe because both element types occupy a single 32-byte storage slot with identical
+    ///      layout (an `address` is a zero-padded `uint160`).
+    function _asUint256Array(address[] storage arr) private pure returns (uint256[] storage casted) {
+        assembly {
+            casted.slot := arr.slot
         }
-        return false;
     }
 
     /// @notice Check if an address is currently an active recipient

--- a/src/abstract/AbstractRecipientRegistry.sol
+++ b/src/abstract/AbstractRecipientRegistry.sol
@@ -24,12 +24,6 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         /// @notice Mapping to quickly check if an address is an active recipient
         /// @dev Maps recipient address to true if active, false otherwise
         mapping(address => bool) isRecipientMapping;
-        /// @notice Mapping to quickly check if an address is queued for addition
-        /// @dev Maps recipient address to true if queued for addition, false otherwise
-        mapping(address => bool) isQueuedForAdditionMapping;
-        /// @notice Mapping to quickly check if an address is queued for removal
-        /// @dev Maps recipient address to true if queued for removal, false otherwise
-        mapping(address => bool) isQueuedForRemovalMapping;
     }
 
     // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.AbstractRecipientRegistry")) - 1)) & ~bytes32(uint256(0xff))
@@ -95,9 +89,12 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
         if (recipient == address(0)) revert InvalidRecipient();
         if ($.isRecipientMapping[recipient]) revert RecipientAlreadyExists();
-        if ($.isQueuedForAdditionMapping[recipient]) revert RecipientAlreadyQueued();
 
-        $.isQueuedForAdditionMapping[recipient] = true;
+        uint256 len = $.queuedRecipientsForAddition.length;
+        if (len > 0 && uint160(recipient) <= uint160($.queuedRecipientsForAddition[len - 1])) {
+            revert QueueNotSorted();
+        }
+
         $.queuedRecipientsForAddition.push(recipient);
         emit RecipientQueued(recipient, true);
     }
@@ -112,9 +109,12 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
         if (recipient == address(0)) revert InvalidRecipient();
         if (!$.isRecipientMapping[recipient]) revert RecipientNotFound();
-        if ($.isQueuedForRemovalMapping[recipient]) revert RecipientAlreadyQueued();
 
-        $.isQueuedForRemovalMapping[recipient] = true;
+        uint256 len = $.queuedRecipientsForRemoval.length;
+        if (len > 0 && uint160(recipient) <= uint160($.queuedRecipientsForRemoval[len - 1])) {
+            revert QueueNotSorted();
+        }
+
         $.queuedRecipientsForRemoval.push(recipient);
         emit RecipientQueued(recipient, false);
     }
@@ -141,7 +141,6 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
             address recipient = addedList[i];
             $.recipients.push(recipient);
             $.isRecipientMapping[recipient] = true;
-            $.isQueuedForAdditionMapping[recipient] = false;
             emit RecipientAdded(recipient);
         }
 
@@ -159,7 +158,6 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
                     if (recipient == removedList[j]) {
                         shouldRemove = true;
                         $.isRecipientMapping[recipient] = false;
-                        $.isQueuedForRemovalMapping[recipient] = false;
                         emit RecipientRemoved(recipient);
                         break;
                     }
@@ -183,22 +181,14 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
     /// @dev Only owner can clear the queue. Use this to cancel all pending additions
     /// @dev This will remove all addresses from the addition queue without adding them
     function clearAdditionQueue() external onlyOwner {
-        AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
-        for (uint256 i = 0; i < $.queuedRecipientsForAddition.length; i++) {
-            $.isQueuedForAdditionMapping[$.queuedRecipientsForAddition[i]] = false;
-        }
-        delete $.queuedRecipientsForAddition;
+        delete _getAbstractRecipientRegistryStorage().queuedRecipientsForAddition;
     }
 
     /// @notice Clear the removal queue without processing
     /// @dev Only owner can clear the queue. Use this to cancel all pending removals
     /// @dev This will remove all addresses from the removal queue without removing them
     function clearRemovalQueue() external onlyOwner {
-        AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
-        for (uint256 i = 0; i < $.queuedRecipientsForRemoval.length; i++) {
-            $.isQueuedForRemovalMapping[$.queuedRecipientsForRemoval[i]] = false;
-        }
-        delete $.queuedRecipientsForRemoval;
+        delete _getAbstractRecipientRegistryStorage().queuedRecipientsForRemoval;
     }
 
     /// @notice Get all active recipients
@@ -233,14 +223,36 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
     /// @param recipient Address to check in the addition queue
     /// @return isQueued True if the address is queued for addition, false otherwise
     function isQueuedForAddition(address recipient) external view returns (bool isQueued) {
-        return _getAbstractRecipientRegistryStorage().isQueuedForAdditionMapping[recipient];
+        return _binarySearch(_getAbstractRecipientRegistryStorage().queuedRecipientsForAddition, recipient);
     }
 
     /// @notice Check if an address is queued for removal
     /// @param recipient Address to check in the removal queue
     /// @return isQueued True if the address is queued for removal, false otherwise
     function isQueuedForRemoval(address recipient) external view returns (bool isQueued) {
-        return _getAbstractRecipientRegistryStorage().isQueuedForRemovalMapping[recipient];
+        return _binarySearch(_getAbstractRecipientRegistryStorage().queuedRecipientsForRemoval, recipient);
+    }
+
+    /// @dev Binary search on a sorted address array
+    function _binarySearch(address[] storage arr, address target) internal view returns (bool) {
+        uint256 len = arr.length;
+        if (len == 0) return false;
+
+        uint256 low = 0;
+        uint256 high = len;
+        uint256 targetUint = uint160(target);
+
+        while (low < high) {
+            uint256 mid = low + (high - low) / 2;
+            uint256 midVal = uint160(arr[mid]);
+            if (midVal == targetUint) return true;
+            if (midVal < targetUint) {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        return false;
     }
 
     /// @notice Check if an address is currently an active recipient

--- a/src/interfaces/IRecipientRegistry.sol
+++ b/src/interfaces/IRecipientRegistry.sol
@@ -40,6 +40,10 @@ interface IRecipientRegistry {
     /// @notice Thrown when attempting to queue a recipient that is already queued
     error RecipientAlreadyQueued();
 
+    /// @notice Thrown when a recipient address is not greater than the last queued address
+    /// @dev Queues must be submitted in ascending address order to enable O(1) duplicate detection
+    error QueueNotSorted();
+
     /// @notice Queue a recipient for addition to the registry
     /// @dev Access control varies by implementation (admin-only vs recipient voting)
     /// @dev The recipient will be added when the queue is processed

--- a/test/AdminRecipientRegistry.t.sol
+++ b/test/AdminRecipientRegistry.t.sol
@@ -189,6 +189,109 @@ contract AdminRecipientRegistryTest is TestWrapper {
         registry.queueRecipientAddition(RECIPIENT_2);
     }
 
+    function test_ReQueueAfterRemoval() public {
+        vm.startPrank(ADMIN);
+
+        // Add → process → remove → process → re-add
+        registry.queueRecipientAddition(RECIPIENT_1);
+        registry.processQueue();
+        assertTrue(registry.isRecipient(RECIPIENT_1));
+
+        registry.queueRecipientRemoval(RECIPIENT_1);
+        registry.processQueue();
+        assertFalse(registry.isRecipient(RECIPIENT_1));
+
+        // Re-add should succeed (queue is empty, no stale state)
+        registry.queueRecipientAddition(RECIPIENT_1);
+        registry.processQueue();
+        assertTrue(registry.isRecipient(RECIPIENT_1));
+
+        vm.stopPrank();
+    }
+
+    function test_ReQueueAfterClear() public {
+        vm.startPrank(ADMIN);
+
+        registry.queueRecipientAddition(RECIPIENT_1);
+        assertTrue(registry.isQueuedForAddition(RECIPIENT_1));
+
+        registry.clearAdditionQueue();
+        assertFalse(registry.isQueuedForAddition(RECIPIENT_1));
+
+        // Re-queue should succeed after clear
+        registry.queueRecipientAddition(RECIPIENT_1);
+        assertTrue(registry.isQueuedForAddition(RECIPIENT_1));
+        registry.processQueue();
+        assertTrue(registry.isRecipient(RECIPIENT_1));
+
+        vm.stopPrank();
+    }
+
+    function test_RevertOnDuplicateQueue() public {
+        vm.startPrank(ADMIN);
+        registry.queueRecipientAddition(RECIPIENT_1);
+
+        // Same address again should revert (not sorted / duplicate)
+        vm.expectRevert(IRecipientRegistry.QueueNotSorted.selector);
+        registry.queueRecipientAddition(RECIPIENT_1);
+        vm.stopPrank();
+    }
+
+    function test_RevertOnOutOfOrderQueue() public {
+        vm.startPrank(ADMIN);
+        registry.queueRecipientAddition(RECIPIENT_2);
+
+        // RECIPIENT_1 < RECIPIENT_2, so this should revert
+        vm.expectRevert(IRecipientRegistry.QueueNotSorted.selector);
+        registry.queueRecipientAddition(RECIPIENT_1);
+        vm.stopPrank();
+    }
+
+    function test_CrossQueueIndependence() public {
+        vm.startPrank(ADMIN);
+
+        // Add recipient first so it can be queued for removal
+        registry.queueRecipientAddition(RECIPIENT_1);
+        registry.queueRecipientAddition(RECIPIENT_2);
+        registry.processQueue();
+
+        // Queue RECIPIENT_1 for removal and a new address for addition independently
+        registry.queueRecipientRemoval(RECIPIENT_1);
+        registry.queueRecipientAddition(RECIPIENT_3);
+
+        assertTrue(registry.isQueuedForRemoval(RECIPIENT_1));
+        assertTrue(registry.isQueuedForAddition(RECIPIENT_3));
+
+        registry.processQueue();
+
+        assertFalse(registry.isRecipient(RECIPIENT_1));
+        assertTrue(registry.isRecipient(RECIPIENT_2));
+        assertTrue(registry.isRecipient(RECIPIENT_3));
+
+        vm.stopPrank();
+    }
+
+    function test_ClearRemovalQueueAndReQueue() public {
+        vm.startPrank(ADMIN);
+
+        registry.queueRecipientAddition(RECIPIENT_1);
+        registry.processQueue();
+
+        registry.queueRecipientRemoval(RECIPIENT_1);
+        assertTrue(registry.isQueuedForRemoval(RECIPIENT_1));
+
+        registry.clearRemovalQueue();
+        assertFalse(registry.isQueuedForRemoval(RECIPIENT_1));
+
+        // Re-queue for removal should succeed after clear
+        registry.queueRecipientRemoval(RECIPIENT_1);
+        assertTrue(registry.isQueuedForRemoval(RECIPIENT_1));
+        registry.processQueue();
+        assertFalse(registry.isRecipient(RECIPIENT_1));
+
+        vm.stopPrank();
+    }
+
     function test_LargeScaleOperations() public {
         vm.startPrank(ADMIN);
 


### PR DESCRIPTION
## Summary

Addresses the review feedback on #90:

- **Removes `isQueuedForAdditionMapping` and `isQueuedForRemovalMapping`** from storage entirely. Instead, queues enforce ascending address order — duplicate detection is a single `<=` comparison against the last element, O(1).
- **`clearAdditionQueue` / `clearRemovalQueue` are O(1) again** — just `delete array`, no loop needed to clear mapping entries. This resolves the gas-unbounded concern.
- **`isQueuedForAddition` / `isQueuedForRemoval` view functions** use binary search on the sorted array.
- **Adds `QueueNotSorted` error** to the interface for when callers submit addresses out of order.
- **Adds test coverage** for: re-queue after removal, re-queue after clear, duplicate queue revert, out-of-order revert, cross-queue independence, and clear-removal-then-requeue.

Tradeoff: callers must submit addresses in ascending order. For admin/governance-gated calls this is trivially enforced off-chain.

## Test plan

- [x] All 18 `AdminRecipientRegistryTest` tests pass (6 new)
- [x] All 24 `VotingRecipientRegistryTest` tests pass
- [x] All 20 `RecipientRegistryTest` tests pass
- [x] 62 total tests, 0 failures