### PR TITLE
fix: align VotingStreakNFTModule init with refactored AbstractVotingModule

### DIFF
--- a/src/implementation/VotingStreakNFTModule.sol
+++ b/src/implementation/VotingStreakNFTModule.sol
@@ -85,22 +85,20 @@ contract VotingStreakNFTModule is BasisPointsVotingModule {
     ///      Can only be called once due to initializer modifier.
     /// @param _maxPoints Maximum basis points that can be allocated per recipient (e.g., 100 for percentage-based)
     /// @param _strategies Array of voting power strategy contracts for power calculation
-    /// @param _distributionModule Address of the distribution module for reward allocation
-    /// @param _recipientRegistry Address of the recipient registry for valid recipients
-    /// @param _cycleModule Address of the cycle module for cycle management
+    /// @param _distributionModule Address of the distribution module (recipientRegistry and cycleModule are derived from it)
+    /// @param _owner Address that will own this contract (receives onlyOwner privileges)
     /// @param _nftContract Crowdstake NFT contract address for streak rewards
     function initialize(
         uint256 _maxPoints,
         IVotingPowerStrategy[] calldata _strategies,
         address _distributionModule,
-        address _recipientRegistry,
-        address _cycleModule,
+        address _owner,
         address _nftContract
     ) external initializer {
         if (_nftContract == address(0)) revert ZeroAddress();
 
         // Initialize parent classes through internal init functions
-        __AbstractVotingModule_init(_strategies, _distributionModule, _recipientRegistry, _cycleModule);
+        __AbstractVotingModule_init(_strategies, _distributionModule, _owner);
 
         // Set up BasisPointsVotingModule storage
         BasisPointsVotingModuleStorage storage basisPoints = _getBasisPointsVotingModuleStorage();

--- a/test/VotingStreakNFTModule.t.sol
+++ b/test/VotingStreakNFTModule.t.sol
@@ -2,12 +2,14 @@
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {VotingStreakNFTModule} from "../src/implementation/VotingStreakNFTModule.sol";
 import {IVotingPowerStrategy} from "../src/interfaces/IVotingPowerStrategy.sol";
 import {ICrowdstakeNFT} from "../src/interfaces/ICrowdstakeNFT.sol";
 import {MockCrowdstakeNFT} from "./mocks/MockCrowdstakeNFT.sol";
 import {MockRecipientRegistry} from "./mocks/MockRecipientRegistry.sol";
 import {MockCycleModule} from "./mocks/MockCycleModule.sol";
+import {MockDistributionModule} from "./mocks/MockDistributionModule.sol";
 
 // ============ Test Harness ============
 
@@ -45,6 +47,7 @@ contract VotingStreakNFTModuleTest is Test {
     MockCrowdstakeNFT public mockNft;
     MockRecipientRegistry public recipientRegistry;
     MockCycleModule public cycleModule;
+    MockDistributionModule public distModule;
     MockVotingPowerStrategy public votingPowerStrategy;
 
     address public user = address(0xBEEF);
@@ -68,32 +71,30 @@ contract VotingStreakNFTModuleTest is Test {
         recipients[1] = user2;
         recipientRegistry = new MockRecipientRegistry(recipients);
 
+        // Create mock distribution module that returns registry and cycle module
+        distModule = new MockDistributionModule(address(recipientRegistry), address(cycleModule));
+
         // Create voting power strategy
         votingPowerStrategy = new MockVotingPowerStrategy();
 
         // Create mock NFT
         mockNft = new MockCrowdstakeNFT();
 
-        // Create harness (this is our VotingStreakNFTModule)
-        harness = new VotingStreakBasisPointsModuleHarness();
-
         // Set up voting power strategies array
         IVotingPowerStrategy[] memory strategies = new IVotingPowerStrategy[](1);
         strategies[0] = votingPowerStrategy;
 
-        // Initialize the harness with all required dependencies
-        // initialize(maxPoints, strategies, distributionModule, recipientRegistry, cycleModule, nftContract)
-        harness.initialize(
-            MAX_POINTS, // _maxPoints = 100
-            strategies, // _strategies
-            address(this), // _distributionModule (dummy)
-            address(recipientRegistry), // _recipientRegistry
-            address(cycleModule), // _cycleModule
-            address(mockNft) // _nftContract
+        // Deploy implementation and proxy
+        VotingStreakBasisPointsModuleHarness impl = new VotingStreakBasisPointsModuleHarness();
+        bytes memory initData = abi.encodeWithSelector(
+            VotingStreakNFTModule.initialize.selector,
+            MAX_POINTS,
+            strategies,
+            address(distModule),
+            admin,
+            address(mockNft)
         );
-
-        // Transfer ownership to admin for testing (optional, but good practice)
-        harness.transferOwnership(admin);
+        harness = VotingStreakBasisPointsModuleHarness(address(new ERC1967Proxy(address(impl), initData)));
     }
 
     // ============ Test Cases ============


### PR DESCRIPTION
## Summary
- VotingStreakNFTModule was not updated when `__AbstractVotingModule_init` was refactored (in #114) to derive `recipientRegistry` and `cycleModule` from the distribution module, causing a compilation error
- Replaced the `_recipientRegistry` and `_cycleModule` params with `_owner` to match the `BasisPointsVotingModule` pattern
- Updated the test to deploy behind an `ERC1967Proxy` (matching other test files) and use `MockDistributionModule`

## Test plan
- [x] `forge build` compiles without errors
- [x] All 7 `VotingStreakNFTModuleTest` tests pass
- [x] Full test suite: 103 passed, 4 pre-existing failures (missing `ETH_RPC_URL`)