### PR TITLE
fix: optimize queue lookup with mapping-based O(1) duplicate detection (#45)

### DIFF
--- a/src/abstract/AbstractRecipientRegistry.sol
+++ b/src/abstract/AbstractRecipientRegistry.sol
@@ -77,6 +77,8 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         return _getAbstractRecipientRegistryStorage().queuedRecipientsForRemoval.length;
     }
 
+    /// @notice Mapping to quickly check if an address is an active recipient
+    /// @dev Maps recipient address to true if active, false otherwise
     function isRecipientMapping(address account) public view returns (bool) {
         return _getAbstractRecipientRegistryStorage().isRecipientMapping[account];
     }

--- a/src/abstract/AbstractRecipientRegistry.sol
+++ b/src/abstract/AbstractRecipientRegistry.sol
@@ -32,7 +32,7 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         mapping(address => bool) isQueuedForRemovalMapping;
     }
 
-    // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.AbstractRecipientRegistry")) - 1)) & ~bytes32(uint256(0xff))
+    /// keccak256(abi.encode(uint256(keccak256("crowdstake.storage.AbstractRecipientRegistry")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant ABSTRACT_RECIPIENT_REGISTRY_STORAGE =
         0x347caeef91698b68f09c13de18e96db5bda028445fd11b86dc029946f360f200;
 
@@ -41,6 +41,9 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
             $.slot := ABSTRACT_RECIPIENT_REGISTRY_STORAGE
         }
     }
+
+    /// @notice Maximum queue size
+    uint256 private constant MAX_QUEUE_SIZE = 100;
 
     // ============ Public Getters ============
 
@@ -96,6 +99,7 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         if (recipient == address(0)) revert InvalidRecipient();
         if ($.isRecipientMapping[recipient]) revert RecipientAlreadyExists();
         if ($.isQueuedForAdditionMapping[recipient]) revert RecipientAlreadyQueued();
+        if ($.queuedRecipientsForAddition.length + 1 > MAX_QUEUE_SIZE) revert MaxQueueSizeReached();
 
         $.isQueuedForAdditionMapping[recipient] = true;
         $.queuedRecipientsForAddition.push(recipient);
@@ -113,6 +117,7 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         if (recipient == address(0)) revert InvalidRecipient();
         if (!$.isRecipientMapping[recipient]) revert RecipientNotFound();
         if ($.isQueuedForRemovalMapping[recipient]) revert RecipientAlreadyQueued();
+        if ($.queuedRecipientsForRemoval.length + 1 > MAX_QUEUE_SIZE) revert MaxQueueSizeReached();
 
         $.isQueuedForRemovalMapping[recipient] = true;
         $.queuedRecipientsForRemoval.push(recipient);

--- a/src/abstract/AbstractRecipientRegistry.sol
+++ b/src/abstract/AbstractRecipientRegistry.sol
@@ -24,6 +24,12 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         /// @notice Mapping to quickly check if an address is an active recipient
         /// @dev Maps recipient address to true if active, false otherwise
         mapping(address => bool) isRecipientMapping;
+        /// @notice Mapping to quickly check if an address is queued for addition
+        /// @dev Maps recipient address to true if queued for addition, false otherwise
+        mapping(address => bool) isQueuedForAdditionMapping;
+        /// @notice Mapping to quickly check if an address is queued for removal
+        /// @dev Maps recipient address to true if queued for removal, false otherwise
+        mapping(address => bool) isQueuedForRemovalMapping;
     }
 
     // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.AbstractRecipientRegistry")) - 1)) & ~bytes32(uint256(0xff))
@@ -71,8 +77,6 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         return _getAbstractRecipientRegistryStorage().queuedRecipientsForRemoval.length;
     }
 
-    /// @notice Mapping to quickly check if an address is an active recipient
-    /// @dev Maps recipient address to true if active, false otherwise
     function isRecipientMapping(address account) public view returns (bool) {
         return _getAbstractRecipientRegistryStorage().isRecipientMapping[account];
     }
@@ -89,14 +93,9 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
         AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
         if (recipient == address(0)) revert InvalidRecipient();
         if ($.isRecipientMapping[recipient]) revert RecipientAlreadyExists();
+        if ($.isQueuedForAdditionMapping[recipient]) revert RecipientAlreadyQueued();
 
-        // Check if already queued to prevent duplicates
-        for (uint256 i = 0; i < $.queuedRecipientsForAddition.length; i++) {
-            if ($.queuedRecipientsForAddition[i] == recipient) {
-                revert RecipientAlreadyQueued();
-            }
-        }
-
+        $.isQueuedForAdditionMapping[recipient] = true;
         $.queuedRecipientsForAddition.push(recipient);
         emit RecipientQueued(recipient, true);
     }
@@ -109,15 +108,11 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
     /// @dev Access control should be implemented in the calling public function
     function _queueForRemoval(address recipient) internal {
         AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
+        if (recipient == address(0)) revert InvalidRecipient();
         if (!$.isRecipientMapping[recipient]) revert RecipientNotFound();
+        if ($.isQueuedForRemovalMapping[recipient]) revert RecipientAlreadyQueued();
 
-        // Check if already queued for removal to prevent duplicates
-        for (uint256 i = 0; i < $.queuedRecipientsForRemoval.length; i++) {
-            if ($.queuedRecipientsForRemoval[i] == recipient) {
-                revert RecipientAlreadyQueued();
-            }
-        }
-
+        $.isQueuedForRemovalMapping[recipient] = true;
         $.queuedRecipientsForRemoval.push(recipient);
         emit RecipientQueued(recipient, false);
     }
@@ -144,6 +139,7 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
             address recipient = addedList[i];
             $.recipients.push(recipient);
             $.isRecipientMapping[recipient] = true;
+            $.isQueuedForAdditionMapping[recipient] = false;
             emit RecipientAdded(recipient);
         }
 
@@ -161,6 +157,7 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
                     if (recipient == removedList[j]) {
                         shouldRemove = true;
                         $.isRecipientMapping[recipient] = false;
+                        $.isQueuedForRemovalMapping[recipient] = false;
                         emit RecipientRemoved(recipient);
                         break;
                     }
@@ -184,14 +181,22 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
     /// @dev Only owner can clear the queue. Use this to cancel all pending additions
     /// @dev This will remove all addresses from the addition queue without adding them
     function clearAdditionQueue() external onlyOwner {
-        delete _getAbstractRecipientRegistryStorage().queuedRecipientsForAddition;
+        AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
+        for (uint256 i = 0; i < $.queuedRecipientsForAddition.length; i++) {
+            $.isQueuedForAdditionMapping[$.queuedRecipientsForAddition[i]] = false;
+        }
+        delete $.queuedRecipientsForAddition;
     }
 
     /// @notice Clear the removal queue without processing
     /// @dev Only owner can clear the queue. Use this to cancel all pending removals
     /// @dev This will remove all addresses from the removal queue without removing them
     function clearRemovalQueue() external onlyOwner {
-        delete _getAbstractRecipientRegistryStorage().queuedRecipientsForRemoval;
+        AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
+        for (uint256 i = 0; i < $.queuedRecipientsForRemoval.length; i++) {
+            $.isQueuedForRemovalMapping[$.queuedRecipientsForRemoval[i]] = false;
+        }
+        delete $.queuedRecipientsForRemoval;
     }
 
     /// @notice Get all active recipients
@@ -226,26 +231,14 @@ abstract contract AbstractRecipientRegistry is IRecipientRegistry, OwnableUpgrad
     /// @param recipient Address to check in the addition queue
     /// @return isQueued True if the address is queued for addition, false otherwise
     function isQueuedForAddition(address recipient) external view returns (bool isQueued) {
-        AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
-        for (uint256 i = 0; i < $.queuedRecipientsForAddition.length; i++) {
-            if ($.queuedRecipientsForAddition[i] == recipient) {
-                return true;
-            }
-        }
-        return false;
+        return _getAbstractRecipientRegistryStorage().isQueuedForAdditionMapping[recipient];
     }
 
     /// @notice Check if an address is queued for removal
     /// @param recipient Address to check in the removal queue
     /// @return isQueued True if the address is queued for removal, false otherwise
     function isQueuedForRemoval(address recipient) external view returns (bool isQueued) {
-        AbstractRecipientRegistryStorage storage $ = _getAbstractRecipientRegistryStorage();
-        for (uint256 i = 0; i < $.queuedRecipientsForRemoval.length; i++) {
-            if ($.queuedRecipientsForRemoval[i] == recipient) {
-                return true;
-            }
-        }
-        return false;
+        return _getAbstractRecipientRegistryStorage().isQueuedForRemovalMapping[recipient];
     }
 
     /// @notice Check if an address is currently an active recipient

--- a/src/interfaces/IRecipientRegistry.sol
+++ b/src/interfaces/IRecipientRegistry.sol
@@ -40,7 +40,7 @@ interface IRecipientRegistry {
     /// @notice Thrown when attempting to queue a recipient that is already queued
     error RecipientAlreadyQueued();
 
-    /// @notice Thrown when attempting to queue a recipient when the queue reached the maximum size
+    /// @notice Thrown when attempting to queue a recipient when the queue has reached the maximum size
     error MaxQueueSizeReached();
 
     /// @notice Queue a recipient for addition to the registry

--- a/src/interfaces/IRecipientRegistry.sol
+++ b/src/interfaces/IRecipientRegistry.sol
@@ -40,6 +40,9 @@ interface IRecipientRegistry {
     /// @notice Thrown when attempting to queue a recipient that is already queued
     error RecipientAlreadyQueued();
 
+    /// @notice Thrown when attempting to queue a recipient when the queue reached the maximum size
+    error MaxQueueSizeReached();
+
     /// @notice Queue a recipient for addition to the registry
     /// @dev Access control varies by implementation (admin-only vs recipient voting)
     /// @dev The recipient will be added when the queue is processed

--- a/test/RecipientRegistry.t.sol
+++ b/test/RecipientRegistry.t.sol
@@ -356,4 +356,35 @@ contract RecipientRegistryTest is TestWrapper {
         registry.processQueue();
         assertEq(registry.getRecipientCount(), 50);
     }
+
+    // ── MAX_QUEUE_SIZE boundary tests ──
+
+    function test_MaxQueueSizeAdditionBoundary() public {
+        // Queue exactly MAX_QUEUE_SIZE (100) additions — should succeed
+        for (uint256 i = 1; i <= 100; i++) {
+            // forge-lint: disable-next-line(unsafe-typecast)
+            registry.queueRecipientAddition(address(uint160(i)));
+        }
+        assertEq(registry.getQueuedAdditions().length, 100);
+
+        // Queue one more — should revert with MaxQueueSizeReached
+        vm.expectRevert(IRecipientRegistry.MaxQueueSizeReached.selector);
+        registry.queueRecipientAddition(address(uint160(101)));
+    }
+
+    function test_MaxQueueSizeRemovalBoundary() public {
+        // First add 100 recipients
+        for (uint256 i = 1; i <= 100; i++) {
+            // forge-lint: disable-next-line(unsafe-typecast)
+            registry.queueRecipientAddition(address(uint160(i)));
+        }
+        registry.processQueue();
+
+        // Queue exactly MAX_QUEUE_SIZE (100) removals — should succeed
+        for (uint256 i = 1; i <= 100; i++) {
+            // forge-lint: disable-next-line(unsafe-typecast)
+            registry.queueRecipientRemoval(address(uint160(i)));
+        }
+        assertEq(registry.getQueuedRemovals().length, 100);
+    }
 }

--- a/test/RecipientRegistry.t.sol
+++ b/test/RecipientRegistry.t.sol
@@ -175,6 +175,46 @@ contract RecipientRegistryTest is TestWrapper {
         assertEq(registry.getQueuedAdditions().length, 0);
     }
 
+    function test_ReQueueRecipientAfterRemoval() public {
+        registry.queueRecipientAddition(RECIPIENT_1);
+        registry.processQueue();
+
+        registry.queueRecipientRemoval(RECIPIENT_1);
+        registry.processQueue();
+
+        assertFalse(registry.isRecipient(RECIPIENT_1));
+        assertFalse(registry.isQueuedForRemoval(RECIPIENT_1));
+
+        registry.queueRecipientAddition(RECIPIENT_1);
+
+        assertTrue(registry.isQueuedForAddition(RECIPIENT_1));
+        assertEq(registry.getQueuedAdditions().length, 1);
+
+        registry.processQueue();
+
+        assertTrue(registry.isRecipient(RECIPIENT_1));
+        assertFalse(registry.isQueuedForAddition(RECIPIENT_1));
+        assertEq(registry.getRecipientCount(), 1);
+    }
+
+    function test_ReQueueRecipientAfterClearingAdditionQueue() public {
+        registry.queueRecipientAddition(RECIPIENT_1);
+
+        registry.clearAdditionQueue();
+
+        assertEq(registry.getQueuedAdditions().length, 0);
+        assertFalse(registry.isQueuedForAddition(RECIPIENT_1));
+
+        registry.queueRecipientAddition(RECIPIENT_1);
+        assertTrue(registry.isQueuedForAddition(RECIPIENT_1));
+
+        registry.processQueue();
+
+        assertTrue(registry.isRecipient(RECIPIENT_1));
+        assertFalse(registry.isQueuedForAddition(RECIPIENT_1));
+        assertEq(registry.getRecipientCount(), 1);
+    }
+
     function test_ClearRemovalQueue() public {
         // Add recipients first
         registry.queueRecipientAddition(RECIPIENT_1);
@@ -221,7 +261,7 @@ contract RecipientRegistryTest is TestWrapper {
     function test_RevertOnDuplicateQueuedAddition() public {
         registry.queueRecipientAddition(RECIPIENT_1);
 
-        vm.expectRevert();
+        vm.expectRevert(IRecipientRegistry.RecipientAlreadyQueued.selector);
         registry.queueRecipientAddition(RECIPIENT_1);
     }
 
@@ -236,8 +276,27 @@ contract RecipientRegistryTest is TestWrapper {
 
         registry.queueRecipientRemoval(RECIPIENT_1);
 
-        vm.expectRevert();
+        vm.expectRevert(IRecipientRegistry.RecipientAlreadyQueued.selector);
         registry.queueRecipientRemoval(RECIPIENT_1);
+    }
+
+    function test_AdditionAndRemovalQueuesAreIndependent() public {
+        registry.queueRecipientAddition(RECIPIENT_1);
+        registry.processQueue();
+
+        registry.queueRecipientAddition(RECIPIENT_2);
+        registry.queueRecipientRemoval(RECIPIENT_1);
+
+        assertTrue(registry.isQueuedForAddition(RECIPIENT_2));
+        assertTrue(registry.isQueuedForRemoval(RECIPIENT_1));
+        assertFalse(registry.isQueuedForAddition(RECIPIENT_1));
+        assertFalse(registry.isQueuedForRemoval(RECIPIENT_2));
+
+        registry.processQueue();
+
+        assertFalse(registry.isRecipient(RECIPIENT_1));
+        assertTrue(registry.isRecipient(RECIPIENT_2));
+        assertEq(registry.getRecipientCount(), 1);
     }
 
     function test_OnlyOwnerCanQueue() public {


### PR DESCRIPTION
## Summary
- Replace O(n) linear search with O(1) mapping-based duplicate detection for both addition and removal queues
- Add `MAX_QUEUE_SIZE = 100` constant to bound gas consumption of `clearAdditionQueue`/`clearRemovalQueue`
- Add `MaxQueueSizeReached` error to `IRecipientRegistry`
- Both queue mappings use EIP-7201 namespaced storage (inside existing struct)

Closes #45
Supersedes #90 (addresses all review feedback from that PR)

## Test plan
- [x] Re-queue after removal works correctly
- [x] Re-queue after clearing addition queue works correctly
- [x] Double-queue reverts with `RecipientAlreadyQueued`
- [x] Addition and removal queues are independent
- [x] `MAX_QUEUE_SIZE` enforced on both queues
- [x] All 103 existing tests pass

**Stack:** PR 1 of 10 (0.0.1)