### PR TITLE
fix(ci): forge fmt + add missing [profile.ci]

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,3 +8,7 @@ libs = ["lib"]
 [fuzz]
 runs = 1000
 max_test_rejects = 100000
+
+# CI profile (referenced via FOUNDRY_PROFILE=ci in .github/workflows/test.yml).
+# Inherits all settings from the default profile.
+[profile.ci]

--- a/src/abstract/AbstractDistributionStrategy.sol
+++ b/src/abstract/AbstractDistributionStrategy.sol
@@ -92,19 +92,18 @@ abstract contract AbstractDistributionStrategy is Initializable, IDistributionSt
     /// @param _yieldToken Address of the yield token to distribute
     /// @param _distributionManager Address of the distribution manager authorized to call distribute
     /// @param _owner Address that will own this contract (receives onlyOwner privileges)
-    function __AbstractDistributionStrategy_init(
-        address _yieldToken,
-        address _distributionManager,
-        address _owner
-    ) internal onlyInitializing {
+    function __AbstractDistributionStrategy_init(address _yieldToken, address _distributionManager, address _owner)
+        internal
+        onlyInitializing
+    {
         __Ownable_init(_owner);
         __AbstractDistributionStrategy_init_unchained(_yieldToken, _distributionManager);
     }
 
-    function __AbstractDistributionStrategy_init_unchained(
-        address _yieldToken,
-        address _distributionManager
-    ) internal onlyInitializing {
+    function __AbstractDistributionStrategy_init_unchained(address _yieldToken, address _distributionManager)
+        internal
+        onlyInitializing
+    {
         if (_yieldToken == address(0)) revert ZeroAddress();
         if (_distributionManager == address(0)) revert ZeroAddress();
 

--- a/src/base/BasisPointsVotingModule.sol
+++ b/src/base/BasisPointsVotingModule.sol
@@ -174,7 +174,7 @@ contract BasisPointsVotingModule is AbstractVotingModule {
     /// @param voter Address of the voter
     /// @param points Array of points allocated to each recipient
     /// @param votingPower Total voting power of the voter
-    function _processVote(address voter, uint256[] calldata points, uint256 votingPower) internal override virtual {
+    function _processVote(address voter, uint256[] calldata points, uint256 votingPower) internal virtual override {
         AbstractVotingModuleStorage storage base = _getAbstractVotingModuleStorage();
         BasisPointsVotingModuleStorage storage $ = _getBasisPointsVotingModuleStorage();
         uint256 currentCycle = base.cycleModule.getCurrentCycle();

--- a/src/implementation/VotingStreakNFTModule.sol
+++ b/src/implementation/VotingStreakNFTModule.sol
@@ -33,11 +33,7 @@ contract VotingStreakNFTModule is BasisPointsVotingModule {
     bytes32 private constant VOTING_STREAK_NFT_MODULE_STORAGE =
         0xa65dee7b045e43a11600ba41b419f3aad18025b3c1b3b7c19daa6c12d6462c00;
 
-    function _getVotingStreakNFTModuleStorage()
-        internal
-        pure
-        returns (VotingStreakNFTModuleStorage storage $)
-    {
+    function _getVotingStreakNFTModuleStorage() internal pure returns (VotingStreakNFTModuleStorage storage $) {
         assembly {
             $.slot := VOTING_STREAK_NFT_MODULE_STORAGE
         }
@@ -68,11 +64,7 @@ contract VotingStreakNFTModule is BasisPointsVotingModule {
     /// @param user The user address to query
     /// @return streak Current consecutive voting streak
     /// @return lastVoteCycle Last cycle in which the user successfully voted
-    function userActivity(address user)
-        external
-        view
-        returns (uint256 streak, uint256 lastVoteCycle)
-    {
+    function userActivity(address user) external view returns (uint256 streak, uint256 lastVoteCycle) {
         VotingStreakNFTModuleStorage storage $ = _getVotingStreakNFTModuleStorage();
         UserActivity storage activity = $.userActivity[user];
         return (activity.streak, activity.lastVoteCycle);
@@ -135,10 +127,7 @@ contract VotingStreakNFTModule is BasisPointsVotingModule {
     /// @param voter Address of the voter
     /// @param points Array of basis points for allocation across recipients
     /// @param votingPower Total voting power of the voter
-    function _processVote(address voter, uint256[] calldata points, uint256 votingPower)
-        internal
-        override
-    {
+    function _processVote(address voter, uint256[] calldata points, uint256 votingPower) internal override {
         // Step 1: Execute standard voting math via parent
         super._processVote(voter, points, votingPower);
 
@@ -186,6 +175,5 @@ contract VotingStreakNFTModule is BasisPointsVotingModule {
             $.nftContract.mint(user);
         }
     }
-
 }
 

--- a/src/implementation/strategies/EqualDistributionStrategy.sol
+++ b/src/implementation/strategies/EqualDistributionStrategy.sol
@@ -22,10 +22,7 @@ contract EqualDistributionStrategy is AbstractDistributionStrategy {
     /// @param _yieldToken Address of the yield token to distribute
     /// @param _distributionManager Address of the distribution manager
     /// @param _owner Address that will own this contract (receives onlyOwner privileges)
-    function initialize(address _yieldToken, address _distributionManager, address _owner)
-        external
-        initializer
-    {
+    function initialize(address _yieldToken, address _distributionManager, address _owner) external initializer {
         __AbstractDistributionStrategy_init(_yieldToken, _distributionManager, _owner);
     }
 

--- a/src/implementation/strategies/VotingDistributionStrategy.sol
+++ b/src/implementation/strategies/VotingDistributionStrategy.sol
@@ -44,11 +44,7 @@ contract VotingDistributionStrategy is AbstractDistributionStrategy {
     /// @param _yieldToken Address of the yield token to distribute
     /// @param _distributionManager Address of the distribution manager
     /// @param _owner Address that will own this contract (receives onlyOwner privileges)
-    function initialize(
-        address _yieldToken,
-        address _distributionManager,
-        address _owner
-    ) external initializer {
+    function initialize(address _yieldToken, address _distributionManager, address _owner) external initializer {
         __AbstractDistributionStrategy_init(_yieldToken, _distributionManager, _owner);
     }
 

--- a/src/interfaces/ICrowdstakeNFT.sol
+++ b/src/interfaces/ICrowdstakeNFT.sol
@@ -10,5 +10,4 @@ interface ICrowdstakeNFT is IERC721 {
     /// @param to The address that will receive the NFT.
     /// @return tokenId The unique ID of the newly minted NFT.
     function mint(address to) external returns (uint256);
-
 }

--- a/test/AdminRecipientRegistry.t.sol
+++ b/test/AdminRecipientRegistry.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {TestWrapper} from "./TestWrapper.sol";
 import {AdminRecipientRegistry} from "../src/implementation/registries/AdminRecipientRegistry.sol";
 import {IRecipientRegistry} from "../src/interfaces/IRecipientRegistry.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract AdminRecipientRegistryTest is TestWrapper {
     AdminRecipientRegistry public registry;
@@ -15,8 +16,9 @@ contract AdminRecipientRegistryTest is TestWrapper {
     address public constant RECIPIENT_4 = address(0x4);
 
     function setUp() public {
-        registry = new AdminRecipientRegistry();
-        registry.initialize(ADMIN);
+        AdminRecipientRegistry impl = new AdminRecipientRegistry();
+        bytes memory initData = abi.encodeCall(AdminRecipientRegistry.initialize, (ADMIN));
+        registry = AdminRecipientRegistry(address(new ERC1967Proxy(address(impl), initData)));
     }
 
     function test_WhenInitializing() external view {

--- a/test/DistributionCycleIntegration.t.sol
+++ b/test/DistributionCycleIntegration.t.sol
@@ -33,8 +33,7 @@ contract DistributionCycleIntegrationTest is Test {
 
         // Deploy cycle module
         CycleModule cycleImpl = new CycleModule();
-        bytes memory cycleInit =
-            abi.encodeWithSelector(AbstractCycleModule.initialize.selector, CYCLE_LENGTH, owner);
+        bytes memory cycleInit = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, CYCLE_LENGTH, owner);
         cycleModule = CycleModule(address(new ERC1967Proxy(address(cycleImpl), cycleInit)));
 
         // Deploy base distribution manager
@@ -85,14 +84,10 @@ contract DistributionCycleIntegrationTest is Test {
             abi.encode(dist)
         );
         vm.mockCall(
-            mockRegistry,
-            abi.encodeWithSelector(IRecipientRegistry.getRecipientCount.selector),
-            abi.encode(uint256(1))
+            mockRegistry, abi.encodeWithSelector(IRecipientRegistry.getRecipientCount.selector), abi.encode(uint256(1))
         );
         vm.mockCall(
-            mockBaseToken,
-            abi.encodeWithSelector(IYieldModule.yieldAccrued.selector),
-            abi.encode(uint256(1000))
+            mockBaseToken, abi.encodeWithSelector(IYieldModule.yieldAccrued.selector), abi.encode(uint256(1000))
         );
         vm.mockCall(
             mockBaseToken,
@@ -104,11 +99,7 @@ contract DistributionCycleIntegrationTest is Test {
             abi.encodeWithSelector(IERC20.transfer.selector, mockStrategy, uint256(1000)),
             abi.encode(true)
         );
-        vm.mockCall(
-            mockStrategy,
-            abi.encodeWithSelector(IDistributionStrategy.distribute.selector, uint256(1000)),
-            ""
-        );
+        vm.mockCall(mockStrategy, abi.encodeWithSelector(IDistributionStrategy.distribute.selector, uint256(1000)), "");
 
         // Execute
         baseManager.claimAndDistribute();

--- a/test/FactoryModuleDeployment.t.sol
+++ b/test/FactoryModuleDeployment.t.sol
@@ -132,11 +132,7 @@ contract FactoryModuleDeploymentTest is Test {
         vm.etch(mockDistManager, hex"00");
 
         // Mock the distribution manager to return the registry
-        vm.mockCall(
-            mockDistManager,
-            abi.encodeWithSignature("recipientRegistry()"),
-            abi.encode(registry)
-        );
+        vm.mockCall(mockDistManager, abi.encodeWithSignature("recipientRegistry()"), abi.encode(registry));
 
         bytes memory payload = abi.encodeWithSelector(
             EqualDistributionStrategy.initialize.selector, mockYieldToken, mockDistManager, owner
@@ -162,22 +158,11 @@ contract FactoryModuleDeploymentTest is Test {
         vm.etch(mockDistManager, hex"00");
 
         // Mock the distribution manager to return registry and voting module
-        vm.mockCall(
-            mockDistManager,
-            abi.encodeWithSignature("recipientRegistry()"),
-            abi.encode(registry)
-        );
-        vm.mockCall(
-            mockDistManager,
-            abi.encodeWithSignature("votingModule()"),
-            abi.encode(mockVotingModule)
-        );
+        vm.mockCall(mockDistManager, abi.encodeWithSignature("recipientRegistry()"), abi.encode(registry));
+        vm.mockCall(mockDistManager, abi.encodeWithSignature("votingModule()"), abi.encode(mockVotingModule));
 
         bytes memory payload = abi.encodeWithSelector(
-            VotingDistributionStrategy.initialize.selector,
-            mockYieldToken,
-            mockDistManager,
-            owner
+            VotingDistributionStrategy.initialize.selector, mockYieldToken, mockDistManager, owner
         );
         address module = factory.create(votingStrategyBeacon, payload, keccak256("voting-strat-salt"));
 

--- a/test/RecipientRegistry.t.sol
+++ b/test/RecipientRegistry.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {TestWrapper} from "./TestWrapper.sol";
 import {RecipientRegistry} from "../src/implementation/registries/RecipientRegistry.sol";
 import {IRecipientRegistry} from "../src/interfaces/IRecipientRegistry.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract RecipientRegistryTest is TestWrapper {
     RecipientRegistry public registry;
@@ -14,8 +15,9 @@ contract RecipientRegistryTest is TestWrapper {
     address public constant RECIPIENT_4 = address(0x4);
 
     function setUp() public {
-        registry = new RecipientRegistry();
-        registry.initialize(address(this));
+        RecipientRegistry impl = new RecipientRegistry();
+        bytes memory initData = abi.encodeCall(RecipientRegistry.initialize, (address(this)));
+        registry = RecipientRegistry(address(new ERC1967Proxy(address(impl), initData)));
     }
 
     function test_WhenInitializing() external view {

--- a/test/VotingRecipientRegistry.t.sol
+++ b/test/VotingRecipientRegistry.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {TestWrapper} from "./TestWrapper.sol";
 import {VotingRecipientRegistry} from "../src/implementation/registries/VotingRecipientRegistry.sol";
 import {IRecipientRegistry} from "../src/interfaces/IRecipientRegistry.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract VotingRecipientRegistryTest is TestWrapper {
     VotingRecipientRegistry public registry;
@@ -21,7 +22,7 @@ contract VotingRecipientRegistryTest is TestWrapper {
     event ProposalExpiryUpdated(uint256 oldExpiry, uint256 newExpiry);
 
     function setUp() public {
-        registry = new VotingRecipientRegistry();
+        VotingRecipientRegistry impl = new VotingRecipientRegistry();
 
         // Initialize with 3 recipients
         address[] memory initial = new address[](3);
@@ -29,7 +30,8 @@ contract VotingRecipientRegistryTest is TestWrapper {
         initial[1] = RECIPIENT_2;
         initial[2] = RECIPIENT_3;
 
-        registry.initialize(ADMIN, initial, 7 days);
+        bytes memory initData = abi.encodeCall(VotingRecipientRegistry.initialize, (ADMIN, initial, 7 days));
+        registry = VotingRecipientRegistry(address(new ERC1967Proxy(address(impl), initData)));
     }
 
     function test_WhenInitializing() external view {
@@ -322,11 +324,12 @@ contract VotingRecipientRegistryTest is TestWrapper {
 
     function test_WhenInitializingWithEmptyRecipients() external {
         // it should revert with NoRecipients
-        VotingRecipientRegistry newRegistry = new VotingRecipientRegistry();
+        VotingRecipientRegistry impl = new VotingRecipientRegistry();
         address[] memory empty = new address[](0);
+        bytes memory initData = abi.encodeCall(VotingRecipientRegistry.initialize, (ADMIN, empty, 7 days));
 
         vm.expectRevert(VotingRecipientRegistry.NoRecipients.selector);
-        newRegistry.initialize(ADMIN, empty, 7 days);
+        new ERC1967Proxy(address(impl), initData);
     }
 
     function test_WhenConfiguringProposalExpiry_ShouldReturnConfiguredExpiry() external view {
@@ -348,12 +351,13 @@ contract VotingRecipientRegistryTest is TestWrapper {
 
     function test_RevertWhen_ConfiguringProposalExpiry_ZeroExpiryInInitialize() external {
         // it should revert on zero expiry in initialize
-        VotingRecipientRegistry newRegistry = new VotingRecipientRegistry();
+        VotingRecipientRegistry impl = new VotingRecipientRegistry();
         address[] memory initial = new address[](1);
         initial[0] = RECIPIENT_1;
+        bytes memory initData = abi.encodeCall(VotingRecipientRegistry.initialize, (ADMIN, initial, 0));
 
         vm.expectRevert(VotingRecipientRegistry.InvalidProposalExpiry.selector);
-        newRegistry.initialize(ADMIN, initial, 0);
+        new ERC1967Proxy(address(impl), initData);
     }
 
     function test_RevertWhen_ConfiguringProposalExpiry_ZeroExpiryInUpdate() external {

--- a/test/VotingStreakNFTModule.t.sol
+++ b/test/VotingStreakNFTModule.t.sol
@@ -142,7 +142,7 @@ contract VotingStreakNFTModuleTest is Test {
 
         // Act - Cycle 1: User votes
         harness.exposed_processVote(user, points, VOTING_POWER);
-        (uint256 streak1, ) = harness.userActivity(user);
+        (uint256 streak1,) = harness.userActivity(user);
         assertEq(streak1, 1, "Streak should be 1 after first vote");
 
         // Act - Cycle 2: Advance cycle but don't vote (user misses this cycle)
@@ -178,11 +178,7 @@ contract VotingStreakNFTModuleTest is Test {
         }
 
         // Assert
-        assertEq(
-            mockNft.balanceOf(user),
-            1,
-            "User should have 1 NFT after 10 consecutive votes"
-        );
+        assertEq(mockNft.balanceOf(user), 1, "User should have 1 NFT after 10 consecutive votes");
         (uint256 streak, uint256 lastVoteCycle) = harness.userActivity(user);
         assertEq(streak, 10, "Streak should be 10");
         assertEq(lastVoteCycle, 10, "lastVoteCycle should be 10");
@@ -209,11 +205,7 @@ contract VotingStreakNFTModuleTest is Test {
 
         // Assert after recast - streak should NOT increment
         (uint256 streakAfterRecast, uint256 lastVoteCycleAfterRecast) = harness.userActivity(user);
-        assertEq(
-            streakAfterRecast,
-            1,
-            "Streak should remain 1 after recasting vote in same cycle"
-        );
+        assertEq(streakAfterRecast, 1, "Streak should remain 1 after recasting vote in same cycle");
         assertEq(lastVoteCycleAfterRecast, 1, "lastVoteCycle should still be 1");
     }
 
@@ -250,7 +242,7 @@ contract VotingStreakNFTModuleTest is Test {
             harness.exposed_processVote(user, points, VOTING_POWER);
             if (i < 2) cycleModule.advanceCycle();
         }
-        (uint256 streak1, ) = harness.userActivity(user);
+        (uint256 streak1,) = harness.userActivity(user);
         assertEq(streak1, 3, "Streak should be 3");
 
         // Act - Miss a cycle to break streak
@@ -259,7 +251,7 @@ contract VotingStreakNFTModuleTest is Test {
 
         // Act - Vote again, streak resets to 1
         harness.exposed_processVote(user, points, VOTING_POWER);
-        (uint256 streak2, ) = harness.userActivity(user);
+        (uint256 streak2,) = harness.userActivity(user);
         assertEq(streak2, 1, "Streak should reset to 1 after gap");
 
         // Act - Build streak again to 5
@@ -267,7 +259,7 @@ contract VotingStreakNFTModuleTest is Test {
             cycleModule.advanceCycle();
             harness.exposed_processVote(user, points, VOTING_POWER);
         }
-        (uint256 streak3, ) = harness.userActivity(user);
+        (uint256 streak3,) = harness.userActivity(user);
         assertEq(streak3, 5, "Streak should build to 5 again");
     }
 
@@ -281,11 +273,11 @@ contract VotingStreakNFTModuleTest is Test {
 
         // Act & Assert - user1 votes in cycle 1
         harness.exposed_processVote(user1, points, VOTING_POWER);
-        (uint256 streak1_c1, ) = harness.userActivity(user1);
+        (uint256 streak1_c1,) = harness.userActivity(user1);
         assertEq(streak1_c1, 1, "user1 streak should be 1 in cycle 1");
 
         // Act & Assert - user2 doesn't vote in cycle 1
-        (uint256 streak2_c1, ) = harness.userActivity(user2);
+        (uint256 streak2_c1,) = harness.userActivity(user2);
         assertEq(streak2_c1, 0, "user2 streak should be 0 if never voted");
 
         // Act - Advance to cycle 2
@@ -293,17 +285,17 @@ contract VotingStreakNFTModuleTest is Test {
 
         // Act & Assert - user1 votes again in cycle 2 (builds streak to 2)
         harness.exposed_processVote(user1, points, VOTING_POWER);
-        (uint256 streak1_c2, ) = harness.userActivity(user1);
+        (uint256 streak1_c2,) = harness.userActivity(user1);
         assertEq(streak1_c2, 2, "user1 streak should be 2 in cycle 2");
 
         // Act & Assert - user2 votes for first time in cycle 2 (starts at 1)
         harness.exposed_processVote(user2, points, VOTING_POWER);
-        (uint256 streak2_c2, ) = harness.userActivity(user2);
+        (uint256 streak2_c2,) = harness.userActivity(user2);
         assertEq(streak2_c2, 1, "user2 streak should be 1 (first vote)");
 
         // Assert final state
-        (uint256 finalStreak1, ) = harness.userActivity(user1);
-        (uint256 finalStreak2, ) = harness.userActivity(user2);
+        (uint256 finalStreak1,) = harness.userActivity(user1);
+        (uint256 finalStreak2,) = harness.userActivity(user2);
         assertEq(finalStreak1, 2, "user1 should maintain streak of 2");
         assertEq(finalStreak2, 1, "user2 should have streak of 1");
     }

--- a/test/fuzz/DistributionFuzz.t.sol
+++ b/test/fuzz/DistributionFuzz.t.sol
@@ -47,10 +47,7 @@ contract DistributionFuzz is Test {
     }
 
     /// @notice Fuzz voting distribution: proportional split conserves total
-    function testFuzz_VotingDistributionConservation(
-        uint256 amount,
-        uint256[5] memory rawVotes
-    ) public pure {
+    function testFuzz_VotingDistributionConservation(uint256 amount, uint256[5] memory rawVotes) public pure {
         amount = bound(amount, 5, 1e30);
 
         // Ensure at least one vote is non-zero
@@ -102,12 +99,9 @@ contract DistributionFuzz is Test {
     }
 
     /// @notice Fuzz voting distribution with token transfers -- proportional and conserving
-    function testFuzz_VotingDistributionTokenTransfer(
-        uint256 amount,
-        uint256 vote0,
-        uint256 vote1,
-        uint256 vote2
-    ) public {
+    function testFuzz_VotingDistributionTokenTransfer(uint256 amount, uint256 vote0, uint256 vote1, uint256 vote2)
+        public
+    {
         amount = bound(amount, 3, 1e24);
         vote0 = bound(vote0, 0, 1e18);
         vote1 = bound(vote1, 0, 1e18);

--- a/test/fuzz/RecipientRegistryFuzz.t.sol
+++ b/test/fuzz/RecipientRegistryFuzz.t.sol
@@ -29,7 +29,11 @@ contract RecipientRegistryFuzz is Test {
     }
 
     /// @notice Fuzz that zero address always reverts
-    function testFuzz_QueueAdditionRejectsZeroAddress(uint256 /* salt */) public {
+    function testFuzz_QueueAdditionRejectsZeroAddress(
+        uint256 /* salt */
+    )
+        public
+    {
         vm.prank(admin);
         vm.expectRevert();
         registry.queueRecipientAddition(address(0));

--- a/test/fuzz/TWVPFuzz.t.sol
+++ b/test/fuzz/TWVPFuzz.t.sol
@@ -121,12 +121,9 @@ contract TWVPFuzz is Test {
     }
 
     /// @notice Fuzz that late deposit gives less power than holding from start
-    function testFuzz_LateDepositLessPower(
-        uint208 balance,
-        uint256 startBlock,
-        uint256 depositOffset,
-        uint256 duration
-    ) public {
+    function testFuzz_LateDepositLessPower(uint208 balance, uint256 startBlock, uint256 depositOffset, uint256 duration)
+        public
+    {
         balance = uint208(bound(balance, 1, 1e24));
         startBlock = bound(startBlock, 10, 1e6);
         duration = bound(duration, 10, 1e6);

--- a/test/fuzz/VotingModuleFuzz.t.sol
+++ b/test/fuzz/VotingModuleFuzz.t.sol
@@ -69,28 +69,32 @@ contract VotingModuleFuzz is Test {
         bytes memory sig = abi.encodePacked(randomR, randomS, v);
 
         // Build a fake struct hash
-        bytes32 structHash = keccak256(abi.encode(
-            keccak256("Vote(address voter,bytes32 pointsHash,uint256 nonce)"),
-            voter,
-            randomR, // pretend this is pointsHash
-            nonce
-        ));
+        bytes32 structHash = keccak256(
+            abi.encode(
+                keccak256("Vote(address voter,bytes32 pointsHash,uint256 nonce)"),
+                voter,
+                randomR, // pretend this is pointsHash
+                nonce
+            )
+        );
 
         // Hash with a fake domain separator
-        bytes32 domainSeparator = keccak256(abi.encode(
-            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-            keccak256("CrowdstakingVoting"),
-            keccak256("1"),
-            block.chainid,
-            address(0xdead)
-        ));
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("CrowdstakingVoting"),
+                keccak256("1"),
+                block.chainid,
+                address(0xdead)
+            )
+        );
 
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
 
         // Try to recover -- random bytes almost never produce a valid recovery matching voter.
         // We don't assert it never matches (extremely unlikely but theoretically possible),
         // but we verify the ecrecover doesn't revert and the flow is safe.
-        (address recovered, , ) = _tryRecover(digest, sig);
+        (address recovered,,) = _tryRecover(digest, sig);
         // The recovered address being different from voter is the expected case
         // but we don't hard-assert since random bytes could theoretically match
         if (recovered == voter) {

--- a/test/mocks/MockCrowdstakeNFT.sol
+++ b/test/mocks/MockCrowdstakeNFT.sol
@@ -18,5 +18,4 @@ contract MockCrowdstakeNFT is ERC721, ICrowdstakeNFT {
         _safeMint(to, tokenId);
         return tokenId;
     }
-
 }


### PR DESCRIPTION
## Why
CI has been red on \`main\`. The latest run ([28331562657](https://github.com/BreadchainCoop/crowdstake.fun/actions/runs/28331562657)) failed at the **\`forge fmt --check\`** step, before build or tests could run.

## What
- \`forge fmt\` over the tree (14 files) to satisfy \`forge fmt --check\`.
- Add the \`[profile.ci]\` referenced by \`FOUNDRY_PROFILE=ci\` in \`.github/workflows/test.yml\`. It was missing, so Foundry warned \`Selected profile 'ci' does not exist; falling back to the default profile\`. The new profile inherits the default settings (verified: \`fuzz.runs=1000\`, \`max_test_rejects=100000\` preserved).

## Verification
- \`FOUNDRY_PROFILE=ci forge fmt --check\` → clean, no profile warning
- \`FOUNDRY_PROFILE=ci forge build\` → compiles
- \`FOUNDRY_PROFILE=ci forge test\` → 144 pass; the only failures are fork tests needing \`ETH_RPC_URL\` (supplied in CI, not locally)