### PR TITLE
fix(web3): empty-env fallback for WC projectId

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,14 +5,22 @@ import type { Address } from "viem";
 export const CHAIN = gnosis;
 export const CHAIN_ID = gnosis.id;
 
+/** Treat empty-string env vars (e.g. an unset CI repo var) as absent. */
+const envOr = (value: string | undefined, fallback: string): string =>
+  value && value.length > 0 ? value : fallback;
+
 /** RPC + WalletConnect project id (override via env for production). */
-export const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ?? "https://rpc.gnosischain.com";
-export const WALLETCONNECT_PROJECT_ID =
-  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? "crowdstake_demo";
+export const RPC_URL = envOr(
+  process.env.NEXT_PUBLIC_RPC_URL,
+  "https://rpc.gnosischain.com",
+);
+export const WALLETCONNECT_PROJECT_ID = envOr(
+  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID,
+  "crowdstake_demo",
+);
 
 const env = (key: string, fallback: Address): Address =>
-  (process.env[key] as Address) ?? fallback;
+  envOr(process.env[key], fallback) as Address;
 
 /**
  * Deployed CrowdStake system on Gnosis mainnet


### PR DESCRIPTION
CI repo vars resolve to empty strings; treat empty as unset so the static build doesn't throw 'No projectId'.