### PR TITLE
fix(ci): Node 22 for Pages deploy

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22 # pnpm 11 (our packageManager) requires Node >= 22.13
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
pnpm 11 (our pinned packageManager) requires Node >= 22.13; the Pages deploy used Node 20 and crashed on `node:sqlite`. Bumps to Node 22.