### PR TITLE
Wire live Arbitrum + Optimism stablecoin deployers into the frontend

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -160,6 +160,9 @@ jobs:
 
       - name: Verify on Blockscout
         continue-on-error: true
+        # Bounded: L2 Blockscout verification can hang the etherform script.
+        # The deploy already succeeded by here — verification is best-effort.
+        timeout-minutes: 5
         env:
           RPC_URL: ${{ steps.chain.outputs.rpc }}
           BLOCKSCOUT_URL: ${{ steps.chain.outputs.blockscout }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -49,6 +49,14 @@ jobs:
           # The canonical CrowdStakeDeployer (admin/democratic registry +
           # instance artwork). See contracts/deployments/gnosis-factory.json.
           NEXT_PUBLIC_DEPLOYER_ADDRESS: ${{ vars.NEXT_PUBLIC_DEPLOYER_ADDRESS }}
+          # Per-chain canonical deployers (unset → that chain is read-only in the
+          # UI). See contracts/deployments/l2-deployers.json.
+          NEXT_PUBLIC_DEPLOYER_42161: ${{ vars.NEXT_PUBLIC_DEPLOYER_42161 }}
+          NEXT_PUBLIC_DEPLOYER_10: ${{ vars.NEXT_PUBLIC_DEPLOYER_10 }}
+          NEXT_PUBLIC_DEPLOYER_1: ${{ vars.NEXT_PUBLIC_DEPLOYER_1 }}
+          NEXT_PUBLIC_RPC_URL_42161: ${{ vars.NEXT_PUBLIC_RPC_URL_42161 }}
+          NEXT_PUBLIC_RPC_URL_10: ${{ vars.NEXT_PUBLIC_RPC_URL_10 }}
+          NEXT_PUBLIC_RPC_URL_1: ${{ vars.NEXT_PUBLIC_RPC_URL_1 }}
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/contracts/deployments/l2-deployers.json
+++ b/contracts/deployments/l2-deployers.json
@@ -1,0 +1,25 @@
+{
+  "note": "Canonical CrowdStakeDeployer + factory per chain (StableYield/USDC on the L2s). Deployed via the 'Deploy contracts (multi-chain)' etherform workflow. Set NEXT_PUBLIC_DEPLOYER_<chainId> repo vars to these.",
+  "chains": {
+    "42161": {
+      "name": "Arbitrum One",
+      "yieldKind": "stable",
+      "deployer": "0x976724aC0d83dC3624920f720b91B1Aa5691E28A",
+      "factory": "0x83C637C270e47d10B48EED0FCb91c5A40cc92F16",
+      "asset": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "assetSymbol": "USDC",
+      "yieldVault": "0x5c0C306Aaa9F877de636f4d5822cA9F2E81563BA",
+      "yieldVaultName": "Steakhouse High-Yield USDC (Morpho)"
+    },
+    "10": {
+      "name": "OP Mainnet",
+      "yieldKind": "stable",
+      "deployer": "0x86054D9d62Fd33FcC30731FCC31A556259810ec2",
+      "factory": "0x3178cf7ba399b48Bb383592B2ddc87D47e478417",
+      "asset": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+      "assetSymbol": "USDC",
+      "yieldVault": "0xC30ce6A5758786e0F640cC5f881Dd96e9a1C5C59",
+      "yieldVaultName": "Gauntlet USDC Prime (Morpho)"
+    }
+  }
+}


### PR DESCRIPTION
Deployed the canonical `CrowdStakeDeployer` (StableYield / USDC → Morpho) to both L2s via the multi-chain etherform workflow and wired them into the live build.

## Deployed (verified on-chain — code present + `FACTORY()` matches)
| Chain | Deployer | Yield vault |
|---|---|---|
| Arbitrum (42161) | `0x976724aC0d83dC3624920f720b91B1Aa5691E28A` | USDC → Steakhouse High-Yield USDC (~4.17%) |
| Optimism (10) | `0x86054D9d62Fd33FcC30731FCC31A556259810ec2` | USDC → Gauntlet USDC Prime (~6.65%) |

Repo variables `NEXT_PUBLIC_DEPLOYER_42161` / `NEXT_PUBLIC_DEPLOYER_10` are already set to these.

## Changes
- **`deploy-frontend.yml`** forwards `NEXT_PUBLIC_DEPLOYER_<id>` + `NEXT_PUBLIC_RPC_URL_<id>` to the build, so the static bundle inlines the L2 deployers and those chains become **deployable in the UI** (they were read-only before).
- **`contracts-deploy.yml`**: bounded the Blockscout verify step (`timeout-minutes: 5`) — it hangs on L2 Blockscout *after* the deploy has already succeeded (that's why the two deploy runs had to be cancelled to finalize).
- **`contracts/deployments/l2-deployers.json`**: recorded the addresses + per-chain yield config.

Merging redeploys Pages with the L2 deployers live, so users can switch their wallet to Arbitrum/Optimism and deploy a USDC stablecoin instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)