### PR TITLE
Animated per-step visuals + over-collateralized lending explainer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,3 +78,163 @@ body {
 .animate-nudge {
   animation: nudge 1.4s ease-in-out infinite;
 }
+
+/* --- "How it Works" step illustrations (looping, purely decorative) ------ */
+
+/* Coins dropping from members into the community pool. */
+@keyframes hiw-coin-drop {
+  0% {
+    opacity: 0;
+    transform: translateY(-14px) scale(0.8);
+  }
+  18% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(30px) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(32px) scale(0.9);
+  }
+}
+.hiw-coin {
+  animation: hiw-coin-drop 2.6s ease-in infinite;
+}
+
+/* The pool level gently rising as deposits land. */
+@keyframes hiw-pool-fill {
+  0%,
+  100% {
+    height: 46%;
+  }
+  50% {
+    height: 72%;
+  }
+}
+.hiw-pool-fill {
+  animation: hiw-pool-fill 3.4s ease-in-out infinite;
+}
+
+/* The yield layer growing on top of an untouched principal. */
+@keyframes hiw-yield-grow {
+  0%,
+  100% {
+    height: 22%;
+  }
+  50% {
+    height: 46%;
+  }
+}
+.hiw-yield-grow {
+  animation: hiw-yield-grow 3s ease-in-out infinite;
+}
+
+/* A badge rising to hint at accruing interest. */
+@keyframes hiw-rise {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-5px);
+  }
+}
+.hiw-rise {
+  animation: hiw-rise 2.4s ease-in-out infinite;
+}
+
+/* Vote-allocation bars tallying up. */
+@keyframes hiw-bar {
+  0% {
+    transform: scaleX(0);
+  }
+  55%,
+  100% {
+    transform: scaleX(1);
+  }
+}
+.hiw-bar {
+  animation: hiw-bar 3.2s ease-in-out infinite;
+}
+
+/* Yield streaming out to funded recipients. */
+@keyframes hiw-flow {
+  0% {
+    opacity: 0;
+    transform: translate(0, -50%);
+  }
+  20% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 1;
+    transform: translate(48px, -50%);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(56px, -50%);
+  }
+}
+.hiw-flow {
+  animation: hiw-flow 1.9s ease-in-out infinite;
+}
+
+/* Recipient tiles lighting up as they receive funds. */
+@keyframes hiw-pulse {
+  0%,
+  100% {
+    opacity: 0.6;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.06);
+  }
+}
+.hiw-pulse {
+  animation: hiw-pulse 1.9s ease-in-out infinite;
+}
+
+/* Collateral / loan columns filling upward (origin set via `origin-bottom`). */
+@keyframes hiw-grow-y {
+  0% {
+    transform: scaleY(0);
+  }
+  55%,
+  100% {
+    transform: scaleY(1);
+  }
+}
+.hiw-grow-y {
+  animation: hiw-grow-y 3s ease-in-out infinite;
+}
+
+/* Collateral value fluctuating with the market — but staying above the loan. */
+@keyframes hiw-dip {
+  0%,
+  100% {
+    height: 82%;
+  }
+  50% {
+    height: 60%;
+  }
+}
+.hiw-dip {
+  animation: hiw-dip 3.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hiw-coin,
+  .hiw-pool-fill,
+  .hiw-yield-grow,
+  .hiw-rise,
+  .hiw-bar,
+  .hiw-flow,
+  .hiw-pulse,
+  .hiw-grow-y,
+  .hiw-dip {
+    animation: none !important;
+  }
+}

--- a/src/components/_home/how-it-works.tsx
+++ b/src/components/_home/how-it-works.tsx
@@ -1,0 +1,265 @@
+import type { ReactNode } from "react";
+import { Body, Heading2, Heading4 } from "@breadcoop/ui";
+import {
+  Buildings,
+  Coins,
+  Confetti,
+  HandCoins,
+  Heart,
+  ShieldCheck,
+  Sliders,
+  TrendUp,
+  User,
+} from "@phosphor-icons/react/dist/ssr";
+import { cn } from "@/lib/utils";
+
+/**
+ * HowItWorks
+ * ----------
+ * The four-beat story of Crowdstaking — pool → earn → vote → fund — with a
+ * bespoke, purely-CSS-animated illustration paired with every step instead of
+ * plain text. The animations loop gently and are disabled automatically under
+ * `prefers-reduced-motion` (see the `.hiw-*` rules in globals.css); each visual
+ * still reads correctly in its resting state.
+ */
+
+type Step = {
+  title: string;
+  body: string;
+  caption: string;
+  Visual: () => ReactNode;
+};
+
+const STEPS: Step[] = [
+  {
+    title: "Community pools assets",
+    body: "Members deposit funds to the shared community pool in your own branded interface.",
+    caption: "Members → community pool",
+    Visual: PoolVisual,
+  },
+  {
+    title: "Automated interest generation",
+    body: "Funds are automatically generating yield through overcollateralized loans.",
+    caption: "Only the yield grows — principal stays whole",
+    Visual: YieldVisual,
+  },
+  {
+    title: "Community decides on funding",
+    body: "Interest is allocated to your community's shared goal.",
+    caption: "Weighted votes split the yield",
+    Visual: VoteVisual,
+  },
+  {
+    title: "Projects get funded",
+    body: "Projects receive funding while members retain their original principal amount.",
+    caption: "Yield → recipients · principal returns 1:1",
+    Visual: FundVisual,
+  },
+];
+
+export function HowItWorks() {
+  return (
+    <section id="how-it-works" className="py-20">
+      <div className="section-container">
+        <Heading2 className="text-text-standard text-center">
+          Fundraising for free: from shared funds to shared futures
+        </Heading2>
+
+        <ol className="mx-auto mt-14 max-w-5xl space-y-12 sm:space-y-16">
+          {STEPS.map((step, i) => {
+            const flip = i % 2 === 1; // alternate the visual left/right on desktop
+            return (
+              <li
+                key={step.title}
+                className="grid items-center gap-6 sm:gap-10 lg:grid-cols-2"
+              >
+                <div className={cn("flex gap-5", flip && "lg:order-2")}>
+                  <span className="bg-core-orange font-breadDisplay flex h-10 w-10 flex-none items-center justify-center rounded-full font-bold text-white">
+                    {i + 1}
+                  </span>
+                  <div>
+                    <Heading4 className="text-text-standard">
+                      {step.title}
+                    </Heading4>
+                    <Body className="text-surface-grey-2 mt-2">{step.body}</Body>
+                  </div>
+                </div>
+
+                <VisualFrame caption={step.caption} className={cn(flip && "lg:order-1")}>
+                  <step.Visual />
+                </VisualFrame>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+/* ------------------------------- Visual frame ----------------------------- */
+
+function VisualFrame({
+  children,
+  caption,
+  className,
+}: {
+  children: ReactNode;
+  caption: string;
+  className?: string;
+}) {
+  return (
+    <figure
+      className={cn(
+        "border-paper-2 from-paper-0 to-paper-1 relative flex h-60 items-center justify-center overflow-hidden rounded-2xl border bg-linear-to-b shadow-sm",
+        className,
+      )}
+    >
+      {children}
+      <figcaption className="text-surface-grey absolute right-4 bottom-3 left-4 truncate text-right text-xs font-medium">
+        {caption}
+      </figcaption>
+    </figure>
+  );
+}
+
+/* ----------------------------- 1 · Pool assets ---------------------------- */
+
+function PoolVisual() {
+  const coins = [
+    { left: "12%", delay: "0s" },
+    { left: "32%", delay: "0.55s" },
+    { left: "50%", delay: "1.1s" },
+    { left: "68%", delay: "1.65s" },
+    { left: "86%", delay: "2.2s" },
+  ];
+  return (
+    <div className="flex w-full max-w-[15rem] flex-col items-center gap-2 px-4 pb-4">
+      <div className="flex justify-center gap-2.5">
+        {[0, 1, 2, 3].map((m) => (
+          <span
+            key={m}
+            className="bg-core-orange/10 flex h-9 w-9 items-center justify-center rounded-full"
+          >
+            <User size={18} weight="bold" className="text-core-orange" />
+          </span>
+        ))}
+      </div>
+
+      <div className="relative h-9 w-full">
+        {coins.map((c, i) => (
+          <span
+            key={i}
+            className="hiw-coin bg-core-orange absolute top-0 h-2.5 w-2.5 rounded-full"
+            style={{ left: c.left, animationDelay: c.delay }}
+          />
+        ))}
+      </div>
+
+      <div className="border-primary-jade/40 relative h-20 w-full overflow-hidden rounded-xl border-2">
+        <div className="hiw-pool-fill bg-primary-jade/25 absolute inset-x-0 bottom-0 h-[60%]" />
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <Coins size={22} weight="duotone" className="text-primary-jade" />
+          <span className="text-primary-jade mt-1 text-xs font-semibold">
+            Community pool
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ---------------------------- 2 · Yield growth ---------------------------- */
+
+function YieldVisual() {
+  return (
+    <div className="flex w-full max-w-[16rem] items-end justify-center gap-4 px-4 pb-6">
+      <div className="border-paper-2 bg-paper-1 relative flex h-40 w-20 flex-col justify-end rounded-xl border-2 p-1.5">
+        <div className="hiw-yield-grow bg-core-orange flex h-[36%] items-center justify-center rounded-md">
+          <TrendUp size={16} weight="bold" className="text-white" />
+        </div>
+        <div className="bg-primary-jade mt-1 flex h-[52%] items-center justify-center rounded-md">
+          <span className="text-[10px] font-bold text-white">Principal</span>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="hiw-rise border-core-orange/30 bg-core-orange/10 text-core-orange inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-bold">
+          <TrendUp size={13} weight="bold" /> + yield
+        </span>
+        <span className="border-primary-jade/30 bg-primary-jade/10 text-primary-jade inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold">
+          <ShieldCheck size={13} weight="bold" /> Over-collateralized
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------- 3 · Voting ------------------------------- */
+
+function VoteVisual() {
+  const rows = [
+    { label: "Recipient A", w: "82%", delay: "0s" },
+    { label: "Recipient B", w: "56%", delay: "0.35s" },
+    { label: "Recipient C", w: "38%", delay: "0.7s" },
+  ];
+  return (
+    <div className="flex w-full max-w-[16rem] flex-col gap-3 px-5 pb-4">
+      <div className="text-surface-grey-2 flex items-center gap-1.5 text-xs font-semibold">
+        <Sliders size={15} weight="bold" className="text-core-orange" />
+        Allocate the yield
+      </div>
+      {rows.map((r) => (
+        <div key={r.label}>
+          <div className="text-surface-grey mb-1 text-[11px] font-medium">
+            {r.label}
+          </div>
+          <div className="bg-paper-1 h-2.5 w-full overflow-hidden rounded-full">
+            <div
+              className="hiw-bar bg-core-orange h-full origin-left rounded-full"
+              style={{ width: r.w, animationDelay: r.delay }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------ 4 · Funding ------------------------------- */
+
+function FundVisual() {
+  const recipients = [Heart, Buildings, Confetti];
+  return (
+    <div className="flex w-full max-w-[17rem] items-center justify-between gap-2 px-4 pb-4">
+      <div className="border-primary-jade/40 bg-primary-jade/5 flex h-16 w-16 flex-none flex-col items-center justify-center rounded-xl border-2">
+        <HandCoins size={20} weight="duotone" className="text-primary-jade" />
+        <span className="text-primary-jade mt-0.5 text-[9px] font-semibold">
+          Yield
+        </span>
+      </div>
+
+      <div className="relative h-8 w-16 flex-none">
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            className="hiw-flow bg-core-orange absolute top-1/2 h-2 w-2 -translate-y-1/2 rounded-full"
+            style={{ animationDelay: `${i * 0.5}s` }}
+          />
+        ))}
+      </div>
+
+      <div className="flex flex-none flex-col gap-2">
+        {recipients.map((Icon, i) => (
+          <span
+            key={i}
+            className="hiw-pulse border-core-orange/30 bg-core-orange/10 flex h-8 w-8 items-center justify-center rounded-lg border"
+            style={{ animationDelay: `${i * 0.5}s` }}
+          >
+            <Icon size={16} weight="bold" className="text-core-orange" />
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/_home/landing-page.tsx
+++ b/src/components/_home/landing-page.tsx
@@ -18,7 +18,9 @@ import {
   Target,
   TrendUp,
 } from "@phosphor-icons/react/dist/ssr";
+import { HowItWorks } from "@/components/_home/how-it-works";
 import { InterestCalculator } from "@/components/_home/interest-calculator";
+import { YieldEngine } from "@/components/_home/yield-engine";
 import { YieldSliceExplainer } from "@/components/_home/yield-slice-explainer";
 
 const DOCS_URL = "/docs"; // in-app documentation & walkthroughs
@@ -35,6 +37,7 @@ export function LandingPage() {
         <UnderTheHood />
         <YieldSliceExplainer />
         <HowItWorks />
+        <YieldEngine />
         <GetStarted />
         <CtaBand />
       </main>
@@ -268,52 +271,6 @@ function UnderTheHood() {
           collateralized xDAI. All interest earned on the sDAI funds their
           shared goal.
         </Body>
-      </div>
-    </section>
-  );
-}
-
-/* ------------------------------ How it Works ----------------------------- */
-
-const STEPS = [
-  {
-    title: "Community pools assets",
-    body: "Members deposit funds to the shared community pool in your own branded interface.",
-  },
-  {
-    title: "Automated interest generation",
-    body: "Funds are automatically generating yield through overcollateralized loans.",
-  },
-  {
-    title: "Community decides on funding",
-    body: "Interest is allocated to your community's shared goal.",
-  },
-  {
-    title: "Projects get funded",
-    body: "Projects receive funding while members retain their original principal amount.",
-  },
-];
-
-function HowItWorks() {
-  return (
-    <section id="how-it-works" className="py-20">
-      <div className="section-container">
-        <Heading2 className="text-text-standard text-center">
-          Fundraising for free: from shared funds to shared futures
-        </Heading2>
-        <ol className="mx-auto mt-12 max-w-2xl space-y-8">
-          {STEPS.map((step, i) => (
-            <li key={step.title} className="flex gap-5">
-              <span className="bg-core-orange font-breadDisplay flex h-10 w-10 flex-none items-center justify-center rounded-full font-bold text-white">
-                {i + 1}
-              </span>
-              <div>
-                <Heading4 className="text-text-standard">{step.title}</Heading4>
-                <Body className="text-surface-grey-2 mt-1">{step.body}</Body>
-              </div>
-            </li>
-          ))}
-        </ol>
       </div>
     </section>
   );

--- a/src/components/_home/yield-engine.tsx
+++ b/src/components/_home/yield-engine.tsx
@@ -1,0 +1,309 @@
+import type { ReactNode } from "react";
+import { Body, Chip, Heading2, Heading4 } from "@breadcoop/ui";
+import {
+  Bank,
+  CurrencyDollar,
+  Lock,
+  Percent,
+  ShieldCheck,
+  TrendUp,
+  User,
+} from "@phosphor-icons/react/dist/ssr";
+import { cn } from "@/lib/utils";
+
+/**
+ * YieldEngine
+ * -----------
+ * A zoom-in on "Automated interest generation" (step 2 of HowItWorks): where
+ * the yield actually comes from. It breaks over-collateralized lending into
+ * five animated beats — lend it out → why borrowers want it → they
+ * over-collateralize → the collateral protects the principal → borrower
+ * interest becomes the yield.
+ *
+ * Kept deliberately protocol-agnostic: no product or venue names, just
+ * "stablecoins"/"dollars" and "an asset", so the mechanism reads on its own.
+ *
+ * Same visual language as HowItWorks: alternating text/visual rows with
+ * purely-CSS `.hiw-*` animations that stop under `prefers-reduced-motion` and
+ * still read correctly at rest.
+ */
+
+type Step = {
+  title: string;
+  body: string;
+  caption: string;
+  Visual: () => ReactNode;
+};
+
+const STEPS: Step[] = [
+  {
+    title: "Your deposit is lent out",
+    body: "The pool's stablecoins don't sit idle. They're lent out to borrowers — your community's dollars become the lending capital that the whole system runs on.",
+    caption: "Pool dollars → lent to borrowers",
+    Visual: LendVisual,
+  },
+  {
+    title: "Why borrowers want the loan",
+    body: "A borrower is betting an asset will rise. Rather than sell it, they lock it up and borrow dollars against it — often to buy even more of it. It's leverage: they hold a bigger position and plan to repay the loan later, keeping the upside if the price climbs.",
+    caption: "Bullish on an asset → borrow dollars against it",
+    Visual: BorrowerVisual,
+  },
+  {
+    title: "They lock up more than they borrow",
+    body: "Nobody borrows on trust. To take a $100 loan, a borrower must first lock roughly $150 of their asset as collateral. The loan is always backed by more value than it lends out — that's over-collateralization.",
+    caption: "$150 locked to borrow $100",
+    Visual: CollateralVisual,
+  },
+  {
+    title: "The collateral protects your principal",
+    body: "That extra collateral is the safety margin. If the asset's price falls, the buffer absorbs the dip; if it ever runs thin, the collateral is automatically sold to repay the loan in full. Losing that collateral is the risk the borrower knowingly takes — and it's exactly what keeps the pool's principal backed 1:1, never at risk.",
+    caption: "Collateral stays above the loan — or it's auto-liquidated",
+    Visual: BufferVisual,
+  },
+  {
+    title: "Borrowers pay interest — that's your yield",
+    body: "For borrowing, they pay interest the whole time the loan is open. That interest flows back into the pool and settles on top of everyone's principal. It's the yield your community distributes — earned without anyone spending their savings.",
+    caption: "Borrower interest → stacks on top as yield",
+    Visual: InterestVisual,
+  },
+];
+
+export function YieldEngine() {
+  return (
+    <section id="yield-engine" className="bg-paper-1 py-20">
+      <div className="section-container">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="flex justify-center">
+            <Chip size="small" className="text-primary-jade">
+              Over-collateralized lending
+            </Chip>
+          </div>
+          <Heading2 className="text-text-standard mt-4">
+            How the interest is actually generated
+          </Heading2>
+          <Body className="text-surface-grey-2 mx-auto mt-4 text-lg">
+            A closer look at step 2. The yield isn&apos;t magic — it&apos;s the
+            interest borrowers pay to take over-collateralized loans against your
+            pool. Here&apos;s the full chain, and why your principal is never at
+            risk.
+          </Body>
+        </div>
+
+        <ol className="mx-auto mt-14 max-w-5xl space-y-12 sm:space-y-16">
+          {STEPS.map((step, i) => {
+            const flip = i % 2 === 1;
+            return (
+              <li
+                key={step.title}
+                className="grid items-center gap-6 sm:gap-10 lg:grid-cols-2"
+              >
+                <div className={cn("flex gap-5", flip && "lg:order-2")}>
+                  <span className="bg-primary-jade font-breadDisplay flex h-10 w-10 flex-none items-center justify-center rounded-full font-bold text-white">
+                    {i + 1}
+                  </span>
+                  <div>
+                    <Heading4 className="text-text-standard">
+                      {step.title}
+                    </Heading4>
+                    <Body className="text-surface-grey-2 mt-2">{step.body}</Body>
+                  </div>
+                </div>
+
+                <VisualFrame
+                  caption={step.caption}
+                  className={cn(flip && "lg:order-1")}
+                >
+                  <step.Visual />
+                </VisualFrame>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+/* ------------------------------- Visual frame ----------------------------- */
+
+function VisualFrame({
+  children,
+  caption,
+  className,
+}: {
+  children: ReactNode;
+  caption: string;
+  className?: string;
+}) {
+  return (
+    <figure
+      className={cn(
+        "border-paper-2 from-paper-0 to-paper-1 relative flex h-60 items-center justify-center overflow-hidden rounded-2xl border bg-linear-to-b shadow-sm",
+        className,
+      )}
+    >
+      {children}
+      <figcaption className="text-surface-grey absolute right-4 bottom-3 left-4 truncate text-right text-xs font-medium">
+        {caption}
+      </figcaption>
+    </figure>
+  );
+}
+
+function FlowDots({ width }: { width: string }) {
+  return (
+    <div className={cn("relative h-8 flex-none", width)}>
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          className="hiw-flow bg-core-orange absolute top-1/2 h-2 w-2 -translate-y-1/2 rounded-full"
+          style={{ animationDelay: `${i * 0.5}s` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/* --------------------------- 1 · Deposit lent out ------------------------- */
+
+function LendVisual() {
+  return (
+    <div className="flex w-full max-w-[18rem] items-center justify-between gap-2 px-4 pb-4">
+      <div className="border-primary-jade/40 bg-primary-jade/5 flex h-20 w-20 flex-none flex-col items-center justify-center rounded-xl border-2 text-center">
+        <Bank size={22} weight="duotone" className="text-primary-jade" />
+        <span className="text-primary-jade mt-1 px-1 text-[10px] leading-tight font-semibold">
+          Stablecoin pool
+        </span>
+      </div>
+
+      <FlowDots width="w-16" />
+
+      <div className="border-paper-2 bg-paper-0 flex h-20 w-20 flex-none flex-col items-center justify-center rounded-xl border-2">
+        <User size={22} weight="bold" className="text-surface-grey-2" />
+        <span className="text-surface-grey-2 mt-1 text-[10px] font-semibold">
+          Borrower
+        </span>
+        <span className="text-core-orange text-[10px] font-bold">
+          borrows $100
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* --------------------------- 2 · Why borrowers borrow --------------------- */
+
+function BorrowerVisual() {
+  return (
+    <div className="flex w-full max-w-[18rem] items-center justify-between gap-2 px-4 pb-4">
+      {/* An asset they believe will rise — kept, not sold. */}
+      <div className="flex flex-none flex-col items-center gap-1.5">
+        <div className="border-primary-jade/40 bg-primary-jade/5 flex h-16 w-16 items-center justify-center rounded-xl border-2">
+          <TrendUp size={22} weight="bold" className="text-primary-jade" />
+        </div>
+        <span className="hiw-rise border-primary-jade/30 bg-primary-jade/10 text-primary-jade inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-bold">
+          <TrendUp size={11} weight="bold" /> expects ↑
+        </span>
+      </div>
+
+      {/* Locked as collateral, dollars flow out. */}
+      <div className="flex flex-none flex-col items-center gap-1.5">
+        <Lock size={15} weight="bold" className="text-surface-grey-2" />
+        <FlowDots width="w-14" />
+      </div>
+
+      {/* Dollars to put to work — leverage. */}
+      <div className="border-core-orange/40 bg-core-orange/5 flex h-16 w-16 flex-none flex-col items-center justify-center rounded-xl border-2">
+        <CurrencyDollar size={22} weight="bold" className="text-core-orange" />
+        <span className="text-core-orange mt-0.5 text-[10px] font-semibold">
+          borrows $
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* --------------------------- 2 · Over-collateralize ----------------------- */
+
+function CollateralVisual() {
+  return (
+    <div className="flex w-full max-w-[16rem] flex-col items-center gap-2.5 px-4 pb-5">
+      <div className="text-primary-jade flex items-center gap-1.5 text-[11px] font-semibold">
+        <Lock size={13} weight="bold" /> Collateral locked · $150
+      </div>
+      <div className="border-primary-jade/50 flex h-36 w-24 flex-col justify-end rounded-xl border-2 p-1.5">
+        <div className="hiw-grow-y bg-primary-jade/25 flex h-[34%] origin-bottom items-center justify-center rounded-md">
+          <span className="text-primary-jade text-[10px] font-bold">
+            +50% buffer
+          </span>
+        </div>
+        <div className="bg-core-orange mt-1 flex h-[57%] items-center justify-center rounded-md">
+          <span className="text-[10px] font-bold text-white">Borrowed $100</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ----------------------------- 3 · Safety buffer -------------------------- */
+
+function BufferVisual() {
+  return (
+    <div className="flex w-full max-w-[17rem] items-center justify-center gap-5 px-4 pb-6">
+      <div className="border-paper-2 bg-paper-0 relative h-40 w-20 flex-none rounded-xl border-2">
+        {/* Collateral value — fluctuates but stays above the loan floor. */}
+        <div className="hiw-dip bg-primary-jade/70 absolute inset-x-1 bottom-1 h-[78%] rounded-lg" />
+        {/* Loan floor. */}
+        <div className="border-core-orange absolute inset-x-0 bottom-[42%] border-t-2 border-dashed" />
+        <ShieldCheck
+          size={20}
+          weight="fill"
+          className="absolute bottom-3 left-1/2 -translate-x-1/2 text-white"
+        />
+      </div>
+
+      <ul className="flex flex-col gap-2.5 text-[11px] font-medium">
+        <li className="text-primary-jade flex items-center gap-1.5">
+          <span className="bg-primary-jade/70 h-2.5 w-2.5 rounded-full" />
+          Collateral value
+        </li>
+        <li className="text-core-orange flex items-center gap-1.5">
+          <span className="border-core-orange w-3 border-t-2 border-dashed" />
+          Loan floor
+        </li>
+        <li className="text-surface-grey-2 flex items-center gap-1.5">
+          <ShieldCheck size={13} weight="bold" className="text-primary-jade" />
+          Auto-liquidates if breached
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+/* --------------------------- 4 · Interest = yield ------------------------- */
+
+function InterestVisual() {
+  return (
+    <div className="flex w-full max-w-[18rem] items-center justify-between gap-2 px-4 pb-4">
+      <div className="flex flex-none flex-col items-center gap-1.5">
+        <div className="border-paper-2 bg-paper-0 flex h-14 w-14 items-center justify-center rounded-xl border-2">
+          <User size={20} weight="bold" className="text-surface-grey-2" />
+        </div>
+        <span className="hiw-rise border-core-orange/30 bg-core-orange/10 text-core-orange inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-bold">
+          <Percent size={11} weight="bold" /> interest
+        </span>
+      </div>
+
+      <FlowDots width="w-14" />
+
+      <div className="border-paper-2 bg-paper-1 relative flex h-36 w-20 flex-none flex-col justify-end rounded-xl border-2 p-1.5">
+        <div className="hiw-yield-grow bg-core-orange flex h-[34%] items-center justify-center rounded-md">
+          <TrendUp size={14} weight="bold" className="text-white" />
+        </div>
+        <div className="bg-primary-jade mt-1 flex h-[52%] items-center justify-center rounded-md">
+          <span className="text-[10px] font-bold text-white">Principal</span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

- Give each landing-page **"How it Works"** step its own on-brand, CSS-animated visualization (members pooling coins, yield growing on principal, vote allocation bars, funding streams) in an alternating two-column layout — replacing the previous text-only list.
- Add a new **"How the interest is actually generated"** section that breaks over-collateralized lending into five animated beats:
  1. Your deposit is lent out
  2. Why borrowers want the loan (leverage on an asset they expect to rise)
  3. They lock up more than they borrow (over-collateralization)
  4. The collateral protects your principal (auto-liquidation is the borrower's risk)
  5. Borrowers pay interest — that's your yield

## Notes

- Kept deliberately protocol-agnostic — "stablecoins" / "dollars" / "an asset", no product or venue names.
- All animations are pure CSS (`.hiw-*` keyframes in globals.css) and disable under `prefers-reduced-motion`; every visual reads correctly at rest.
- Verified: `tsc` clean, `next lint` clean, `next build` + static export succeed.