### PR TITLE
fix(addresses): fetch manifest from CORS-safe `addresses` branch (raw)

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -242,3 +242,25 @@ jobs:
           gh release upload contract-addresses addresses.json --clobber -R "$GITHUB_REPOSITORY"
           gh release edit contract-addresses -R "$GITHUB_REPOSITORY" \
             --notes "Rolling manifest of live contract addresses (last update: $TARGET on chain $CHAIN_ID @ ${GITHUB_SHA::7}, $(date -u +%Y-%m-%dT%H:%MZ)). The static frontend fetches addresses.json from this release at runtime."
+
+      # Mirror the manifest to the `addresses` branch, which the frontend fetches
+      # cross-origin via raw.githubusercontent.com (sends Access-Control-Allow-
+      # Origin: *). The release *asset* download redirects to a host that omits
+      # CORS headers, so a browser on our Pages origin can't fetch it directly.
+      # continue-on-error: a mirror hiccup must never fail the contract deploy
+      # (which already completed above). addresses.json is in ./contracts (the
+      # job's working-directory).
+      - name: Mirror manifest to addresses branch (CORS-fetchable)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 -m json.tool addresses.json >/dev/null
+          content_b64=$(base64 -w0 addresses.json)
+          sha=$(gh api "repos/$GITHUB_REPOSITORY/contents/addresses.json?ref=addresses" --jq .sha 2>/dev/null || true)
+          gh api -X PUT "repos/$GITHUB_REPOSITORY/contents/addresses.json" \
+            -f message="chore(addresses): publish manifest @ ${GITHUB_SHA::7}" \
+            -f content="$content_b64" \
+            -f branch=addresses \
+            ${sha:+-f sha="$sha"}

--- a/src/lib/remote-addresses.ts
+++ b/src/lib/remote-addresses.ts
@@ -15,19 +15,23 @@ import { CHAINS, ENV_PINNED, type InstanceAddresses } from "@/lib/chains";
  *   2. This manifest (latest release)
  *   3. Baked-in fallbacks in chains.ts
  *
- * CORS note: plain `github.com/releases/download/...` URLs don't send CORS
- * headers on the redirect, so browsers can't fetch them. api.github.com sends
- * `access-control-allow-origin: *` on every response (including the asset
- * redirect when requested with `Accept: application/octet-stream`), so we go
- * through the API: release-by-tag → asset → download. Both requests are
- * "simple" (no preflight) and anonymous (60 req/h/IP rate limit — fine for
- * one fetch per page load).
+ * CORS note: fetching the manifest from the GitHub *release asset* fails
+ * in-browser — the asset download 302-redirects to
+ * release-assets.githubusercontent.com, which omits `Access-Control-Allow-
+ * Origin`. So contracts-deploy also mirrors the manifest to the `addresses`
+ * branch, and we fetch it via raw.githubusercontent.com, which DOES send
+ * `access-control-allow-origin: *`. This keeps the no-rebuild property: a
+ * contract redeploy updates the branch and the live app picks it up on the next
+ * page load. `NEXT_PUBLIC_ADDRESSES_URL` still overrides for previews.
  */
 
-const REPO = "BreadchainCoop/crowdstake.fun";
-const RELEASE_TAG = "contract-addresses";
-const ASSET_NAME = "addresses.json";
 const FETCH_TIMEOUT_MS = 5_000;
+
+// CORS-fetchable mirror of the manifest (contracts-deploy pushes here). raw
+// .githubusercontent.com sends `access-control-allow-origin: *`; the GitHub
+// release-asset download does not (it redirects to a host without CORS).
+const MANIFEST_URL =
+  "https://raw.githubusercontent.com/BreadchainCoop/crowdstake.fun/addresses/addresses.json";
 
 /** Per-chain entry in the published manifest (all fields optional). */
 interface ManifestChain {
@@ -69,15 +73,7 @@ async function fetchManifest(): Promise<Manifest> {
   if (override && override.length > 0) {
     return (await fetchJson(override)) as Manifest;
   }
-  const release = (await fetchJson(
-    `https://api.github.com/repos/${REPO}/releases/tags/${RELEASE_TAG}`,
-  )) as { assets?: { name: string; url: string }[] };
-  const asset = release.assets?.find((a) => a.name === ASSET_NAME);
-  if (!asset) throw new Error(`release has no ${ASSET_NAME} asset`);
-  return (await fetchJson(
-    asset.url,
-    "application/octet-stream",
-  )) as Manifest;
+  return (await fetchJson(MANIFEST_URL)) as Manifest;
 }
 
 /** A checksummed address, or null if the input isn't a valid address. */

--- a/src/lib/remote-addresses.ts
+++ b/src/lib/remote-addresses.ts
@@ -66,7 +66,7 @@ function fetchJson(url: string, accept?: string): Promise<unknown> {
   });
 }
 
-/** Fetch the manifest — direct URL override, or via the GitHub API release. */
+/** Fetch the manifest — direct URL override, or the CORS-fetchable `addresses` branch (raw). */
 async function fetchManifest(): Promise<Manifest> {
   // NOTE: must be a static literal for Next to inline it into the bundle.
   const override = process.env.NEXT_PUBLIC_ADDRESSES_URL;


### PR DESCRIPTION
Same fix as [safety-net #99](https://github.com/BreadchainCoop/safety-net/pull/99), applied here (Ron's **Option A**).

## Problem
This static-export Pages app fetched `addresses.json` from the GitHub release **asset**, whose download redirects to `release-assets.githubusercontent.com` — which omits `Access-Control-Allow-Origin`, so the browser blocked it and the app silently fell back to baked-in addresses.

## Fix
- **contracts-deploy.yml**: new resilient (`continue-on-error`) step mirrors `addresses.json` to a dedicated **`addresses` branch** on every deploy (after the existing release publish).
- **`remote-addresses.ts`**: fetches the manifest at runtime from `https://raw.githubusercontent.com/BreadchainCoop/crowdstake.fun/addresses/addresses.json` — raw sends **`access-control-allow-origin: *`** (verified).
- The `addresses` branch is already **seeded** with the current manifest (chains 100 / 42161 / 10) and confirmed live (`200` + CORS `*`).

## Preserved
No-rebuild updates (contract redeploy → branch update → live on next load), baked-in fallback, and the `NEXT_PUBLIC_ADDRESSES_URL` override.

## Risk
Low — frontend read-path + an additive CI step that runs *after* the deploy completes and can't fail it.