### PR TITLE
feat: factory instance deployment + multi-instance + admin

### DIFF
--- a/contracts/deployments/gnosis-factory.json
+++ b/contracts/deployments/gnosis-factory.json
@@ -1,0 +1,12 @@
+{
+  "factory": "0x75b383Dc91822Bc8138a75fd8E7aE144f88AEed6",
+  "deployer": "0x6193210E25aAc4f645D2a7e9420Cb57B0F193033",
+  "beacons": {
+    "cycleModule": "0x4108acedbf2d0e1806a589903945a0ca260bf2da",
+    "adminRegistry": "0x856f8c0d2d56acfc0d77b98bdd2aec9283b6bbea",
+    "token": "0x97b0a0ef59cb1e43c29e6748ebaf03f109f5486f",
+    "baseDistributionManager": "0xaa3a42be84bb45d59faf15b44f72943d4d0665b4",
+    "votingStrategy": "0xc47decd27ea604e6b423cca1d1c4cbec328930c1",
+    "votingModule": "0x8d8855fae60fafff906305b9fda8840d7d7ec3d1"
+  }
+}

--- a/contracts/src/CrowdStakeDeployer.sol
+++ b/contracts/src/CrowdStakeDeployer.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {AbstractCycleModule} from "./abstract/AbstractCycleModule.sol";
+import {BaseDistributionManager} from "./base/BaseDistributionManager.sol";
+import {AbstractDistributionManager} from "./abstract/AbstractDistributionManager.sol";
+import {BasisPointsVotingModule} from "./base/BasisPointsVotingModule.sol";
+import {VotingDistributionStrategy} from "./implementation/strategies/VotingDistributionStrategy.sol";
+import {AdminRecipientRegistry} from "./implementation/registries/AdminRecipientRegistry.sol";
+import {SexyDaiYield} from "./implementation/token/SexyDaiYield.sol";
+import {AbstractToken} from "./abstract/AbstractToken.sol";
+import {TimeWeightedVotingPower} from "./implementation/TimeWeightedVotingPower.sol";
+import {IVotingPowerStrategy} from "./interfaces/IVotingPowerStrategy.sol";
+import {IVotesCheckpoints} from "./interfaces/IVotesCheckpoints.sol";
+
+/// @notice Minimal view of CrowdStakeFactory's deployment entrypoints.
+interface ICrowdStakeFactory {
+    function create(address beacon, bytes calldata payload, bytes32 salt) external returns (address);
+    function createToken(address beacon, bytes calldata payload, bytes32 salt) external returns (address);
+}
+
+/// @title CrowdStakeDeployer
+/// @notice One-transaction deployer for a complete, fully-wired CrowdStake instance
+///         (the voting-driven configuration). Reuses an existing factory + allowlisted
+///         beacons. Mirrors DeployGnosis._deploySystemInstance: the deployer temporarily
+///         owns the cycle module, token, and distribution manager so it can wire references
+///         and set the yield claimer, then hands every contract to `params.owner`.
+contract CrowdStakeDeployer {
+    ICrowdStakeFactory public immutable FACTORY;
+    address public immutable CYCLE_BEACON;
+    address public immutable REGISTRY_BEACON;
+    address public immutable TOKEN_BEACON;
+    address public immutable DIST_MANAGER_BEACON;
+    address public immutable STRATEGY_BEACON;
+    address public immutable VOTING_BEACON;
+
+    struct Params {
+        address owner;
+        uint256 cycleLength;
+        string tokenName;
+        string tokenSymbol;
+        uint256 maxVotingPoints;
+        bytes32 salt;
+    }
+
+    struct Instance {
+        address cycleModule;
+        address registry;
+        address token;
+        address votingPowerStrategy;
+        address distributionManager;
+        address distributionStrategy;
+        address votingModule;
+    }
+
+    error ZeroOwner();
+    error ZeroCycleLength();
+
+    /// @notice Emitted once a full instance is deployed and handed to its owner.
+    event SystemDeployed(address indexed owner, address indexed deployer, bytes32 indexed salt, Instance instance);
+
+    constructor(
+        address factory,
+        address cycleBeacon,
+        address registryBeacon,
+        address tokenBeacon,
+        address distManagerBeacon,
+        address strategyBeacon,
+        address votingBeacon
+    ) {
+        FACTORY = ICrowdStakeFactory(factory);
+        CYCLE_BEACON = cycleBeacon;
+        REGISTRY_BEACON = registryBeacon;
+        TOKEN_BEACON = tokenBeacon;
+        DIST_MANAGER_BEACON = distManagerBeacon;
+        STRATEGY_BEACON = strategyBeacon;
+        VOTING_BEACON = votingBeacon;
+    }
+
+    /// @notice Deploy a full, working CrowdStake instance in one transaction.
+    /// @param p owner / cycle length / token name+symbol / max voting points / salt
+    /// @return inst the seven deployed addresses
+    function deploy(Params calldata p) external returns (Instance memory inst) {
+        if (p.owner == address(0)) revert ZeroOwner();
+        if (p.cycleLength == 0) revert ZeroCycleLength();
+
+        // Scope CREATE2 salts to (caller, salt) so distinct users/instances never collide
+        // (the factory already scopes by msg.sender, which is this deployer for every call).
+        bytes32 baseSalt = keccak256(abi.encodePacked(p.salt, msg.sender));
+        address self = address(this);
+
+        // 1. Cycle module (deployer-owned for wiring).
+        inst.cycleModule = FACTORY.create(
+            CYCLE_BEACON,
+            abi.encodeWithSelector(AbstractCycleModule.initialize.selector, p.cycleLength, self),
+            keccak256(abi.encodePacked(baseSalt, "cycle"))
+        );
+
+        // 2. Admin recipient registry (owned by the final owner).
+        inst.registry = FACTORY.create(
+            REGISTRY_BEACON,
+            abi.encodeWithSelector(AdminRecipientRegistry.initialize.selector, p.owner),
+            keccak256(abi.encodePacked(baseSalt, "registry"))
+        );
+
+        // 3. Token (deployer-owned so it can set the yield claimer).
+        inst.token = FACTORY.createToken(
+            TOKEN_BEACON,
+            abi.encodeWithSelector(SexyDaiYield.initialize.selector, p.tokenName, p.tokenSymbol, self),
+            keccak256(abi.encodePacked(baseSalt, "token"))
+        );
+
+        // 4. Time-weighted voting power (immutable; deployed directly).
+        inst.votingPowerStrategy =
+            address(new TimeWeightedVotingPower(IVotesCheckpoints(inst.token), AbstractCycleModule(inst.cycleModule)));
+
+        // 5. Distribution manager (deployer-owned; placeholders corrected below).
+        inst.distributionManager = FACTORY.create(
+            DIST_MANAGER_BEACON,
+            abi.encodeWithSelector(
+                BaseDistributionManager.initialize.selector,
+                inst.cycleModule,
+                inst.registry,
+                inst.token, // baseToken == token (the yield module)
+                self, // placeholder votingModule
+                address(0), // placeholder strategy
+                self // deployer owns it temporarily
+            ),
+            keccak256(abi.encodePacked(baseSalt, "dist-manager"))
+        );
+
+        // 6. Voting distribution strategy (votes drive the split).
+        inst.distributionStrategy = FACTORY.create(
+            STRATEGY_BEACON,
+            abi.encodeWithSelector(
+                VotingDistributionStrategy.initialize.selector, inst.token, inst.distributionManager, p.owner
+            ),
+            keccak256(abi.encodePacked(baseSalt, "strategy"))
+        );
+
+        // 7. Voting module.
+        IVotingPowerStrategy[] memory vps = new IVotingPowerStrategy[](1);
+        vps[0] = IVotingPowerStrategy(inst.votingPowerStrategy);
+        inst.votingModule = FACTORY.create(
+            VOTING_BEACON,
+            abi.encodeWithSelector(
+                BasisPointsVotingModule.initialize.selector, p.maxVotingPoints, vps, inst.distributionManager, p.owner
+            ),
+            keccak256(abi.encodePacked(baseSalt, "voting"))
+        );
+
+        // Wire references + authorise the manager as the token's yield claimer.
+        BaseDistributionManager(inst.distributionManager).setDistributionStrategy(inst.distributionStrategy);
+        AbstractDistributionManager(inst.distributionManager).setVotingModule(inst.votingModule);
+        AbstractCycleModule(inst.cycleModule).setDistributionManager(inst.distributionManager);
+        AbstractToken(inst.token).setYieldClaimer(inst.distributionManager);
+
+        // Hand the temporarily-owned contracts to the final owner.
+        AbstractToken(inst.token).transferOwnership(p.owner);
+        AbstractDistributionManager(inst.distributionManager).transferOwnership(p.owner);
+        AbstractCycleModule(inst.cycleModule).transferOwnership(p.owner);
+
+        emit SystemDeployed(p.owner, msg.sender, p.salt, inst);
+    }
+}

--- a/contracts/test/CrowdStakeDeployer.t.sol
+++ b/contracts/test/CrowdStakeDeployer.t.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {CrowdStakeFactory} from "../src/CrowdStakeFactory.sol";
+import {CrowdStakeDeployer} from "../src/CrowdStakeDeployer.sol";
+
+import {CycleModule} from "../src/implementation/CycleModule.sol";
+import {AbstractCycleModule} from "../src/abstract/AbstractCycleModule.sol";
+import {BasisPointsVotingModule} from "../src/base/BasisPointsVotingModule.sol";
+import {BaseDistributionManager} from "../src/base/BaseDistributionManager.sol";
+import {AbstractDistributionManager} from "../src/abstract/AbstractDistributionManager.sol";
+import {VotingDistributionStrategy} from "../src/implementation/strategies/VotingDistributionStrategy.sol";
+import {AdminRecipientRegistry} from "../src/implementation/registries/AdminRecipientRegistry.sol";
+import {SexyDaiYield} from "../src/implementation/token/SexyDaiYield.sol";
+import {AbstractToken} from "../src/abstract/AbstractToken.sol";
+
+interface IOwnable {
+    function owner() external view returns (address);
+}
+
+contract CrowdStakeDeployerTest is Test {
+    CrowdStakeDeployer internal deployer;
+
+    address internal constant WXDAI = address(0x11dA1);
+    address internal constant SXDAI = address(0x5DA1);
+    address internal constant OWNER = address(0xABCD);
+
+    function setUp() public {
+        CrowdStakeFactory factory = new CrowdStakeFactory(address(this));
+
+        address cycleBeacon = address(new UpgradeableBeacon(address(new CycleModule()), address(this)));
+        address registryBeacon = address(new UpgradeableBeacon(address(new AdminRecipientRegistry()), address(this)));
+        address tokenBeacon = address(new UpgradeableBeacon(address(new SexyDaiYield(WXDAI, SXDAI)), address(this)));
+        address distBeacon = address(new UpgradeableBeacon(address(new BaseDistributionManager()), address(this)));
+        address stratBeacon = address(new UpgradeableBeacon(address(new VotingDistributionStrategy()), address(this)));
+        address votingBeacon = address(new UpgradeableBeacon(address(new BasisPointsVotingModule()), address(this)));
+
+        address[] memory beacons = new address[](6);
+        beacons[0] = cycleBeacon;
+        beacons[1] = registryBeacon;
+        beacons[2] = tokenBeacon;
+        beacons[3] = distBeacon;
+        beacons[4] = stratBeacon;
+        beacons[5] = votingBeacon;
+        factory.allowlistBeacons(beacons);
+
+        deployer = new CrowdStakeDeployer(
+            address(factory), cycleBeacon, registryBeacon, tokenBeacon, distBeacon, stratBeacon, votingBeacon
+        );
+    }
+
+    function _deploy(bytes32 salt) internal returns (CrowdStakeDeployer.Instance memory) {
+        return deployer.deploy(
+            CrowdStakeDeployer.Params({
+                owner: OWNER,
+                cycleLength: 100,
+                tokenName: "Test Stake",
+                tokenSymbol: "TSTK",
+                maxVotingPoints: 10_000,
+                salt: salt
+            })
+        );
+    }
+
+    function test_DeploysFullyWiredInstance() public {
+        CrowdStakeDeployer.Instance memory i = _deploy("instance-1");
+
+        // Every contract handed to the owner.
+        assertEq(IOwnable(i.token).owner(), OWNER, "token owner");
+        assertEq(IOwnable(i.cycleModule).owner(), OWNER, "cycle owner");
+        assertEq(IOwnable(i.distributionManager).owner(), OWNER, "distMgr owner");
+        assertEq(IOwnable(i.registry).owner(), OWNER, "registry owner");
+        assertEq(IOwnable(i.distributionStrategy).owner(), OWNER, "strategy owner");
+        assertEq(IOwnable(i.votingModule).owner(), OWNER, "voting owner");
+
+        // Wiring complete.
+        assertEq(AbstractToken(i.token).yieldClaimer(), i.distributionManager, "yieldClaimer");
+        assertEq(AbstractCycleModule(i.cycleModule).distributionManager(), i.distributionManager, "cycle->distMgr");
+        assertEq(
+            address(BaseDistributionManager(i.distributionManager).distributionStrategy()),
+            i.distributionStrategy,
+            "distMgr->strategy"
+        );
+        assertEq(
+            address(AbstractDistributionManager(i.distributionManager).votingModule()),
+            i.votingModule,
+            "distMgr->voting"
+        );
+
+        // Sane initial state.
+        assertEq(AbstractCycleModule(i.cycleModule).getCurrentCycle(), 1, "cycle #1");
+        assertEq(BasisPointsVotingModule(i.votingModule).maxPoints(), 10_000, "maxPoints");
+        assertEq(AdminRecipientRegistry(i.registry).getRecipientCount(), 0, "no recipients yet");
+    }
+
+    function test_DistinctSaltsGiveDistinctInstances() public {
+        CrowdStakeDeployer.Instance memory a = _deploy("alpha");
+        CrowdStakeDeployer.Instance memory b = _deploy("beta");
+        assertTrue(a.token != b.token, "distinct tokens");
+        assertTrue(a.distributionManager != b.distributionManager, "distinct managers");
+    }
+
+    function test_RevertWhen_OwnerIsZero() public {
+        vm.expectRevert(CrowdStakeDeployer.ZeroOwner.selector);
+        deployer.deploy(
+            CrowdStakeDeployer.Params({
+                owner: address(0),
+                cycleLength: 100,
+                tokenName: "x",
+                tokenSymbol: "x",
+                maxVotingPoints: 10_000,
+                salt: "z"
+            })
+        );
+    }
+}

--- a/src/app/app/admin/page.tsx
+++ b/src/app/app/admin/page.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { isAddress, type Address } from "viem";
+import { useAccount } from "wagmi";
+import { Body, Button, Caption } from "@breadcoop/ui";
+import { ArrowRight } from "@phosphor-icons/react";
+import { Card, PageHeader } from "@/components/dapp/ui";
+import { ConnectGate } from "@/components/dapp/connect-gate";
+import { TxStatus } from "@/components/dapp/tx-status";
+import { useCycle } from "@/hooks/use-cycle";
+import { useDelegate, useDelegateVotes } from "@/hooks/use-token";
+import { useRegistryOwner } from "@/hooks/use-recipients";
+import {
+  useUpdateCycleLength,
+  useYieldClaimer,
+  useYieldClaimerAdmin,
+} from "@/hooks/use-admin";
+import { shortenAddress, blocksToDuration } from "@/lib/format";
+
+export default function AdminPage() {
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <PageHeader
+        title="Admin"
+        subtitle="Manage this instance: voting delegation, cycle length, and the yield-claimer role."
+      />
+      <ConnectGate>
+        <Delegation />
+        <AdminOnly />
+      </ConnectGate>
+    </div>
+  );
+}
+
+function Delegation() {
+  const { address } = useAccount();
+  const delegate = useDelegate();
+  const { delegate: doDelegate, ...tx } = useDelegateVotes();
+  const delegatedToSelf =
+    delegate.data &&
+    address &&
+    delegate.data.toLowerCase() === address.toLowerCase();
+
+  return (
+    <Card>
+      <Caption className="text-surface-grey-2">Voting delegation</Caption>
+      <Body className="text-surface-grey-2 mt-1">
+        Current delegate:{" "}
+        <span className="text-text-standard font-mono">
+          {delegate.data ? shortenAddress(delegate.data, 6) : "none"}
+        </span>
+        {delegatedToSelf ? " (you)" : ""}
+      </Body>
+      <Body className="text-surface-grey mt-2 text-sm">
+        Deposits auto-delegate to you. Use this to re-delegate your voting power
+        to another address.
+      </Body>
+      <Button
+        app="fund"
+        variant="secondary"
+        className="mt-4"
+        isLoading={tx.isBusy}
+        onClick={() => doDelegate()}
+      >
+        Delegate to myself
+      </Button>
+      <TxStatus
+        status={tx.status}
+        hash={tx.hash}
+        error={tx.error}
+        successLabel="Delegated"
+      />
+    </Card>
+  );
+}
+
+function AdminOnly() {
+  const { isAdmin } = useRegistryOwner();
+  if (!isAdmin) {
+    return (
+      <Caption className="bg-paper-1 text-surface-grey-2 block rounded-lg px-4 py-3">
+        Owner-only controls (cycle length, yield claimer) are hidden — connect
+        as this instance&apos;s admin to manage them.
+      </Caption>
+    );
+  }
+  return (
+    <>
+      <CycleLength />
+      <YieldClaimer />
+      <Card>
+        <Caption className="text-surface-grey-2">Recipients</Caption>
+        <Body className="text-surface-grey-2 mt-1">
+          Add, remove, and process funding recipients.
+        </Body>
+        <Button
+          app="fund"
+          variant="secondary"
+          as={Link}
+          href="/app/recipients"
+          className="mt-4"
+          rightIcon={<ArrowRight weight="bold" />}
+        >
+          Manage recipients
+        </Button>
+      </Card>
+    </>
+  );
+}
+
+function CycleLength() {
+  const cycle = useCycle();
+  const { update, ...tx } = useUpdateCycleLength();
+  const [blocks, setBlocks] = useState("");
+  const valid = /^\d+$/.test(blocks) && BigInt(blocks || "0") > 0n;
+
+  return (
+    <Card>
+      <Caption className="text-surface-grey-2">Cycle length</Caption>
+      <Body className="text-surface-grey-2 mt-1">
+        Current:{" "}
+        <span className="text-text-standard font-semibold">
+          {cycle.cycleLength?.toString() ?? "—"} blocks
+        </span>{" "}
+        ({cycle.cycleLength ? blocksToDuration(cycle.cycleLength) : "—"})
+      </Body>
+      <div className="mt-3 flex gap-2">
+        <input
+          value={blocks}
+          onChange={(e) => setBlocks(e.target.value)}
+          placeholder="new length in blocks"
+          className="border-paper-2 bg-paper-main text-text-standard focus:border-core-orange w-full rounded-xl border px-4 py-2.5 outline-none"
+        />
+        <Button
+          app="fund"
+          variant="primary"
+          isLoading={tx.isBusy}
+          onClick={() => valid && update(BigInt(blocks))}
+          {...(!valid ? { disabled: true } : {})}
+        >
+          Update
+        </Button>
+      </div>
+      <Caption className="text-surface-grey mt-1 block">
+        Applies to future cycles only.
+      </Caption>
+      <TxStatus
+        status={tx.status}
+        hash={tx.hash}
+        error={tx.error}
+        successLabel="Cycle length updated"
+      />
+    </Card>
+  );
+}
+
+function YieldClaimer() {
+  const claimer = useYieldClaimer();
+  const { prepare, finalize, ...tx } = useYieldClaimerAdmin();
+  const [addr, setAddr] = useState("");
+  const valid = isAddress(addr);
+  const hasPending =
+    claimer.pending &&
+    claimer.pending !== "0x0000000000000000000000000000000000000000";
+
+  return (
+    <Card>
+      <Caption className="text-surface-grey-2">Yield claimer</Caption>
+      <Body className="text-surface-grey-2 mt-1">
+        Current:{" "}
+        <span className="text-text-standard font-mono">
+          {claimer.current ? shortenAddress(claimer.current, 6) : "—"}
+        </span>
+      </Body>
+      <Body className="text-surface-grey mt-2 text-sm">
+        The yield claimer (the distribution manager) is what claims accrued
+        yield on distribution. Rotating it uses a 14-day timelock.
+      </Body>
+      {hasPending && (
+        <Caption className="text-system-warning mt-2 block">
+          Pending: {shortenAddress(claimer.pending!, 6)} — finalizable after the
+          timelock.
+        </Caption>
+      )}
+      <div className="mt-3 flex gap-2">
+        <input
+          value={addr}
+          onChange={(e) => setAddr(e.target.value)}
+          placeholder="0x… new claimer"
+          className="border-paper-2 bg-paper-main text-text-standard focus:border-core-orange w-full rounded-xl border px-4 py-2.5 font-mono text-sm outline-none"
+        />
+        <Button
+          app="fund"
+          variant="secondary"
+          isLoading={tx.isBusy}
+          onClick={() => valid && prepare(addr as Address)}
+          {...(!valid ? { disabled: true } : {})}
+        >
+          Prepare
+        </Button>
+      </div>
+      {hasPending && (
+        <Button
+          app="fund"
+          variant="primary"
+          className="mt-3"
+          isLoading={tx.isBusy}
+          onClick={() => finalize()}
+        >
+          Finalize rotation
+        </Button>
+      )}
+      <TxStatus
+        status={tx.status}
+        hash={tx.hash}
+        error={tx.error}
+        successLabel="Done"
+      />
+    </Card>
+  );
+}

--- a/src/app/app/deploy/page.tsx
+++ b/src/app/app/deploy/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { keccak256, toHex, isAddress, type Address } from "viem";
+import { useAccount } from "wagmi";
+import { Body, Button, Caption } from "@breadcoop/ui";
+import { ArrowRight, CheckCircle } from "@phosphor-icons/react";
+import { Card, PageHeader } from "@/components/dapp/ui";
+import { ConnectGate } from "@/components/dapp/connect-gate";
+import { TxStatus } from "@/components/dapp/tx-status";
+import { useDeployInstance } from "@/hooks/use-deploy";
+import { useInstanceContext } from "@/components/instance-provider";
+import { shortenAddress } from "@/lib/format";
+
+export default function DeployPage() {
+  return (
+    <div className="mx-auto max-w-lg">
+      <PageHeader
+        title="Deploy your instance"
+        subtitle="Launch a complete, self-owned Crowdstaking instance on Gnosis in one transaction. You become the admin of every contract."
+      />
+      <ConnectGate>
+        <DeployForm />
+      </ConnectGate>
+    </div>
+  );
+}
+
+function DeployForm() {
+  const { address } = useAccount();
+  const router = useRouter();
+  const { addInstance } = useInstanceContext();
+  const { deploy, instance, isBusy, isSuccess, error, hash } =
+    useDeployInstance();
+
+  const [name, setName] = useState("");
+  const [symbol, setSymbol] = useState("");
+  const [cycleLength, setCycleLength] = useState("17280");
+  const [owner, setOwner] = useState("");
+
+  const ownerValue = (owner || address || "") as string;
+  const ownerValid = isAddress(ownerValue);
+  const cycleValid = /^\d+$/.test(cycleLength) && BigInt(cycleLength) > 0n;
+  const canDeploy =
+    name.trim().length > 0 &&
+    symbol.trim().length > 0 &&
+    cycleValid &&
+    ownerValid;
+
+  const onDeploy = () => {
+    if (!canDeploy) return;
+    const salt = keccak256(toHex(`${symbol}-${cycleLength}-${ownerValue}`));
+    void deploy({
+      owner: ownerValue as Address,
+      cycleLength: BigInt(cycleLength),
+      tokenName: name.trim(),
+      tokenSymbol: symbol.trim(),
+      maxVotingPoints: 10_000n,
+      salt,
+    });
+  };
+
+  // Success — show the new instance and let the user switch to it.
+  if (isSuccess && instance) {
+    return (
+      <Card>
+        <p className="text-system-green flex items-center gap-2">
+          <CheckCircle size={22} weight="fill" />
+          <span className="font-breadDisplay text-lg font-bold">
+            Instance deployed!
+          </span>
+        </p>
+        <dl className="mt-4 space-y-2">
+          {(
+            [
+              ["Token", instance.token],
+              ["Distribution Manager", instance.distributionManager],
+              ["Cycle Module", instance.cycleModule],
+              ["Voting Module", instance.votingModule],
+              ["Recipient Registry", instance.recipientRegistry],
+            ] as const
+          ).map(([label, addr]) => (
+            <div
+              key={label}
+              className="border-paper-2 flex items-center justify-between border-t pt-2"
+            >
+              <Caption className="text-surface-grey">{label}</Caption>
+              <span className="text-text-standard font-mono text-sm">
+                {shortenAddress(addr, 6)}
+              </span>
+            </div>
+          ))}
+        </dl>
+        <Button
+          app="fund"
+          variant="primary"
+          className="mt-6 w-full"
+          rightIcon={<ArrowRight weight="bold" />}
+          onClick={() => {
+            addInstance({
+              label: symbol.trim() || "New instance",
+              addresses: instance,
+            });
+            router.push("/app");
+          }}
+        >
+          Use this instance
+        </Button>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <Field label="Token name">
+        <Input
+          value={name}
+          onChange={setName}
+          placeholder="Acme Community Stake"
+        />
+      </Field>
+      <Field label="Token symbol">
+        <Input value={symbol} onChange={setSymbol} placeholder="ACME" />
+      </Field>
+      <Field label="Cycle length (blocks, ~5s each on Gnosis)">
+        <Input
+          value={cycleLength}
+          onChange={setCycleLength}
+          placeholder="17280"
+        />
+        {!cycleValid && cycleLength !== "" && (
+          <Caption className="text-system-red mt-1 block">
+            Must be a positive integer.
+          </Caption>
+        )}
+      </Field>
+      <Field label="Owner / admin (defaults to you)">
+        <Input
+          value={owner}
+          onChange={setOwner}
+          placeholder={address ?? "0x…"}
+          mono
+        />
+        {!ownerValid && (
+          <Caption className="text-system-red mt-1 block">
+            Not a valid address.
+          </Caption>
+        )}
+      </Field>
+
+      <Button
+        app="fund"
+        variant="primary"
+        className="mt-2 w-full"
+        isLoading={isBusy}
+        onClick={onDeploy}
+        {...(!canDeploy ? { disabled: true } : {})}
+      >
+        Deploy instance
+      </Button>
+
+      <TxStatus
+        status={isBusy ? "confirming" : error ? "error" : "idle"}
+        hash={hash}
+        error={error}
+      />
+
+      <Body className="text-surface-grey mt-6 text-sm">
+        Deploys the full system — token, cycle module, voting module + power,
+        recipient registry, and a vote-driven distribution manager — wired and
+        owned by you. Yield is distributed proportionally to community votes.
+      </Body>
+    </Card>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mb-4">
+      <Caption className="text-surface-grey-2 mb-1.5 block">{label}</Caption>
+      {children}
+    </div>
+  );
+}
+
+function Input({
+  value,
+  onChange,
+  placeholder,
+  mono,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  mono?: boolean;
+}) {
+  return (
+    <input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      className={`border-paper-2 bg-paper-main text-text-standard focus:border-core-orange w-full rounded-xl border px-4 py-3 outline-none ${
+        mono ? "font-mono text-sm" : ""
+      }`}
+    />
+  );
+}

--- a/src/components/dapp/dapp-nav.tsx
+++ b/src/components/dapp/dapp-nav.tsx
@@ -6,6 +6,7 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { Logo } from "@breadcoop/ui";
 import { cn } from "@/lib/utils";
 import { useRegistryOwner } from "@/hooks/use-recipients";
+import { InstanceSwitcher } from "@/components/dapp/instance-switcher";
 
 const LINKS = [
   { href: "/app", label: "Portfolio" },
@@ -13,13 +14,18 @@ const LINKS = [
   { href: "/app/withdraw", label: "Withdraw" },
   { href: "/app/vote", label: "Vote" },
   { href: "/app/distribute", label: "Distribute" },
+  { href: "/app/deploy", label: "Deploy" },
 ];
 
 export function DappNav() {
   const pathname = usePathname();
   const { isAdmin } = useRegistryOwner();
   const links = isAdmin
-    ? [...LINKS, { href: "/app/recipients", label: "Recipients" }]
+    ? [
+        ...LINKS,
+        { href: "/app/recipients", label: "Recipients" },
+        { href: "/app/admin", label: "Admin" },
+      ]
     : LINKS;
 
   return (
@@ -55,11 +61,14 @@ export function DappNav() {
           })}
         </div>
 
-        <ConnectButton
-          showBalance={false}
-          accountStatus="address"
-          chainStatus="icon"
-        />
+        <div className="flex items-center gap-2">
+          <InstanceSwitcher />
+          <ConnectButton
+            showBalance={false}
+            accountStatus="address"
+            chainStatus="icon"
+          />
+        </div>
       </nav>
 
       {/* Mobile nav */}

--- a/src/components/dapp/instance-switcher.tsx
+++ b/src/components/dapp/instance-switcher.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { isAddress, type Address } from "viem";
+import { CaretDown, Check, Plus, SpinnerGap } from "@phosphor-icons/react";
+import { useInstanceContext } from "@/components/instance-provider";
+import { resolveInstance } from "@/lib/instance";
+import { shortenAddress } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+/** Pick the active CrowdStake instance, or add one by its distribution-manager address. */
+export function InstanceSwitcher() {
+  const { label, known, addresses, setActive, addInstance } =
+    useInstanceContext();
+  const [open, setOpen] = useState(false);
+  const [addr, setAddr] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const onAdd = async () => {
+    if (!isAddress(addr)) {
+      setErr("Not a valid address");
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    try {
+      const resolved = await resolveInstance(addr as Address);
+      addInstance({ label: shortenAddress(addr, 4), addresses: resolved });
+      setAddr("");
+      setOpen(false);
+    } catch {
+      setErr("Could not resolve — is this a distribution manager?");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="border-paper-2 text-text-standard hover:border-core-orange flex max-w-[10rem] items-center gap-1 rounded-lg border px-2.5 py-1.5 text-sm font-medium"
+      >
+        <span className="truncate">{label}</span>
+        <CaretDown size={14} className="text-surface-grey flex-none" />
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="border-paper-2 bg-paper-0 absolute right-0 z-50 mt-2 w-72 rounded-xl border p-2 shadow-xl">
+            <p className="text-surface-grey px-2 py-1 text-xs font-semibold">
+              Instances
+            </p>
+            {known.map((inst) => {
+              const isActive =
+                inst.addresses.distributionManager ===
+                addresses.distributionManager;
+              return (
+                <button
+                  key={inst.addresses.distributionManager}
+                  onClick={() => {
+                    setActive(inst.addresses.distributionManager);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    "hover:bg-paper-1 flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm",
+                    isActive && "text-core-orange",
+                  )}
+                >
+                  <span className="truncate">{inst.label}</span>
+                  {isActive && <Check size={16} weight="bold" />}
+                </button>
+              );
+            })}
+
+            <div className="border-paper-2 mt-2 border-t pt-2">
+              <p className="text-surface-grey px-2 pb-1 text-xs font-semibold">
+                Add by distribution manager
+              </p>
+              <div className="flex gap-1.5 px-1">
+                <input
+                  value={addr}
+                  onChange={(e) => setAddr(e.target.value)}
+                  placeholder="0x…"
+                  className="border-paper-2 bg-paper-main text-text-standard focus:border-core-orange w-full rounded-lg border px-2 py-1.5 font-mono text-xs outline-none"
+                />
+                <button
+                  onClick={onAdd}
+                  disabled={busy}
+                  className="bg-core-orange flex flex-none items-center rounded-lg px-2 text-white disabled:opacity-50"
+                >
+                  {busy ? (
+                    <SpinnerGap size={16} className="animate-spin" />
+                  ) : (
+                    <Plus size={16} weight="bold" />
+                  )}
+                </button>
+              </div>
+              {err && (
+                <p className="text-system-red px-2 pt-1 text-xs">{err}</p>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/instance-provider.tsx
+++ b/src/components/instance-provider.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type { Address } from "viem";
+import {
+  DEFAULT_INSTANCE,
+  loadActiveManager,
+  loadKnownInstances,
+  saveActiveManager,
+  saveKnownInstances,
+  type InstanceAddresses,
+  type KnownInstance,
+} from "@/lib/instance";
+
+interface InstanceContextValue {
+  /** Active instance's contract addresses (what every hook reads from). */
+  addresses: InstanceAddresses;
+  /** Human label for the active instance. */
+  label: string;
+  /** All known instances (default + saved). */
+  known: KnownInstance[];
+  /** Activate a known instance by its distribution-manager address. */
+  setActive: (distributionManager: Address) => void;
+  /** Add (and activate) a newly discovered/deployed instance. */
+  addInstance: (instance: KnownInstance) => void;
+}
+
+const InstanceContext = createContext<InstanceContextValue | null>(null);
+
+export function InstanceProvider({ children }: { children: ReactNode }) {
+  const [known, setKnown] = useState<KnownInstance[]>([DEFAULT_INSTANCE]);
+  const [activeManager, setActiveManager] = useState<Address>(
+    DEFAULT_INSTANCE.addresses.distributionManager,
+  );
+
+  // Hydrate from localStorage (client only — static export safe).
+  useEffect(() => {
+    const loaded = loadKnownInstances();
+    setKnown(loaded);
+    const saved = loadActiveManager();
+    if (
+      saved &&
+      loaded.some((i) => i.addresses.distributionManager === saved)
+    ) {
+      setActiveManager(saved);
+    }
+  }, []);
+
+  const active = useMemo(
+    () =>
+      known.find((i) => i.addresses.distributionManager === activeManager) ??
+      DEFAULT_INSTANCE,
+    [known, activeManager],
+  );
+
+  const setActive = useCallback((distributionManager: Address) => {
+    setActiveManager(distributionManager);
+    saveActiveManager(distributionManager);
+  }, []);
+
+  const addInstance = useCallback((instance: KnownInstance) => {
+    setKnown((prev) => {
+      const exists = prev.some(
+        (i) =>
+          i.addresses.distributionManager.toLowerCase() ===
+          instance.addresses.distributionManager.toLowerCase(),
+      );
+      const next = exists ? prev : [...prev, instance];
+      saveKnownInstances(next);
+      return next;
+    });
+    setActiveManager(instance.addresses.distributionManager);
+    saveActiveManager(instance.addresses.distributionManager);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      addresses: active.addresses,
+      label: active.label,
+      known,
+      setActive,
+      addInstance,
+    }),
+    [active, known, setActive, addInstance],
+  );
+
+  return (
+    <InstanceContext.Provider value={value}>
+      {children}
+    </InstanceContext.Provider>
+  );
+}
+
+/** Full instance context (addresses + switching). */
+export function useInstanceContext(): InstanceContextValue {
+  const ctx = useContext(InstanceContext);
+  if (!ctx)
+    throw new Error("useInstanceContext must be used within InstanceProvider");
+  return ctx;
+}
+
+/** Active instance addresses — the common case used by data hooks. */
+export function useInstance(): InstanceAddresses {
+  return useInstanceContext().addresses;
+}

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RainbowKitProvider, lightTheme } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
 import { wagmiConfig } from "@/lib/wagmi";
+import { InstanceProvider } from "@/components/instance-provider";
 
 export function Providers({ children }: { children: ReactNode }) {
   // One QueryClient per browser session; hashFn keeps bigint query keys stable.
@@ -28,7 +29,7 @@ export function Providers({ children }: { children: ReactNode }) {
             borderRadius: "medium",
           })}
         >
-          {children}
+          <InstanceProvider>{children}</InstanceProvider>
         </RainbowKitProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/src/hooks/use-admin.ts
+++ b/src/hooks/use-admin.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import type { Address } from "viem";
+import { useReadContract } from "wagmi";
+import { cycleModuleAbi, tokenAbi } from "@/lib/abis";
+import { CHAIN_ID } from "@/lib/constants";
+import { useInstance } from "@/components/instance-provider";
+import { useTx } from "@/hooks/use-tx";
+
+/** Update the cycle length (blocks) for future cycles — registry/cycle owner only. */
+export function useUpdateCycleLength() {
+  const a = useInstance();
+  const tx = useTx();
+  const update = (blocks: bigint) =>
+    tx.run({
+      address: a.cycleModule,
+      abi: cycleModuleAbi,
+      functionName: "updateCycleLength",
+      args: [blocks],
+    });
+  return { update, ...tx };
+}
+
+/** Read the token's yield-claimer state (current + pending two-phase transfer). */
+export function useYieldClaimer() {
+  const a = useInstance();
+  const current = useReadContract({
+    address: a.token,
+    abi: tokenAbi,
+    functionName: "yieldClaimer",
+    chainId: CHAIN_ID,
+  });
+  const pending = useReadContract({
+    address: a.token,
+    abi: tokenAbi,
+    functionName: "pendingYieldClaimer",
+    chainId: CHAIN_ID,
+  });
+  const finishedAt = useReadContract({
+    address: a.token,
+    abi: tokenAbi,
+    functionName: "pendingFinishedAt",
+    chainId: CHAIN_ID,
+  });
+  return {
+    current: current.data as Address | undefined,
+    pending: pending.data as Address | undefined,
+    pendingFinishedAt: finishedAt.data as bigint | undefined,
+    refetch: () => {
+      void current.refetch();
+      void pending.refetch();
+      void finishedAt.refetch();
+    },
+  };
+}
+
+/** Two-phase (14-day timelock) yield-claimer rotation — token owner only. */
+export function useYieldClaimerAdmin() {
+  const a = useInstance();
+  const tx = useTx();
+  const prepare = (newClaimer: Address) =>
+    tx.run({
+      address: a.token,
+      abi: tokenAbi,
+      functionName: "prepareNewYieldClaimer",
+      args: [newClaimer],
+    });
+  const finalize = () =>
+    tx.run({
+      address: a.token,
+      abi: tokenAbi,
+      functionName: "finalizeNewYieldClaimer",
+      args: [],
+    });
+  return { prepare, finalize, ...tx };
+}

--- a/src/hooks/use-cycle.ts
+++ b/src/hooks/use-cycle.ts
@@ -2,46 +2,48 @@
 
 import { useBlockNumber, useReadContract } from "wagmi";
 import { cycleModuleAbi } from "@/lib/abis";
-import { ADDRESSES, CHAIN_ID } from "@/lib/constants";
+import { CHAIN_ID } from "@/lib/constants";
+import { useInstance } from "@/components/instance-provider";
 
 const LIVE = { refetchInterval: 12_000 } as const;
 
 /** Current cycle status: number, length, progress, blocks remaining. */
 export function useCycle() {
+  const a = useInstance();
   const { data: blockNumber } = useBlockNumber({
     chainId: CHAIN_ID,
     watch: true,
   });
 
   const cycle = useReadContract({
-    address: ADDRESSES.cycleModule,
+    address: a.cycleModule,
     abi: cycleModuleAbi,
     functionName: "getCurrentCycle",
     chainId: CHAIN_ID,
     query: LIVE,
   });
   const length = useReadContract({
-    address: ADDRESSES.cycleModule,
+    address: a.cycleModule,
     abi: cycleModuleAbi,
     functionName: "cycleLength",
     chainId: CHAIN_ID,
   });
   const lastStart = useReadContract({
-    address: ADDRESSES.cycleModule,
+    address: a.cycleModule,
     abi: cycleModuleAbi,
     functionName: "lastCycleStartBlock",
     chainId: CHAIN_ID,
     query: LIVE,
   });
   const complete = useReadContract({
-    address: ADDRESSES.cycleModule,
+    address: a.cycleModule,
     abi: cycleModuleAbi,
     functionName: "isCycleComplete",
     chainId: CHAIN_ID,
     query: LIVE,
   });
   const blocksLeft = useReadContract({
-    address: ADDRESSES.cycleModule,
+    address: a.cycleModule,
     abi: cycleModuleAbi,
     functionName: "getBlocksUntilNextCycle",
     chainId: CHAIN_ID,
@@ -50,7 +52,6 @@ export function useCycle() {
 
   const cycleLength = length.data;
   const lastStartBlock = lastStart.data;
-  // Progress 0..1, computed locally against the live block for smoothness.
   let progress = 0;
   if (
     cycleLength &&

--- a/src/hooks/use-deploy.ts
+++ b/src/hooks/use-deploy.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useMemo } from "react";
+import { decodeEventLog, type Address, type Hex } from "viem";
+import { useWaitForTransactionReceipt, useWriteContract } from "wagmi";
+import { deployerAbi } from "@/lib/abis";
+import { DEPLOYER } from "@/lib/constants";
+import { parseTxError } from "@/hooks/use-tx";
+import type { InstanceAddresses } from "@/lib/instance";
+
+export interface DeployParams {
+  owner: Address;
+  cycleLength: bigint;
+  tokenName: string;
+  tokenSymbol: string;
+  maxVotingPoints: bigint;
+  salt: Hex;
+}
+
+/**
+ * Deploy a full CrowdStake instance in one transaction via CrowdStakeDeployer,
+ * then surface the resulting seven addresses (decoded from SystemDeployed).
+ */
+export function useDeployInstance() {
+  const {
+    writeContractAsync,
+    data: hash,
+    isPending: isSigning,
+    reset,
+    error: writeError,
+  } = useWriteContract();
+  const {
+    data: receipt,
+    isLoading: isConfirming,
+    isSuccess,
+    error: receiptError,
+  } = useWaitForTransactionReceipt({ hash });
+
+  const instance = useMemo<InstanceAddresses | null>(() => {
+    if (!receipt) return null;
+    for (const log of receipt.logs) {
+      try {
+        const ev = decodeEventLog({
+          abi: deployerAbi,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (ev.eventName === "SystemDeployed" && "instance" in ev.args) {
+          return ev.args.instance as unknown as InstanceAddresses;
+        }
+      } catch {
+        // not our event — keep scanning
+      }
+    }
+    return null;
+  }, [receipt]);
+
+  const deploy = async (p: DeployParams) => {
+    try {
+      return await writeContractAsync({
+        address: DEPLOYER,
+        abi: deployerAbi,
+        functionName: "deploy",
+        args: [
+          {
+            owner: p.owner,
+            cycleLength: p.cycleLength,
+            tokenName: p.tokenName,
+            tokenSymbol: p.tokenSymbol,
+            maxVotingPoints: p.maxVotingPoints,
+            salt: p.salt,
+          },
+        ],
+      });
+    } catch (e) {
+      throw new Error(parseTxError(e));
+    }
+  };
+
+  return {
+    deploy,
+    hash,
+    instance,
+    isBusy: isSigning || isConfirming,
+    isSuccess,
+    error: writeError
+      ? parseTxError(writeError)
+      : receiptError
+        ? parseTxError(receiptError)
+        : null,
+    reset,
+  };
+}

--- a/src/hooks/use-distribution.ts
+++ b/src/hooks/use-distribution.ts
@@ -2,13 +2,15 @@
 
 import { useReadContract } from "wagmi";
 import { distributionManagerAbi } from "@/lib/abis";
-import { ADDRESSES, CHAIN_ID } from "@/lib/constants";
+import { CHAIN_ID } from "@/lib/constants";
+import { useInstance } from "@/components/instance-provider";
 import { useTx } from "@/hooks/use-tx";
 
 /** Whether the protocol can run a distribution right now (all gates satisfied). */
 export function useDistributionReady() {
+  const a = useInstance();
   const ready = useReadContract({
-    address: ADDRESSES.distributionManager,
+    address: a.distributionManager,
     abi: distributionManagerAbi,
     functionName: "isDistributionReady",
     chainId: CHAIN_ID,
@@ -23,10 +25,11 @@ export function useDistributionReady() {
 
 /** Public keeper action: claim accrued yield, distribute to recipients, advance the cycle. */
 export function useDistribute() {
+  const a = useInstance();
   const tx = useTx();
   const distribute = () =>
     tx.run({
-      address: ADDRESSES.distributionManager,
+      address: a.distributionManager,
       abi: distributionManagerAbi,
       functionName: "claimAndDistribute",
       args: [],

--- a/src/hooks/use-recipients.ts
+++ b/src/hooks/use-recipients.ts
@@ -3,29 +3,31 @@
 import type { Address } from "viem";
 import { useAccount, useReadContract } from "wagmi";
 import { recipientRegistryAbi } from "@/lib/abis";
-import { ADDRESSES, CHAIN_ID } from "@/lib/constants";
+import { CHAIN_ID } from "@/lib/constants";
+import { useInstance } from "@/components/instance-provider";
 import { useTx } from "@/hooks/use-tx";
 
 const LIVE = { refetchInterval: 15_000 } as const;
 
 /** Active recipients + pending queue (additions/removals). */
 export function useRecipients() {
+  const a = useInstance();
   const recipients = useReadContract({
-    address: ADDRESSES.recipientRegistry,
+    address: a.recipientRegistry,
     abi: recipientRegistryAbi,
     functionName: "getRecipients",
     chainId: CHAIN_ID,
     query: LIVE,
   });
   const queuedAdditions = useReadContract({
-    address: ADDRESSES.recipientRegistry,
+    address: a.recipientRegistry,
     abi: recipientRegistryAbi,
     functionName: "getQueuedAdditions",
     chainId: CHAIN_ID,
     query: LIVE,
   });
   const queuedRemovals = useReadContract({
-    address: ADDRESSES.recipientRegistry,
+    address: a.recipientRegistry,
     abi: recipientRegistryAbi,
     functionName: "getQueuedRemovals",
     chainId: CHAIN_ID,
@@ -45,10 +47,11 @@ export function useRecipients() {
 }
 
 export function useIsRecipient(account?: Address) {
+  const a = useInstance();
   const { address } = useAccount();
   const who = account ?? address;
   return useReadContract({
-    address: ADDRESSES.recipientRegistry,
+    address: a.recipientRegistry,
     abi: recipientRegistryAbi,
     functionName: "isRecipient",
     args: who ? [who] : undefined,
@@ -59,9 +62,10 @@ export function useIsRecipient(account?: Address) {
 
 /** Registry admin (owner) — used to gate the admin UI. */
 export function useRegistryOwner() {
+  const a = useInstance();
   const { address } = useAccount();
   const owner = useReadContract({
-    address: ADDRESSES.recipientRegistry,
+    address: a.recipientRegistry,
     abi: recipientRegistryAbi,
     functionName: "owner",
     chainId: CHAIN_ID,
@@ -78,37 +82,89 @@ export function useRegistryOwner() {
 /* ----------------------------- Admin actions ----------------------------- */
 
 export function useQueueRecipientAddition() {
+  const a = useInstance();
   const tx = useTx();
   const queue = (recipient: Address) =>
     tx.run({
-      address: ADDRESSES.recipientRegistry,
+      address: a.recipientRegistry,
       abi: recipientRegistryAbi,
       functionName: "queueRecipientAddition",
       args: [recipient],
     });
-  return { queue, ...tx };
+  const queueMany = (recipients: Address[]) =>
+    tx.run({
+      address: a.recipientRegistry,
+      abi: recipientRegistryAbi,
+      functionName: "queueRecipientsAddition",
+      args: [recipients],
+    });
+  return { queue, queueMany, ...tx };
 }
 
 export function useQueueRecipientRemoval() {
+  const a = useInstance();
   const tx = useTx();
   const queue = (recipient: Address) =>
     tx.run({
-      address: ADDRESSES.recipientRegistry,
+      address: a.recipientRegistry,
       abi: recipientRegistryAbi,
       functionName: "queueRecipientRemoval",
       args: [recipient],
     });
-  return { queue, ...tx };
+  const queueMany = (recipients: Address[]) =>
+    tx.run({
+      address: a.recipientRegistry,
+      abi: recipientRegistryAbi,
+      functionName: "queueRecipientsRemoval",
+      args: [recipients],
+    });
+  return { queue, queueMany, ...tx };
 }
 
 export function useProcessQueue() {
+  const a = useInstance();
   const tx = useTx();
   const process = () =>
     tx.run({
-      address: ADDRESSES.recipientRegistry,
+      address: a.recipientRegistry,
       abi: recipientRegistryAbi,
       functionName: "processQueue",
       args: [],
     });
   return { process, ...tx };
+}
+
+/** Clear pending additions or removals without processing them. */
+export function useClearQueue() {
+  const a = useInstance();
+  const tx = useTx();
+  const clearAdditions = () =>
+    tx.run({
+      address: a.recipientRegistry,
+      abi: recipientRegistryAbi,
+      functionName: "clearAdditionQueue",
+      args: [],
+    });
+  const clearRemovals = () =>
+    tx.run({
+      address: a.recipientRegistry,
+      abi: recipientRegistryAbi,
+      functionName: "clearRemovalQueue",
+      args: [],
+    });
+  return { clearAdditions, clearRemovals, ...tx };
+}
+
+/** Transfer registry admin to a new address. */
+export function useTransferAdmin() {
+  const a = useInstance();
+  const tx = useTx();
+  const transferAdmin = (newAdmin: Address) =>
+    tx.run({
+      address: a.recipientRegistry,
+      abi: recipientRegistryAbi,
+      functionName: "transferAdmin",
+      args: [newAdmin],
+    });
+  return { transferAdmin, ...tx };
 }

--- a/src/hooks/use-token.ts
+++ b/src/hooks/use-token.ts
@@ -3,16 +3,18 @@
 import { erc20Abi, maxUint256, zeroAddress, type Address } from "viem";
 import { useAccount, useBalance, useReadContract } from "wagmi";
 import { tokenAbi } from "@/lib/abis";
-import { ADDRESSES, CHAIN_ID, WXDAI } from "@/lib/constants";
+import { CHAIN_ID, WXDAI } from "@/lib/constants";
+import { useInstance } from "@/components/instance-provider";
 import { useTx } from "@/hooks/use-tx";
 
 const LIVE = { refetchInterval: 12_000 } as const;
 
 export function useTokenBalance(account?: Address) {
+  const a = useInstance();
   const { address } = useAccount();
   const owner = account ?? address;
   return useReadContract({
-    address: ADDRESSES.token,
+    address: a.token,
     abi: tokenAbi,
     functionName: "balanceOf",
     args: owner ? [owner] : undefined,
@@ -23,15 +25,16 @@ export function useTokenBalance(account?: Address) {
 
 /** Protocol-wide token stats: total supply + accrued (claimable) yield. */
 export function useTokenStats() {
+  const a = useInstance();
   const totalSupply = useReadContract({
-    address: ADDRESSES.token,
+    address: a.token,
     abi: tokenAbi,
     functionName: "totalSupply",
     chainId: CHAIN_ID,
     query: LIVE,
   });
   const yieldAccrued = useReadContract({
-    address: ADDRESSES.token,
+    address: a.token,
     abi: tokenAbi,
     functionName: "yieldAccrued",
     chainId: CHAIN_ID,
@@ -49,10 +52,11 @@ export function useTokenStats() {
 }
 
 export function useVotes(account?: Address) {
+  const a = useInstance();
   const { address } = useAccount();
   const owner = account ?? address;
   return useReadContract({
-    address: ADDRESSES.token,
+    address: a.token,
     abi: tokenAbi,
     functionName: "getVotes",
     args: owner ? [owner] : undefined,
@@ -62,10 +66,11 @@ export function useVotes(account?: Address) {
 }
 
 export function useDelegate(account?: Address) {
+  const a = useInstance();
   const { address } = useAccount();
   const owner = account ?? address;
   return useReadContract({
-    address: ADDRESSES.token,
+    address: a.token,
     abi: tokenAbi,
     functionName: "delegates",
     args: owner ? [owner] : undefined,
@@ -86,6 +91,7 @@ export function useNativeBalance(account?: Address) {
 
 /** wxDAI balance + current allowance granted to the token contract. */
 export function useWxdai(account?: Address) {
+  const a = useInstance();
   const { address } = useAccount();
   const owner = account ?? address;
   const balance = useReadContract({
@@ -100,7 +106,7 @@ export function useWxdai(account?: Address) {
     address: WXDAI,
     abi: erc20Abi,
     functionName: "allowance",
-    args: owner ? [owner, ADDRESSES.token] : undefined,
+    args: owner ? [owner, a.token] : undefined,
     chainId: CHAIN_ID,
     query: { enabled: Boolean(owner) },
   });
@@ -117,19 +123,21 @@ export function useWxdai(account?: Address) {
 /* ----------------------------- Write actions ----------------------------- */
 
 export function useApproveWxdai() {
+  const a = useInstance();
   const tx = useTx();
   const approve = (amount: bigint = maxUint256) =>
     tx.run({
       address: WXDAI,
       abi: erc20Abi,
       functionName: "approve",
-      args: [ADDRESSES.token, amount],
+      args: [a.token, amount],
     });
   return { approve, ...tx };
 }
 
 /** Deposit: native xDAI (`mint(receiver){value}`) or wxDAI (`mint(receiver, amount)`). */
 export function useDeposit() {
+  const a = useInstance();
   const { address } = useAccount();
   const tx = useTx();
   const deposit = (opts: {
@@ -140,7 +148,7 @@ export function useDeposit() {
     const receiver = opts.receiver ?? address ?? zeroAddress;
     if (opts.mode === "native") {
       return tx.run({
-        address: ADDRESSES.token,
+        address: a.token,
         abi: tokenAbi,
         functionName: "mint",
         args: [receiver],
@@ -148,7 +156,7 @@ export function useDeposit() {
       });
     }
     return tx.run({
-      address: ADDRESSES.token,
+      address: a.token,
       abi: tokenAbi,
       functionName: "mint",
       args: [receiver, opts.amount],
@@ -157,16 +165,32 @@ export function useDeposit() {
   return { deposit, ...tx };
 }
 
-/** Withdraw: burn CSTAKE and remit native xDAI to `receiver`. */
+/** Withdraw: burn the token and remit native xDAI to `receiver`. */
 export function useWithdraw() {
+  const a = useInstance();
   const { address } = useAccount();
   const tx = useTx();
   const withdraw = (amount: bigint, receiver?: Address) =>
     tx.run({
-      address: ADDRESSES.token,
+      address: a.token,
       abi: tokenAbi,
       functionName: "burn",
       args: [amount, receiver ?? address ?? zeroAddress],
     });
   return { withdraw, ...tx };
+}
+
+/** Manually (re)delegate voting power to an address (self by default). */
+export function useDelegateVotes() {
+  const a = useInstance();
+  const { address } = useAccount();
+  const tx = useTx();
+  const delegate = (to?: Address) =>
+    tx.run({
+      address: a.token,
+      abi: tokenAbi,
+      functionName: "delegate",
+      args: [to ?? address ?? zeroAddress],
+    });
+  return { delegate, ...tx };
 }

--- a/src/hooks/use-voting.ts
+++ b/src/hooks/use-voting.ts
@@ -2,7 +2,8 @@
 
 import { useAccount, useReadContract } from "wagmi";
 import { votingModuleAbi, votingPowerAbi } from "@/lib/abis";
-import { ADDRESSES, CHAIN_ID } from "@/lib/constants";
+import { CHAIN_ID } from "@/lib/constants";
+import { useInstance } from "@/components/instance-provider";
 import { useTx } from "@/hooks/use-tx";
 
 const LIVE = { refetchInterval: 12_000 } as const;
@@ -13,39 +14,39 @@ const LIVE = { refetchInterval: 12_000 } as const;
  * whether they've voted this cycle.
  */
 export function useVotingState() {
+  const a = useInstance();
   const { address } = useAccount();
 
   const distribution = useReadContract({
-    address: ADDRESSES.votingModule,
+    address: a.votingModule,
     abi: votingModuleAbi,
     functionName: "getCurrentVotingDistribution",
     chainId: CHAIN_ID,
     query: LIVE,
   });
   const expectedPointsLength = useReadContract({
-    address: ADDRESSES.votingModule,
+    address: a.votingModule,
     abi: votingModuleAbi,
     functionName: "getExpectedPointsLength",
     chainId: CHAIN_ID,
     query: LIVE,
   });
   const maxPoints = useReadContract({
-    address: ADDRESSES.votingModule,
+    address: a.votingModule,
     abi: votingModuleAbi,
     functionName: "maxPoints",
     chainId: CHAIN_ID,
   });
   const hasVoted = useReadContract({
-    address: ADDRESSES.votingModule,
+    address: a.votingModule,
     abi: votingModuleAbi,
     functionName: "hasVotedInCurrentCycle",
     args: address ? [address] : undefined,
     chainId: CHAIN_ID,
     query: { enabled: Boolean(address), ...LIVE },
   });
-  // Time-weighted voting power for the connected user this cycle.
   const power = useReadContract({
-    address: ADDRESSES.votingPowerStrategy,
+    address: a.votingPowerStrategy,
     abi: votingPowerAbi,
     functionName: "getCurrentVotingPower",
     args: address ? [address] : undefined,
@@ -70,10 +71,11 @@ export function useVotingState() {
 
 /** Cast a direct vote: `points[]` (one per recipient, basis points). */
 export function useVote() {
+  const a = useInstance();
   const tx = useTx();
   const vote = (points: bigint[]) =>
     tx.run({
-      address: ADDRESSES.votingModule,
+      address: a.votingModule,
       abi: votingModuleAbi,
       functionName: "voteWithData",
       args: [points, "0x"],

--- a/src/lib/abis/crowdstake-deployer.ts
+++ b/src/lib/abis/crowdstake-deployer.ts
@@ -1,0 +1,167 @@
+export const deployerAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      { name: "factory", type: "address", internalType: "address" },
+      { name: "cycleBeacon", type: "address", internalType: "address" },
+      { name: "registryBeacon", type: "address", internalType: "address" },
+      { name: "tokenBeacon", type: "address", internalType: "address" },
+      { name: "distManagerBeacon", type: "address", internalType: "address" },
+      { name: "strategyBeacon", type: "address", internalType: "address" },
+      { name: "votingBeacon", type: "address", internalType: "address" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "CYCLE_BEACON",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "DIST_MANAGER_BEACON",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "FACTORY",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract ICrowdStakeFactory",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "REGISTRY_BEACON",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "STRATEGY_BEACON",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "TOKEN_BEACON",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "VOTING_BEACON",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "deploy",
+    inputs: [
+      {
+        name: "p",
+        type: "tuple",
+        internalType: "struct CrowdStakeDeployer.Params",
+        components: [
+          { name: "owner", type: "address", internalType: "address" },
+          { name: "cycleLength", type: "uint256", internalType: "uint256" },
+          { name: "tokenName", type: "string", internalType: "string" },
+          { name: "tokenSymbol", type: "string", internalType: "string" },
+          { name: "maxVotingPoints", type: "uint256", internalType: "uint256" },
+          { name: "salt", type: "bytes32", internalType: "bytes32" },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: "inst",
+        type: "tuple",
+        internalType: "struct CrowdStakeDeployer.Instance",
+        components: [
+          { name: "cycleModule", type: "address", internalType: "address" },
+          { name: "registry", type: "address", internalType: "address" },
+          { name: "token", type: "address", internalType: "address" },
+          {
+            name: "votingPowerStrategy",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "distributionManager",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "distributionStrategy",
+            type: "address",
+            internalType: "address",
+          },
+          { name: "votingModule", type: "address", internalType: "address" },
+        ],
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "SystemDeployed",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "deployer",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      { name: "salt", type: "bytes32", indexed: true, internalType: "bytes32" },
+      {
+        name: "instance",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct CrowdStakeDeployer.Instance",
+        components: [
+          { name: "cycleModule", type: "address", internalType: "address" },
+          { name: "registry", type: "address", internalType: "address" },
+          { name: "token", type: "address", internalType: "address" },
+          {
+            name: "votingPowerStrategy",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "distributionManager",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "distributionStrategy",
+            type: "address",
+            internalType: "address",
+          },
+          { name: "votingModule", type: "address", internalType: "address" },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  { type: "error", name: "ZeroCycleLength", inputs: [] },
+  { type: "error", name: "ZeroOwner", inputs: [] },
+] as const;

--- a/src/lib/abis/factory.ts
+++ b/src/lib/abis/factory.ts
@@ -1,0 +1,267 @@
+export const factoryAbi = [
+  {
+    type: "constructor",
+    inputs: [{ name: "_owner", type: "address", internalType: "address" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "allowlistBeacons",
+    inputs: [
+      { name: "beacons_", type: "address[]", internalType: "address[]" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "beacons",
+    inputs: [],
+    outputs: [{ name: "", type: "address[]", internalType: "address[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "beaconsContains",
+    inputs: [{ name: "beacon_", type: "address", internalType: "address" }],
+    outputs: [{ name: "isContained", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "cancelOwnershipHandover",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "completeOwnershipHandover",
+    inputs: [
+      { name: "pendingOwner", type: "address", internalType: "address" },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "computeAddress",
+    inputs: [
+      { name: "beacon_", type: "address", internalType: "address" },
+      { name: "payload_", type: "bytes", internalType: "bytes" },
+      { name: "salt_", type: "bytes32", internalType: "bytes32" },
+    ],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "computeAddress",
+    inputs: [
+      { name: "beacon_", type: "address", internalType: "address" },
+      { name: "payload_", type: "bytes", internalType: "bytes" },
+      { name: "salt_", type: "bytes32", internalType: "bytes32" },
+      { name: "sender_", type: "address", internalType: "address" },
+    ],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "computeTokenAddress",
+    inputs: [
+      { name: "beacon_", type: "address", internalType: "address" },
+      { name: "payload_", type: "bytes", internalType: "bytes" },
+      { name: "salt_", type: "bytes32", internalType: "bytes32" },
+    ],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "create",
+    inputs: [
+      { name: "beacon_", type: "address", internalType: "address" },
+      { name: "payload_", type: "bytes", internalType: "bytes" },
+      { name: "salt_", type: "bytes32", internalType: "bytes32" },
+    ],
+    outputs: [{ name: "module", type: "address", internalType: "address" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "createToken",
+    inputs: [
+      { name: "beacon_", type: "address", internalType: "address" },
+      { name: "payload_", type: "bytes", internalType: "bytes" },
+      { name: "salt_", type: "bytes32", internalType: "bytes32" },
+    ],
+    outputs: [{ name: "token", type: "address", internalType: "address" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "denylistBeacons",
+    inputs: [
+      { name: "beacons_", type: "address[]", internalType: "address[]" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "owner",
+    inputs: [],
+    outputs: [{ name: "result", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "ownershipHandoverExpiresAt",
+    inputs: [
+      { name: "pendingOwner", type: "address", internalType: "address" },
+    ],
+    outputs: [{ name: "result", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "renounceOwnership",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "requestOwnershipHandover",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "transferOwnership",
+    inputs: [{ name: "newOwner", type: "address", internalType: "address" }],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "event",
+    name: "AllowlistBeacons",
+    inputs: [
+      {
+        name: "beacons",
+        type: "address[]",
+        indexed: false,
+        internalType: "address[]",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "CreateModule",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+      {
+        name: "beacon",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+      { name: "payload", type: "bytes", indexed: false, internalType: "bytes" },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "CreateToken",
+    inputs: [
+      {
+        name: "token",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+      {
+        name: "beacon",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+      { name: "payload", type: "bytes", indexed: false, internalType: "bytes" },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "DenylistBeacons",
+    inputs: [
+      {
+        name: "beacons",
+        type: "address[]",
+        indexed: false,
+        internalType: "address[]",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipHandoverCanceled",
+    inputs: [
+      {
+        name: "pendingOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipHandoverRequested",
+    inputs: [
+      {
+        name: "pendingOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferred",
+    inputs: [
+      {
+        name: "oldOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  { type: "error", name: "AlreadyAllowlistedBeacon", inputs: [] },
+  { type: "error", name: "AlreadyInitialized", inputs: [] },
+  { type: "error", name: "Create2Failed", inputs: [] },
+  { type: "error", name: "NewOwnerIsZeroAddress", inputs: [] },
+  { type: "error", name: "NoHandoverRequest", inputs: [] },
+  { type: "error", name: "NotAllowlistedBeacon", inputs: [] },
+  { type: "error", name: "NotBeacon", inputs: [] },
+  { type: "error", name: "Unauthorized", inputs: [] },
+] as const;

--- a/src/lib/abis/index.ts
+++ b/src/lib/abis/index.ts
@@ -5,3 +5,5 @@ export { votingModuleAbi } from "./voting-module";
 export { recipientRegistryAbi } from "./recipient-registry";
 export { distributionStrategyAbi } from "./distribution-strategy";
 export { votingPowerAbi } from "./voting-power";
+export { deployerAbi } from "./crowdstake-deployer";
+export { factoryAbi } from "./factory";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -57,6 +57,12 @@ export const ADDRESSES = {
   ),
 } as const;
 
+/** CrowdStakeDeployer — one-tx full-instance deployer (reuses the live factory + beacons). */
+export const DEPLOYER: Address = env(
+  "NEXT_PUBLIC_DEPLOYER_ADDRESS",
+  "0x6193210E25aAc4f645D2a7e9420Cb57B0F193033",
+);
+
 /** Underlying Gnosis tokens used by the SexyDaiYield token. */
 export const WXDAI: Address = "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
 export const SDAI: Address = "0xaf204776c7245bF4147c2612BF6e5972Ee483701";

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -1,0 +1,112 @@
+import { createPublicClient, http, type Address } from "viem";
+import { gnosis } from "viem/chains";
+import { ADDRESSES, RPC_URL, TOKEN_SYMBOL } from "@/lib/constants";
+import { distributionManagerAbi, votingModuleAbi } from "@/lib/abis";
+
+/** The full set of contract addresses that make up one CrowdStake instance. */
+export interface InstanceAddresses {
+  token: Address;
+  distributionManager: Address;
+  cycleModule: Address;
+  votingModule: Address;
+  recipientRegistry: Address;
+  distributionStrategy: Address;
+  votingPowerStrategy: Address;
+}
+
+export interface KnownInstance {
+  label: string;
+  addresses: InstanceAddresses;
+}
+
+/** The instance deployed with the protocol (always available, can't be removed). */
+export const DEFAULT_INSTANCE: KnownInstance = {
+  label: `${TOKEN_SYMBOL} (default)`,
+  addresses: ADDRESSES,
+};
+
+const STORAGE_KEY = "crowdstake.instances.v1";
+const ACTIVE_KEY = "crowdstake.activeInstance.v1";
+
+const client = createPublicClient({ chain: gnosis, transport: http(RPC_URL) });
+
+/**
+ * Resolve a full instance from just its distribution-manager address by reading
+ * the wired references on-chain. Lets the dapp point at *any* deployed instance.
+ */
+export async function resolveInstance(
+  distributionManager: Address,
+): Promise<InstanceAddresses> {
+  const base = {
+    address: distributionManager,
+    abi: distributionManagerAbi,
+  } as const;
+  const [cycleModule, votingModule, recipientRegistry, token, strategy] =
+    await Promise.all([
+      client.readContract({ ...base, functionName: "cycleManager" }),
+      client.readContract({ ...base, functionName: "votingModule" }),
+      client.readContract({ ...base, functionName: "recipientRegistry" }),
+      client.readContract({ ...base, functionName: "baseToken" }),
+      client.readContract({ ...base, functionName: "distributionStrategy" }),
+    ]);
+  const vpStrategies = await client.readContract({
+    address: votingModule as Address,
+    abi: votingModuleAbi,
+    functionName: "getVotingPowerStrategies",
+  });
+  return {
+    distributionManager,
+    cycleModule: cycleModule as Address,
+    votingModule: votingModule as Address,
+    recipientRegistry: recipientRegistry as Address,
+    token: token as Address,
+    distributionStrategy: strategy as Address,
+    votingPowerStrategy: (vpStrategies as readonly Address[])[0],
+  };
+}
+
+/* --------------------------- localStorage helpers -------------------------- */
+
+export function loadKnownInstances(): KnownInstance[] {
+  if (typeof window === "undefined") return [DEFAULT_INSTANCE];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const saved: KnownInstance[] = raw ? JSON.parse(raw) : [];
+    // Default first, then saved (deduped by distributionManager).
+    const seen = new Set([
+      DEFAULT_INSTANCE.addresses.distributionManager.toLowerCase(),
+    ]);
+    const merged = [DEFAULT_INSTANCE];
+    for (const inst of saved) {
+      const key = inst.addresses?.distributionManager?.toLowerCase();
+      if (key && !seen.has(key)) {
+        seen.add(key);
+        merged.push(inst);
+      }
+    }
+    return merged;
+  } catch {
+    return [DEFAULT_INSTANCE];
+  }
+}
+
+export function saveKnownInstances(instances: KnownInstance[]): void {
+  if (typeof window === "undefined") return;
+  // Persist everything except the built-in default.
+  const custom = instances.filter(
+    (i) =>
+      i.addresses.distributionManager.toLowerCase() !==
+      DEFAULT_INSTANCE.addresses.distributionManager.toLowerCase(),
+  );
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(custom));
+}
+
+export function loadActiveManager(): Address | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem(ACTIVE_KEY) as Address | null;
+}
+
+export function saveActiveManager(distributionManager: Address): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(ACTIVE_KEY, distributionManager);
+}


### PR DESCRIPTION
Addresses the gap: the dapp now supports the contracts' full functionality, headlined by **deploying a new Crowdstaking instance via the factory** (the white-label premise).

## Contracts
- **CrowdStakeDeployer** — one-transaction full-instance deploy (reuses the live factory + beacons), validated on Gnosis (instance `CSD2` deployed, fully wired, ~2.76M gas). 3 new tests; 300 total pass.

## Frontend
- **/app/deploy** — white-label instance creator (name/symbol/cycle/owner → one tx → switch to it).
- **Multi-instance** — `InstanceProvider` + nav switcher; every hook reads the active instance; add any instance by its distribution-manager address (resolved on-chain).
- **/app/admin** — cycle-length, yield-claimer rotation (14-day timelock), delegation.
- **Recipients** — batch add/remove, clear queues, transfer admin.

## Not surfaced (intentional, noted)
Gasless EIP-712 voting (`castVoteWithSignature`, needs a relayer) and beacon `upgradeTo` (protocol governance) — direct `voteWithData` already covers voting.