### PR TITLE
fix: allow zero-voter distributions in isDistributionReady (#77)

### DIFF
--- a/src/base/MultiStrategyDistributionManager.sol
+++ b/src/base/MultiStrategyDistributionManager.sol
@@ -79,7 +79,7 @@ contract MultiStrategyDistributionManager is AbstractDistributionManager {
         emit StrategiesInitialized(_strategies);
     }
 
-    /// @notice Checks if distribution is ready based on cycle completion, votes, recipients, strategies, and yield
+    /// @notice Checks if conditions are met for distribution (cycle complete, recipients configured, sufficient yield)
     /// @return ready True if cycle is complete, there are recipients, configured strategies, and sufficient yield
     /// @dev Allows zero-voter distributions for small communities (matches breadchain contracts)
     function isDistributionReady() public view override returns (bool ready) {

--- a/src/base/MultiStrategyDistributionManager.sol
+++ b/src/base/MultiStrategyDistributionManager.sol
@@ -80,14 +80,14 @@ contract MultiStrategyDistributionManager is AbstractDistributionManager {
     }
 
     /// @notice Checks if distribution is ready based on cycle completion, votes, recipients, strategies, and yield
-    /// @return ready True if cycle is complete, there are votes, recipients, configured strategies, and sufficient yield
+    /// @return ready True if cycle is complete, there are recipients, configured strategies, and sufficient yield
+    /// @dev Allows zero-voter distributions for small communities (matches breadchain contracts)
     function isDistributionReady() public view override returns (bool ready) {
         if (cycleManager().distributionManager() != address(this)) return false;
         if (!cycleManager().isCycleComplete()) return false;
 
-        uint256 totalVotes = getTotalCurrentVotingPower();
-        if (totalVotes == 0) return false;
-
+        // Allow zero-voter distributions — small communities may legitimately have no votes
+        // but still want to distribute to recipients (e.g., fixed grants).
         uint256 recipientCount = recipientRegistry().getRecipientCount();
         if (recipientCount == 0) return false;
 

--- a/src/interfaces/IDistributionManager.sol
+++ b/src/interfaces/IDistributionManager.sol
@@ -13,7 +13,9 @@ interface IDistributionManager {
     error ZeroAddress();
 
     /// @notice Thrown when distribution conditions are not met
-    /// @dev Distribution is not ready when voting power is 0 or yield < recipient count
+    /// @dev Distribution is not ready when cycle is incomplete, there are no recipients,
+    ///      or yield is insufficient. Note: MultiStrategyDistributionManager allows
+    ///      zero-voter distributions for fixed-grant use cases.
     error DistributionNotReady();
 
     /// @notice Thrown when there is no yield available to distribute


### PR DESCRIPTION
Extracts the zero-voter distribution fix (#77) from the bottom of the stacked PR chain onto a clean branch off `main`.

## Why
The original PR (#121) was closed and its branch (`104-zero-voter`) carries ~9 commits already squash-merged to main (#63/#64/#45). This branch is just the 3 real zero-voter commits rebased cleanly onto current `main`.

## What
- `MultiStrategyDistributionManager.isDistributionReady()` no longer requires nonzero voting power — allows zero-voter distributions for fixed-grant use cases.
- NatSpec updated on `IDistributionManager` to document the allowance.

## Verification
- `forge fmt --check` clean
- `FOUNDRY_PROFILE=ci forge test` → 209 passed, 0 failed
- Diff is only `MultiStrategyDistributionManager.sol` (+/- 10) and `IDistributionManager.sol` (+4/-1)