### PR TITLE
Multi-chain etherform deploy workflow (L2 stablecoin support)

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -1,41 +1,70 @@
-name: Deploy contracts (Gnosis)
+name: Deploy contracts (multi-chain)
 
-# Manual deploy to Gnosis via etherform's helper scripts (prepare-env.sh +
-# verify-blockscout.sh, sparse-checked-out), with Blockscout verification.
-# Two targets:
-#   - DeployGnosis           → a fresh, fully-wired CrowdStake instance
-#   - DeployCrowdStakeDeployer → the ONE canonical one-tx deployer (+ its own
-#                                factory/beacons). After it runs, set the printed
-#                                address as the NEXT_PUBLIC_DEPLOYER_ADDRESS repo
-#                                variable and redeploy the frontend.
+# Manual deploy via etherform's helper scripts (prepare-env.sh +
+# verify-blockscout.sh, sparse-checked-out), keeping the key in a secret.
 #
-# Requires repo secrets: DEPLOY_PRIVATE_KEY (funded Gnosis key), GNOSIS_RPC_URL.
+# Targets:
+#   - DeployCrowdStakeDeployer → the ONE canonical one-tx deployer (+ its own
+#       factory/beacons) on the chosen chain. After it runs, set the printed
+#       address as the NEXT_PUBLIC_DEPLOYER_<chainId> repo variable and redeploy
+#       the frontend.
+#   - DeployGnosis            → a fresh, fully-wired Gnosis instance (Gnosis only).
+#
+# Chains: gnosis (native xDAI → sDAI) · arbitrum / optimism (stablecoin USDC →
+# Morpho vaults). Per-chain yield config comes from the yield_kind/asset/
+# yield_vault inputs — see contracts/deployments/yield-assets.md.
+#
+# Requires repo secrets: DEPLOY_PRIVATE_KEY (funded on the target chain), and
+# optionally GNOSIS_RPC_URL / ARBITRUM_RPC_URL / OPTIMISM_RPC_URL (else public).
 
 on:
   workflow_dispatch:
     inputs:
+      chain:
+        description: "Target chain"
+        type: choice
+        default: gnosis
+        options:
+          - gnosis
+          - arbitrum
+          - optimism
       target:
         description: "What to deploy"
         type: choice
-        default: DeployGnosis
+        default: DeployCrowdStakeDeployer
         options:
-          - DeployGnosis
           - DeployCrowdStakeDeployer
+          - DeployGnosis
+      yield_kind:
+        description: "Yield token kind (native = SexyDaiYield, stable = StableYield/USDC)"
+        type: choice
+        default: native
+        options:
+          - native
+          - stable
+      asset:
+        description: "Deposit token — wrapped-native for native, stablecoin (USDC) for stable. Blank = Gnosis WXDAI."
+        required: false
+        default: ""
+      yield_vault:
+        description: "ERC-4626 vault (asset() must == asset). Blank = Gnosis sDAI."
+        required: false
+        default: ""
       owner:
         description: "System owner (DeployGnosis only — ignored for the deployer)"
         required: false
       token_name:
-        description: "ERC20 token name"
+        description: "ERC20 token name (DeployGnosis only)"
         default: "Crowdstaking Stake"
       token_symbol:
-        description: "ERC20 token symbol"
+        description: "ERC20 token symbol (DeployGnosis only)"
         default: "CSTAKE"
       cycle_length:
-        description: "Cycle length in blocks (~5s each on Gnosis)"
+        description: "Cycle length in blocks (DeployGnosis only)"
         default: "17280"
       salt:
         description: "CREATE2 salt (change for a fresh instance)"
-        default: "crowdstake.fun-gnosis"
+        default: "crowdstake.fun"
 
 permissions:
   contents: read
@@ -63,38 +92,79 @@ jobs:
         with:
           version: "1.4.4"
 
+      - name: Resolve chain (id + RPC + explorer)
+        id: chain
+        run: |
+          case "${{ inputs.chain }}" in
+            gnosis)
+              ID=100
+              RPC="${{ secrets.GNOSIS_RPC_URL || 'https://rpc.gnosischain.com' }}"
+              BS="https://gnosis.blockscout.com" ;;
+            arbitrum)
+              ID=42161
+              RPC="${{ secrets.ARBITRUM_RPC_URL || 'https://arb1.arbitrum.io/rpc' }}"
+              BS="https://arbitrum.blockscout.com" ;;
+            optimism)
+              ID=10
+              RPC="${{ secrets.OPTIMISM_RPC_URL || 'https://mainnet.optimism.io' }}"
+              BS="https://optimism.blockscout.com" ;;
+          esac
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "rpc=$RPC" >> "$GITHUB_OUTPUT"
+          echo "blockscout=$BS" >> "$GITHUB_OUTPUT"
+
+      - name: Guard — DeployGnosis is Gnosis-only
+        if: inputs.target == 'DeployGnosis' && inputs.chain != 'gnosis'
+        run: |
+          echo "::error::DeployGnosis only supports the gnosis chain. Use DeployCrowdStakeDeployer for L2s."
+          exit 1
+
       - name: Deploy
         id: deploy
         env:
           PRIVATE_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
-          RPC_URL: ${{ secrets.GNOSIS_RPC_URL || 'https://rpc.gnosischain.com' }}
+          RPC_URL: ${{ steps.chain.outputs.rpc }}
           OWNER: ${{ inputs.owner }}
           TOKEN_NAME: ${{ inputs.token_name }}
           TOKEN_SYMBOL: ${{ inputs.token_symbol }}
           CYCLE_LENGTH: ${{ inputs.cycle_length }}
           MAX_VOTING_POINTS: "10000"
           SALT: ${{ inputs.salt }}
+          YIELD_KIND: ${{ inputs.yield_kind }}
+          # DeployGnosis reads WXDAI/SXDAI; the canonical deployer reads ASSET/YIELD_VAULT.
           WXDAI: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d"
           SXDAI: "0xaf204776c7245bF4147c2612BF6e5972Ee483701"
+          CHAIN_ID: ${{ steps.chain.outputs.id }}
+          ASSET_IN: ${{ inputs.asset }}
+          VAULT_IN: ${{ inputs.yield_vault }}
         run: |
           source ../.etherform/scripts/deploy/prepare-env.sh
+          # Only export ASSET/YIELD_VAULT when provided, so the script keeps its
+          # Gnosis defaults otherwise (an empty env var would fail address parse).
+          [ -n "$ASSET_IN" ] && export ASSET="$ASSET_IN"
+          [ -n "$VAULT_IN" ] && export YIELD_VAULT="$VAULT_IN"
           forge script "script/${{ inputs.target }}.s.sol:${{ inputs.target }}" \
             --rpc-url "$RPC_URL" --broadcast --slow -vvvv
           if [ "${{ inputs.target }}" = "DeployCrowdStakeDeployer" ]; then
-            ADDR=$(python3 -c "import json;d=json.load(open('broadcast/DeployCrowdStakeDeployer.s.sol/100/run-latest.json'));print([t['contractAddress'] for t in d['transactions'] if t.get('contractName')=='CrowdStakeDeployer'][0])")
-            echo "### Canonical CrowdStakeDeployer deployed" >> "$GITHUB_STEP_SUMMARY"
-            echo "\`$ADDR\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Set repo variable **NEXT_PUBLIC_DEPLOYER_ADDRESS** to this address, then redeploy the frontend." >> "$GITHUB_STEP_SUMMARY"
+            ADDR=$(python3 -c "import json;d=json.load(open('broadcast/DeployCrowdStakeDeployer.s.sol/${CHAIN_ID}/run-latest.json'));print([t['contractAddress'] for t in d['transactions'] if t.get('contractName')=='CrowdStakeDeployer'][0])")
+            VAR="NEXT_PUBLIC_DEPLOYER_ADDRESS"
+            [ "$CHAIN_ID" != "100" ] && VAR="NEXT_PUBLIC_DEPLOYER_${CHAIN_ID}"
+            {
+              echo "### Canonical CrowdStakeDeployer deployed on ${{ inputs.chain }} (chain $CHAIN_ID)"
+              echo "\`$ADDR\`"
+              echo ""
+              echo "- Yield: **${{ inputs.yield_kind }}** · asset \`${ASSET_IN:-WXDAI (default)}\` · vault \`${VAULT_IN:-sDAI (default)}\`"
+              echo "- Set repo variable **$VAR** to this address, then redeploy the frontend."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Verify on Blockscout
         continue-on-error: true
         env:
-          RPC_URL: ${{ secrets.GNOSIS_RPC_URL || 'https://rpc.gnosischain.com' }}
-          BLOCKSCOUT_URL: "https://gnosis.blockscout.com"
+          RPC_URL: ${{ steps.chain.outputs.rpc }}
+          BLOCKSCOUT_URL: ${{ steps.chain.outputs.blockscout }}
         run: |
-          BROADCAST_FILE=$(ls "broadcast/${{ inputs.target }}.s.sol/100/run-latest.json" 2>/dev/null || true)
+          BROADCAST_FILE=$(ls "broadcast/${{ inputs.target }}.s.sol/${{ steps.chain.outputs.id }}/run-latest.json" 2>/dev/null || true)
           if [ -n "$BROADCAST_FILE" ]; then
             BROADCAST_FILE="$BROADCAST_FILE" bash ../.etherform/scripts/deploy/verify-blockscout.sh || true
           fi
@@ -102,8 +172,8 @@ jobs:
       - name: Upload deployment manifest
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.target }}-deployment
+          name: ${{ inputs.target }}-${{ inputs.chain }}-deployment
           path: |
             contracts/deployments/gnosis.json
-            contracts/broadcast/${{ inputs.target }}.s.sol/100/run-latest.json
+            contracts/broadcast/${{ inputs.target }}.s.sol/${{ steps.chain.outputs.id }}/run-latest.json
           if-no-files-found: warn

--- a/contracts/deployments/yield-assets.md
+++ b/contracts/deployments/yield-assets.md
@@ -22,13 +22,18 @@ All rows **verified on-chain** (`asset()`, `decimals`, appreciating `convertToAs
 | Optimism (10) | **stable** | USDC `0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85` | Gauntlet USDC Prime `0xC30ce6A5758786e0F640cC5f881Dd96e9a1C5C59` | Morpho ~6.65% | ✅ asset()==USDC |
 | Ethereum (1, config-only) | stable | USDC `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` | sUSDS `0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD` or a Morpho/Yearn USDC vault | ~3.6% | re-verify before deploy |
 
-Deploy example (Optimism, stablecoin):
-```
-YIELD_KIND=stable \
-ASSET=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85 \
-YIELD_VAULT=0xC30ce6A5758786e0F640cC5f881Dd96e9a1C5C59 \
-PRIVATE_KEY=… forge script script/DeployCrowdStakeDeployer.s.sol --rpc-url <op-rpc> --broadcast
-```
+**Deploy via the etherform CI workflow** (`Deploy contracts (multi-chain)` →
+Run workflow), so the key stays a repo secret (`DEPLOY_PRIVATE_KEY`, funded on
+the target chain). For Optimism stablecoin, set the inputs:
+- chain: `optimism`
+- target: `DeployCrowdStakeDeployer`
+- yield_kind: `stable`
+- asset: `0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85` (native USDC)
+- yield_vault: `0xC30ce6A5758786e0F640cC5f881Dd96e9a1C5C59` (Gauntlet USDC Prime)
+
+The run summary prints the deployer address + the `NEXT_PUBLIC_DEPLOYER_10` repo
+variable to set. (Locally, the equivalent is `YIELD_KIND=stable ASSET=… YIELD_VAULT=…
+PRIVATE_KEY=… forge script script/DeployCrowdStakeDeployer.s.sol --rpc-url <op> --broadcast`.)
 
 ## Native-ETH alternative (rejected — ~1% yield)
 The safe native-ETH ERC-4626 vaults (Aave Static aTokens, `asset()==WETH`, 18dp,


### PR DESCRIPTION
## Why

`contracts-deploy.yml` (the etherform-assisted deploy workflow) was hardcoded to Gnosis — RPC default, `WXDAI`/`SXDAI` env, chain-id-`100` broadcast path, Gnosis Blockscout. So the new **L2 stablecoin deploys couldn't run through etherform**, and the docs fell back to a raw `forge script` with a plaintext key — exactly the pattern etherform exists to avoid.

## What

The workflow is now multi-chain + yield-kind aware, so Arbitrum/Optimism stablecoin instances deploy through etherform with the key kept as a secret:

- **`chain`** input (gnosis / arbitrum / optimism) → resolves chain id, RPC (`GNOSIS_RPC_URL` / `ARBITRUM_RPC_URL` / `OPTIMISM_RPC_URL` secrets, public fallback), and Blockscout URL.
- **`yield_kind`** (native / stable) + **`asset`** + **`yield_vault`** inputs → passed to `DeployCrowdStakeDeployer` (which selects `SexyDaiYield` vs `StableYield`). Blank asset/vault → the script's Gnosis defaults.
- Correct chain-id broadcast path + per-chain Blockscout verification (continue-on-error).
- Run summary prints the deployer address and the `NEXT_PUBLIC_DEPLOYER_<id>` repo variable to set.
- `DeployGnosis` guarded to gnosis-only.
- `contracts/deployments/yield-assets.md` now points at the workflow (with the exact inputs for the Optimism USDC deploy).

## To actually deploy an L2 (your side)

1. Make sure `DEPLOY_PRIVATE_KEY` is funded on the target chain (and optionally set `ARBITRUM_RPC_URL` / `OPTIMISM_RPC_URL` secrets).
2. Actions → **Deploy contracts (multi-chain)** → Run workflow: chain=`optimism`, yield_kind=`stable`, asset=`<USDC>`, yield_vault=`<Morpho vault>`.
3. Set the printed `NEXT_PUBLIC_DEPLOYER_10` (or `_42161`) repo variable, redeploy the frontend → that chain lights up in the UI.

YAML validated. No app/contract code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)