### PR TITLE
Cross-chain yield distribution history (serverless client-side indexer)

### DIFF
--- a/src/app/app/history/page.tsx
+++ b/src/app/app/history/page.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useState } from "react";
+import { Body, Button, Caption } from "@breadcoop/ui";
+import { ArrowSquareOut, CaretDown, Globe } from "@phosphor-icons/react";
+import { Card, EmptyState, PageHeader, StatCard } from "@/components/dapp/ui";
+import {
+  useDistributionHistory,
+  type EnrichedRound,
+  type RecipientSummary,
+} from "@/hooks/use-distribution-history";
+import { addressUrl, shortChainName, txUrl } from "@/lib/chains";
+import { formatAmount, shortenAddress } from "@/lib/format";
+import { useInstanceToken } from "@/hooks/use-token";
+
+/** ~decimal number → grouped string (family total across stablecoin chains). */
+function fmtNum(n: number, frac = 2): string {
+  return n.toLocaleString("en-US", { maximumFractionDigits: frac });
+}
+
+function fmtDate(ts: number): string {
+  if (!ts) return "—";
+  return new Date(ts * 1000).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function HistoryPage() {
+  const { history, isLoading, error, loadOlder } = useDistributionHistory();
+  const { symbol: tokenSymbol } = useInstanceToken();
+
+  const hasData = history && history.roundCount > 0;
+
+  return (
+    <div>
+      <PageHeader
+        title={`${tokenSymbol} distribution history`}
+        subtitle="Every yield payout, aggregated across all the chains this community lives on."
+      />
+
+      {isLoading && !history && (
+        <Card>
+          <Body className="text-surface-grey-2">
+            Reading distributions from each chain…
+          </Body>
+        </Card>
+      )}
+
+      {error && !history && (
+        <Card>
+          <Body className="text-system-red">
+            Couldn&apos;t load history: {error}
+          </Body>
+        </Card>
+      )}
+
+      {history && !hasData && !isLoading && (
+        <EmptyState>
+          No yield has been distributed yet. Once a cycle completes and someone
+          runs distribution, it will show up here.
+        </EmptyState>
+      )}
+
+      {hasData && (
+        <>
+          {/* Summary */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <StatCard
+              label="Total distributed"
+              value={`≈ ${fmtNum(history.totalNormalized)}`}
+              sub={
+                history.isFamily
+                  ? `across ${history.chains.length} chains`
+                  : shortChainName(history.chains[0]?.chainId)
+              }
+              accent
+            />
+            <StatCard label="Payout rounds" value={history.roundCount} />
+            <StatCard label="Recipients paid" value={history.recipientCount} />
+            <StatCard
+              label="Chains"
+              value={history.chains.length}
+              sub={history.isFamily ? "one community, many chains" : undefined}
+            />
+          </div>
+
+          {/* Per-chain breakdown */}
+          {history.isFamily && history.chains.length > 1 && (
+            <Card className="mt-6">
+              <Caption className="text-surface-grey-2 flex items-center gap-1.5">
+                <Globe size={14} weight="fill" className="text-core-orange" />
+                By chain
+              </Caption>
+              <ul className="mt-3 space-y-3">
+                {history.chains.map((c) => {
+                  const pct = history.totalNormalized
+                    ? c.normalized / history.totalNormalized
+                    : 0;
+                  return (
+                    <li key={c.chainId}>
+                      <div className="flex items-baseline justify-between text-sm">
+                        <span className="text-text-standard font-medium">
+                          {shortChainName(c.chainId)}
+                        </span>
+                        <span className="text-surface-grey-2">
+                          {formatAmount(c.total, 2, c.decimals)} {c.symbol}
+                          <span className="text-surface-grey ml-2">
+                            {c.rounds} round{c.rounds === 1 ? "" : "s"}
+                          </span>
+                        </span>
+                      </div>
+                      <div className="bg-paper-2 mt-1.5 h-2 w-full overflow-hidden rounded-full">
+                        <div
+                          className="bg-core-orange h-full rounded-full"
+                          style={{ width: `${Math.max(2, pct * 100)}%` }}
+                        />
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Card>
+          )}
+
+          {/* Recipient leaderboard */}
+          <Card className="mt-6">
+            <Caption className="text-surface-grey-2">
+              Recipients (all-time)
+            </Caption>
+            <ul className="mt-3 space-y-3">
+              {history.recipients.slice(0, 12).map((r) => (
+                <RecipientRow
+                  key={r.recipient}
+                  r={r}
+                  isFamily={history.isFamily}
+                />
+              ))}
+            </ul>
+          </Card>
+
+          {/* Timeline */}
+          <Caption className="text-surface-grey-2 mt-8 mb-3 block">
+            Payout timeline
+          </Caption>
+          <div className="space-y-2">
+            {history.rounds.map((round) => (
+              <RoundRow
+                key={`${round.chainId}-${round.txHash}`}
+                round={round}
+              />
+            ))}
+          </div>
+
+          <div className="mt-6 flex items-center gap-3">
+            <Button
+              app="fund"
+              variant="secondary"
+              isLoading={isLoading}
+              onClick={() => loadOlder()}
+            >
+              Load older history
+            </Button>
+            <Caption className="text-surface-grey">
+              History is read live from each chain — older payouts may take a
+              moment to load.
+            </Caption>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function RecipientRow({
+  r,
+  isFamily,
+}: {
+  r: RecipientSummary;
+  isFamily: boolean;
+}) {
+  return (
+    <li className="flex items-start justify-between gap-3">
+      <a
+        href={addressUrl(r.recipient, r.perChain[0]?.chainId)}
+        target="_blank"
+        rel="noreferrer"
+        className="text-text-standard hover:text-core-orange font-mono text-sm"
+      >
+        {shortenAddress(r.recipient)}
+      </a>
+      <div className="text-right">
+        <span className="text-text-standard text-sm font-semibold">
+          ≈ {fmtNum(r.normalized)}
+        </span>
+        {isFamily && r.perChain.length > 0 && (
+          <div className="text-surface-grey mt-0.5 text-xs">
+            {r.perChain
+              .map(
+                (pc) =>
+                  `${formatAmount(pc.amount, 2, pc.decimals)} ${pc.symbol} on ${shortChainName(
+                    pc.chainId,
+                  )}`,
+              )
+              .join(" · ")}
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function RoundRow({ round }: { round: EnrichedRound }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Card className="!p-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between gap-3 px-5 py-3.5 text-left"
+      >
+        <div className="min-w-0">
+          <div className="text-text-standard text-sm font-semibold">
+            {formatAmount(round.total, 2, round.decimals)} {round.symbol}
+          </div>
+          <div className="text-surface-grey text-xs">
+            {fmtDate(round.timestamp)} · {shortChainName(round.chainId)} ·{" "}
+            {round.recipients.length} recipient
+            {round.recipients.length === 1 ? "" : "s"}
+          </div>
+        </div>
+        <CaretDown
+          size={16}
+          className={`text-surface-grey transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      {open && (
+        <div className="border-paper-2 border-t px-5 py-3">
+          <ul className="space-y-1.5">
+            {round.recipients.map((x) => (
+              <li
+                key={x.recipient}
+                className="flex items-center justify-between text-sm"
+              >
+                <a
+                  href={addressUrl(x.recipient, round.chainId)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-surface-grey-2 hover:text-core-orange font-mono text-xs"
+                >
+                  {shortenAddress(x.recipient)}
+                </a>
+                <span className="text-text-standard">
+                  {formatAmount(x.amount, 4, round.decimals)} {round.symbol}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <a
+            href={txUrl(round.txHash, round.chainId)}
+            target="_blank"
+            rel="noreferrer"
+            className="text-core-orange mt-3 inline-flex items-center gap-1 text-xs font-semibold hover:underline"
+          >
+            View transaction <ArrowSquareOut size={12} />
+          </a>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/app/app/history/page.tsx
+++ b/src/app/app/history/page.tsx
@@ -2,7 +2,12 @@
 
 import { useState } from "react";
 import { Body, Button, Caption } from "@breadcoop/ui";
-import { ArrowSquareOut, CaretDown, Globe } from "@phosphor-icons/react";
+import {
+  ArrowSquareOut,
+  CaretDown,
+  Globe,
+  Warning,
+} from "@phosphor-icons/react";
 import { Card, EmptyState, PageHeader, StatCard } from "@/components/dapp/ui";
 import {
   useDistributionHistory,
@@ -56,12 +61,29 @@ export default function HistoryPage() {
         </Card>
       )}
 
-      {history && !hasData && !isLoading && (
-        <EmptyState>
-          No yield has been distributed yet. Once a cycle completes and someone
-          runs distribution, it will show up here.
-        </EmptyState>
+      {/* Partial data: one or more chains couldn't be read, so totals undercount. */}
+      {history && history.failedChains.length > 0 && (
+        <Card className="border-system-warning/40 bg-system-warning/5 mb-6">
+          <Caption className="text-system-warning flex items-center gap-1.5">
+            <Warning size={14} weight="fill" />
+            Partial history — couldn&apos;t read{" "}
+            {history.failedChains.map((c) => shortChainName(c)).join(", ")}.
+            Totals below exclude{" "}
+            {history.failedChains.length === 1 ? "it" : "them"}; try again
+            shortly.
+          </Caption>
+        </Card>
       )}
+
+      {history &&
+        !hasData &&
+        !isLoading &&
+        history.failedChains.length === 0 && (
+          <EmptyState>
+            No yield has been distributed yet. Once a cycle completes and
+            someone runs distribution, it will show up here.
+          </EmptyState>
+        )}
 
       {hasData && (
         <>
@@ -213,11 +235,14 @@ function RecipientRow({
 
 function RoundRow({ round }: { round: EnrichedRound }) {
   const [open, setOpen] = useState(false);
+  const panelId = `round-${round.chainId}-${round.txHash}`;
   return (
     <Card className="!p-0">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={panelId}
         className="flex w-full items-center justify-between gap-3 px-5 py-3.5 text-left"
       >
         <div className="min-w-0">
@@ -236,7 +261,7 @@ function RoundRow({ round }: { round: EnrichedRound }) {
         />
       </button>
       {open && (
-        <div className="border-paper-2 border-t px-5 py-3">
+        <div id={panelId} className="border-paper-2 border-t px-5 py-3">
           <ul className="space-y-1.5">
             {round.recipients.map((x) => (
               <li

--- a/src/app/app/vote/_components/family-explainer.tsx
+++ b/src/app/app/vote/_components/family-explainer.tsx
@@ -1,17 +1,100 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { X, Globe } from "@phosphor-icons/react";
+import { useEffect, useState, type ReactNode } from "react";
+import {
+  X,
+  Globe,
+  Scales,
+  ArrowsClockwise,
+  ShieldCheck,
+  ArrowLeft,
+  ArrowRight,
+} from "@phosphor-icons/react";
 import { Body, Caption } from "@breadcoop/ui";
 
-const DISMISS_KEY = "crowdstake.familyVoteExplainer.dismissed.v1";
+// Bumped to v2 so the richer, multi-slide explainer surfaces once more even for
+// voters who dismissed the old single-paragraph primer.
+const DISMISS_KEY = "crowdstake.familyVoteExplainer.dismissed.v2";
+
+interface Slide {
+  icon: ReactNode;
+  title: string;
+  body: ReactNode;
+}
+
+const SLIDES: Slide[] = [
+  {
+    icon: <Globe size={16} weight="fill" className="text-core-orange" />,
+    title: "One vote, every chain",
+    body: (
+      <>
+        This community lives on several chains at once. You sign a{" "}
+        <strong>single ballot</strong> and it counts on all of them — no
+        switching networks, no repeating yourself. Anyone can deliver your
+        signed vote, so it still lands on chains where you hold no gas.
+      </>
+    ),
+  },
+  {
+    icon: <Scales size={16} weight="fill" className="text-core-orange" />,
+    title: "Same ballot, weighted by your stake on each chain",
+    body: (
+      <>
+        Your allocation — the points you give each recipient — is{" "}
+        <strong>identical</strong> on every chain. What changes is how much it
+        counts: on each chain your ballot carries{" "}
+        <strong>your voting power there</strong>, i.e. your stake on that chain.
+        Big stake on Base and none on Gnosis? The same picks push hard on Base
+        and are simply skipped on Gnosis. Because each chain tallies its own
+        stakers, the <strong>outcome can differ per chain</strong> — that&apos;s
+        by design, not a bug.
+      </>
+    ),
+  },
+  {
+    icon: (
+      <ArrowsClockwise size={16} weight="fill" className="text-core-orange" />
+    ),
+    title: "How the recipients stay in sync",
+    body: (
+      <>
+        Your points line up with recipients by <strong>identity</strong>, not
+        position — so recipient #2 on Base is the same address as recipient #2
+        on Gnosis. That only holds if every chain agrees on the recipient list,
+        so the roster itself is governed the same sign-once way: add/remove
+        proposals are replayed on each chain and take effect independently. If a
+        chain&apos;s list has <strong>drifted</strong> out of sync, we flag it
+        and hold your vote there until an admin re-syncs it — the other chains
+        still land.
+      </>
+    ),
+  },
+  {
+    icon: <ShieldCheck size={16} weight="fill" className="text-core-orange" />,
+    title: "This is not a bridge",
+    body: (
+      <>
+        Nothing crosses chains — no tokens moved, no bridge messages, no wrapped
+        assets, none of the bridge hack surface. Your <strong>signature</strong>{" "}
+        is what travels: each chain independently verifies it and records the
+        vote <strong>locally</strong>, using the stake you already hold there. A
+        bridge would move value between chains and take on that risk; here your
+        stake stays put and simply votes in place on every chain it already
+        lives on.
+      </>
+    ),
+  },
+];
 
 /**
- * First-family-vote primer: sign once, land everywhere, weighted per chain.
- * Dismissed permanently via localStorage so it never nags a returning voter.
+ * First-family-vote primer, as a short slideshow: sign once and land
+ * everywhere, why the same ballot weighs differently per chain, how the
+ * recipient roster stays in sync, and how this differs from a bridge. Dismissed
+ * permanently via localStorage so it never nags a returning voter.
  */
 export function FamilyExplainer() {
   const [show, setShow] = useState(false);
+  const [i, setI] = useState(0);
   useEffect(() => {
     try {
       setShow(window.localStorage.getItem(DISMISS_KEY) !== "1");
@@ -31,6 +114,10 @@ export function FamilyExplainer() {
     setShow(false);
   };
 
+  const last = SLIDES.length - 1;
+  const slide = SLIDES[i];
+  const atEnd = i === last;
+
   return (
     <div className="border-core-orange/30 bg-core-orange/5 relative mb-6 rounded-xl border p-4">
       <button
@@ -41,16 +128,61 @@ export function FamilyExplainer() {
       >
         <X size={16} weight="bold" />
       </button>
-      <Caption className="text-text-standard flex items-center gap-1.5 font-semibold">
-        <Globe size={16} weight="fill" className="text-core-orange" />
-        One vote, every chain
+
+      <Caption className="text-text-standard flex items-center gap-1.5 pr-6 font-semibold">
+        {slide.icon}
+        {slide.title}
       </Caption>
-      <Body className="text-surface-grey-2 mt-1.5 text-sm">
-        This is a multi-chain community. You sign a single ballot and it counts
-        on every chain — the same ballot, weighted by your stake on each chain.
-        Anyone can deliver your signed vote, so it lands even if you have no gas
-        on some chains.
-      </Body>
+      <Body className="text-surface-grey-2 mt-1.5 text-sm">{slide.body}</Body>
+
+      <div className="mt-3 flex items-center justify-between">
+        {/* Progress dots — click to jump. */}
+        <div className="flex items-center gap-1.5">
+          {SLIDES.map((_, idx) => (
+            <button
+              key={idx}
+              type="button"
+              aria-label={`Go to slide ${idx + 1}`}
+              aria-current={idx === i}
+              onClick={() => setI(idx)}
+              className={`h-1.5 rounded-full transition-all ${
+                idx === i
+                  ? "bg-core-orange w-4"
+                  : "bg-core-orange/30 hover:bg-core-orange/50 w-1.5"
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="flex items-center gap-3">
+          {i > 0 && (
+            <button
+              type="button"
+              onClick={() => setI((n) => Math.max(0, n - 1))}
+              className="text-surface-grey hover:text-text-standard inline-flex items-center gap-1 text-sm font-semibold"
+            >
+              <ArrowLeft size={14} weight="bold" /> Back
+            </button>
+          )}
+          {atEnd ? (
+            <button
+              type="button"
+              onClick={dismiss}
+              className="text-core-orange inline-flex items-center gap-1 text-sm font-semibold hover:underline"
+            >
+              Got it
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setI((n) => Math.min(last, n + 1))}
+              className="text-core-orange inline-flex items-center gap-1 text-sm font-semibold hover:underline"
+            >
+              Next <ArrowRight size={14} weight="bold" />
+            </button>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/dapp/dapp-nav.tsx
+++ b/src/components/dapp/dapp-nav.tsx
@@ -33,6 +33,7 @@ const LINKS = [
   { href: "/app/withdraw", label: "Withdraw" },
   { href: "/app/vote", label: "Vote" },
   { href: "/app/distribute", label: "Distribute" },
+  { href: "/app/history", label: "History" },
   { href: "/app/deploy", label: "Deploy" },
 ];
 

--- a/src/hooks/use-distribution-history.ts
+++ b/src/hooks/use-distribution-history.ts
@@ -1,0 +1,263 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Address } from "viem";
+import { tokenAbi } from "@/lib/abis";
+import { useActiveChainId, useInstance } from "@/components/instance-provider";
+import { publicClientFor } from "@/lib/instance";
+import { chainConfig } from "@/lib/chains";
+import {
+  loadChainDistributions,
+  toDecimal,
+  type DistributionRound,
+  type DistributionTarget,
+} from "@/lib/distribution-history";
+import { useFamily } from "@/hooks/use-family";
+
+/** Yield-token display metadata for one chain. */
+interface TokenMeta {
+  symbol: string;
+  decimals: number;
+}
+
+/** One distribution round enriched with its chain's token display metadata. */
+export interface EnrichedRound extends DistributionRound {
+  symbol: string;
+  decimals: number;
+}
+
+export interface ChainSummary {
+  chainId: number;
+  symbol: string;
+  decimals: number;
+  /** Total distributed on this chain (base units). */
+  total: bigint;
+  /** Same, normalized to a decimal number (for cross-chain comparison). */
+  normalized: number;
+  rounds: number;
+}
+
+export interface RecipientSummary {
+  recipient: Address;
+  /** Total received across all chains, normalized to a decimal number. */
+  normalized: number;
+  perChain: {
+    chainId: number;
+    amount: bigint;
+    decimals: number;
+    symbol: string;
+  }[];
+}
+
+export interface DistributionHistory {
+  /** Every distribution round across all chains, newest first. */
+  rounds: EnrichedRound[];
+  /** Per-chain totals. */
+  chains: ChainSummary[];
+  /** Per-recipient totals across chains, highest first. */
+  recipients: RecipientSummary[];
+  /** Family-wide total, normalized (stable-value ~$; each chain's stablecoin). */
+  totalNormalized: number;
+  roundCount: number;
+  recipientCount: number;
+  isFamily: boolean;
+}
+
+async function readTokenMeta(
+  chainId: number,
+  token: Address,
+): Promise<TokenMeta> {
+  const client = publicClientFor(chainId);
+  try {
+    const [decimals, symbol] = await Promise.all([
+      client.readContract({
+        address: token,
+        abi: tokenAbi,
+        functionName: "decimals",
+      }),
+      client.readContract({
+        address: token,
+        abi: tokenAbi,
+        functionName: "symbol",
+      }),
+    ]);
+    return { decimals: Number(decimals), symbol: String(symbol) };
+  } catch {
+    const cfg = chainConfig(chainId);
+    return { decimals: 18, symbol: cfg.wrappedSymbol };
+  }
+}
+
+function aggregate(
+  rounds: DistributionRound[],
+  meta: Map<number, TokenMeta>,
+  isFamily: boolean,
+): DistributionHistory {
+  const metaFor = (chainId: number): TokenMeta =>
+    meta.get(chainId) ?? { decimals: 18, symbol: "" };
+
+  const enriched: EnrichedRound[] = rounds
+    .map((r) => ({ ...r, ...metaFor(r.chainId) }))
+    .sort((a, b) => b.timestamp - a.timestamp);
+
+  // Per chain.
+  const chainMap = new Map<number, ChainSummary>();
+  for (const r of enriched) {
+    const s =
+      chainMap.get(r.chainId) ??
+      ({
+        chainId: r.chainId,
+        symbol: r.symbol,
+        decimals: r.decimals,
+        total: 0n,
+        normalized: 0,
+        rounds: 0,
+      } satisfies ChainSummary);
+    s.total += r.total;
+    s.normalized += toDecimal(r.total, r.decimals);
+    s.rounds += 1;
+    chainMap.set(r.chainId, s);
+  }
+
+  // Per recipient (aggregated across chains).
+  const recMap = new Map<string, RecipientSummary>();
+  for (const r of enriched) {
+    for (const { recipient, amount } of r.recipients) {
+      const key = recipient.toLowerCase();
+      const rec =
+        recMap.get(key) ??
+        ({ recipient, normalized: 0, perChain: [] } satisfies RecipientSummary);
+      rec.normalized += toDecimal(amount, r.decimals);
+      const pc = rec.perChain.find((x) => x.chainId === r.chainId);
+      if (pc) pc.amount += amount;
+      else
+        rec.perChain.push({
+          chainId: r.chainId,
+          amount,
+          decimals: r.decimals,
+          symbol: r.symbol,
+        });
+      recMap.set(key, rec);
+    }
+  }
+
+  const chains = [...chainMap.values()].sort(
+    (a, b) => b.normalized - a.normalized,
+  );
+  const recipients = [...recMap.values()].sort(
+    (a, b) => b.normalized - a.normalized,
+  );
+
+  return {
+    rounds: enriched,
+    chains,
+    recipients,
+    totalNormalized: chains.reduce((s, c) => s + c.normalized, 0),
+    roundCount: enriched.length,
+    recipientCount: recipients.length,
+    isFamily,
+  };
+}
+
+/**
+ * Cross-chain yield-distribution history for the active instance (or its whole
+ * family). Reads `Distributed` events from every chain's strategy client-side
+ * (no server), then aggregates per chain and per recipient. `loadOlder` extends
+ * the scanned window further into the past.
+ */
+export function useDistributionHistory() {
+  const family = useFamily();
+  const instance = useInstance();
+  const activeChainId = useActiveChainId();
+
+  const [history, setHistory] = useState<DistributionHistory | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [seq, setSeq] = useState(0);
+  const olderRef = useRef(0n);
+
+  // The chains + strategies to index: family siblings, or the active instance.
+  const targets: DistributionTarget[] = useMemo(() => {
+    if (family.isFamily) {
+      return family.perChain
+        .filter((c) => c.status === "found" && c.instance)
+        .map((c) => ({
+          chainId: c.chainId,
+          strategy: c.instance!.distributionStrategy,
+        }));
+    }
+    return [
+      { chainId: activeChainId, strategy: instance.distributionStrategy },
+    ];
+  }, [
+    family.isFamily,
+    family.perChain,
+    activeChainId,
+    instance.distributionStrategy,
+  ]);
+
+  // Token addresses per chain (for decimals/symbol).
+  const tokens = useMemo(() => {
+    const m = new Map<number, Address>();
+    if (family.isFamily) {
+      for (const c of family.perChain)
+        if (c.status === "found" && c.instance)
+          m.set(c.chainId, c.instance.token);
+    } else {
+      m.set(activeChainId, instance.token);
+    }
+    return m;
+  }, [family.isFamily, family.perChain, activeChainId, instance.token]);
+
+  const targetKey = targets.map((t) => `${t.chainId}:${t.strategy}`).join("|");
+
+  useEffect(() => {
+    if (family.isLoading || targets.length === 0) return;
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const older = olderRef.current;
+        const [allRounds, metaEntries] = await Promise.all([
+          Promise.all(
+            targets.map((t) =>
+              loadChainDistributions(t, {
+                initialLookback: 200_000n,
+                maxRange: 9_000n,
+                ...(older > 0n ? { olderBlocks: older } : {}),
+              }).catch(() => [] as DistributionRound[]),
+            ),
+          ),
+          Promise.all(
+            [...tokens.entries()].map(async ([chainId, token]) => {
+              const meta = await readTokenMeta(chainId, token);
+              return [chainId, meta] as const;
+            }),
+          ),
+        ]);
+        if (cancelled) return;
+        const meta = new Map<number, TokenMeta>(metaEntries);
+        setHistory(aggregate(allRounds.flat(), meta, family.isFamily));
+      } catch (e) {
+        if (!cancelled)
+          setError(e instanceof Error ? e.message : "Failed to load history");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetKey, family.isLoading, seq]);
+
+  const refetch = useCallback(() => setSeq((s) => s + 1), []);
+  /** Extend the scanned window ~`blocks` further back and reload. */
+  const loadOlder = useCallback((blocks = 400_000n) => {
+    olderRef.current = blocks;
+    setSeq((s) => s + 1);
+  }, []);
+
+  return { history, isLoading, error, refetch, loadOlder };
+}

--- a/src/hooks/use-distribution-history.ts
+++ b/src/hooks/use-distribution-history.ts
@@ -61,6 +61,8 @@ export interface DistributionHistory {
   roundCount: number;
   recipientCount: number;
   isFamily: boolean;
+  /** Chains whose scan errored — their history is missing, so totals are partial. */
+  failedChains: number[];
 }
 
 async function readTokenMeta(
@@ -92,6 +94,7 @@ function aggregate(
   rounds: DistributionRound[],
   meta: Map<number, TokenMeta>,
   isFamily: boolean,
+  failedChains: number[],
 ): DistributionHistory {
   const metaFor = (chainId: number): TokenMeta =>
     meta.get(chainId) ?? { decimals: 18, symbol: "" };
@@ -156,6 +159,7 @@ function aggregate(
     roundCount: enriched.length,
     recipientCount: recipients.length,
     isFamily,
+    failedChains,
   };
 }
 
@@ -211,6 +215,12 @@ export function useDistributionHistory() {
 
   const targetKey = targets.map((t) => `${t.chainId}:${t.strategy}`).join("|");
 
+  // A "load older" request is scoped to the current target set — reset it when
+  // the instance/family changes so we don't kick off an oversized scan.
+  useEffect(() => {
+    olderRef.current = 0n;
+  }, [targetKey]);
+
   useEffect(() => {
     if (family.isLoading || targets.length === 0) return;
     let cancelled = false;
@@ -219,14 +229,16 @@ export function useDistributionHistory() {
     void (async () => {
       try {
         const older = olderRef.current;
-        const [allRounds, metaEntries] = await Promise.all([
-          Promise.all(
+        // Per-chain: allSettled so one chain's RPC error surfaces as a partial
+        // warning instead of silently undercounting the aggregated totals.
+        const [settled, metaEntries] = await Promise.all([
+          Promise.allSettled(
             targets.map((t) =>
               loadChainDistributions(t, {
                 initialLookback: 200_000n,
                 maxRange: 9_000n,
                 ...(older > 0n ? { olderBlocks: older } : {}),
-              }).catch(() => [] as DistributionRound[]),
+              }),
             ),
           ),
           Promise.all(
@@ -237,8 +249,20 @@ export function useDistributionHistory() {
           ),
         ]);
         if (cancelled) return;
+        const rounds: DistributionRound[] = [];
+        const failedChains: number[] = [];
+        settled.forEach((res, i) => {
+          if (res.status === "fulfilled") rounds.push(...res.value);
+          else failedChains.push(targets[i].chainId);
+        });
+        // Every target failed → treat it as a hard error, not a partial view.
+        if (failedChains.length === targets.length) {
+          setError("Couldn't reach any chain to read distribution history.");
+          setIsLoading(false);
+          return;
+        }
         const meta = new Map<number, TokenMeta>(metaEntries);
-        setHistory(aggregate(allRounds.flat(), meta, family.isFamily));
+        setHistory(aggregate(rounds, meta, family.isFamily, failedChains));
       } catch (e) {
         if (!cancelled)
           setError(e instanceof Error ? e.message : "Failed to load history");

--- a/src/lib/distribution-history.ts
+++ b/src/lib/distribution-history.ts
@@ -1,0 +1,305 @@
+import {
+  formatUnits,
+  parseAbiItem,
+  type Address,
+  type Hex,
+  type Log,
+} from "viem";
+import { publicClientFor } from "@/lib/instance";
+
+/**
+ * Client-side, serverless cross-chain indexer for yield distributions.
+ *
+ * Every distribution strategy emits `Distributed(recipient, amount)` once per
+ * recipient each time yield is paid out, in the same tx as one
+ * `DistributionExecuted`. We read those logs from each family chain's strategy
+ * over a bounded block window, group them by transaction into distribution
+ * "rounds", and aggregate across chains — so a family (e.g. RonCoin) gets one
+ * history summarising how yield was distributed on every chain.
+ *
+ * No server: reads go straight to each chain's RPC via viem `getLogs`, chunked
+ * (bisecting on range-limit errors) and cached incrementally in localStorage.
+ */
+
+export const DISTRIBUTED_EVENT = parseAbiItem(
+  "event Distributed(address indexed recipient, uint256 amount)",
+);
+
+export interface RecipientAmount {
+  recipient: Address;
+  amount: bigint;
+}
+
+/** One distribution payout on one chain (all recipients paid in a single tx). */
+export interface DistributionRound {
+  chainId: number;
+  txHash: Hex;
+  blockNumber: bigint;
+  /** Unix seconds. */
+  timestamp: number;
+  /** Sum over recipients (yield-token base units on this chain). */
+  total: bigint;
+  recipients: RecipientAmount[];
+}
+
+/** A chain + the strategy contract whose `Distributed` events we index. */
+export interface DistributionTarget {
+  chainId: number;
+  strategy: Address;
+}
+
+type DistLog = Log<bigint, number, false, typeof DISTRIBUTED_EVENT, true>;
+
+/** Split [from, to] into ≤maxRange windows. */
+function windows(
+  from: bigint,
+  to: bigint,
+  maxRange: bigint,
+): [bigint, bigint][] {
+  const out: [bigint, bigint][] = [];
+  for (let lo = from; lo <= to; lo += maxRange) {
+    const hi = lo + maxRange - 1n;
+    out.push([lo, hi > to ? to : hi]);
+  }
+  return out;
+}
+
+/**
+ * Fetch `Distributed` logs for one strategy over [fromBlock, toBlock], chunked
+ * by `maxRange` and bisecting any window the RPC rejects (range too large).
+ */
+async function fetchDistributedLogs(
+  chainId: number,
+  strategy: Address,
+  fromBlock: bigint,
+  toBlock: bigint,
+  maxRange: bigint,
+): Promise<DistLog[]> {
+  const client = publicClientFor(chainId);
+  const stack = windows(fromBlock, toBlock, maxRange).reverse();
+  const logs: DistLog[] = [];
+  while (stack.length > 0) {
+    const [lo, hi] = stack.pop()!;
+    if (lo > hi) continue;
+    try {
+      const got = await client.getLogs({
+        address: strategy,
+        event: DISTRIBUTED_EVENT,
+        fromBlock: lo,
+        toBlock: hi,
+      });
+      logs.push(...(got as DistLog[]));
+    } catch {
+      // Range too large / rate limited → split and retry, unless single block.
+      if (hi > lo) {
+        const mid = lo + (hi - lo) / 2n;
+        stack.push([mid + 1n, hi], [lo, mid]);
+      }
+      // A single block that still fails is dropped (next refresh retries).
+    }
+  }
+  return logs;
+}
+
+/** Group per-recipient logs into rounds (one per tx) and attach timestamps. */
+async function logsToRounds(
+  chainId: number,
+  logs: DistLog[],
+): Promise<DistributionRound[]> {
+  const byTx = new Map<Hex, DistLog[]>();
+  for (const log of logs) {
+    const list = byTx.get(log.transactionHash) ?? [];
+    list.push(log);
+    byTx.set(log.transactionHash, list);
+  }
+  // Fetch each unique block's timestamp once.
+  const client = publicClientFor(chainId);
+  const blocks = new Map<bigint, number>();
+  await Promise.all(
+    [...new Set(logs.map((l) => l.blockNumber))].map(async (bn) => {
+      try {
+        const block = await client.getBlock({ blockNumber: bn });
+        blocks.set(bn, Number(block.timestamp));
+      } catch {
+        blocks.set(bn, 0);
+      }
+    }),
+  );
+  const rounds: DistributionRound[] = [];
+  for (const [txHash, list] of byTx) {
+    const blockNumber = list[0].blockNumber;
+    const recipients = list.map((l) => ({
+      recipient: l.args.recipient as Address,
+      amount: l.args.amount as bigint,
+    }));
+    rounds.push({
+      chainId,
+      txHash,
+      blockNumber,
+      timestamp: blocks.get(blockNumber) ?? 0,
+      total: recipients.reduce((s, r) => s + r.amount, 0n),
+      recipients,
+    });
+  }
+  return rounds;
+}
+
+/* --------------------------- localStorage cache ---------------------------- */
+
+interface CacheEntry {
+  /** Lowest block scanned so far (inclusive). */
+  fromBlock: string;
+  /** Highest block scanned so far (inclusive). */
+  toBlock: string;
+  rounds: SerializedRound[];
+}
+interface SerializedRound {
+  chainId: number;
+  txHash: Hex;
+  blockNumber: string;
+  timestamp: number;
+  recipients: { recipient: Address; amount: string }[];
+}
+
+const cacheKey = (chainId: number, strategy: Address) =>
+  `crowdstake.dist-history.v1:${chainId}:${strategy.toLowerCase()}`;
+
+function readCache(chainId: number, strategy: Address): CacheEntry | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(cacheKey(chainId, strategy));
+    return raw ? (JSON.parse(raw) as CacheEntry) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(
+  chainId: number,
+  strategy: Address,
+  from: bigint,
+  to: bigint,
+  rounds: DistributionRound[],
+): void {
+  if (typeof window === "undefined") return;
+  const entry: CacheEntry = {
+    fromBlock: from.toString(),
+    toBlock: to.toString(),
+    rounds: rounds.map((r) => ({
+      chainId: r.chainId,
+      txHash: r.txHash,
+      blockNumber: r.blockNumber.toString(),
+      timestamp: r.timestamp,
+      recipients: r.recipients.map((x) => ({
+        recipient: x.recipient,
+        amount: x.amount.toString(),
+      })),
+    })),
+  };
+  try {
+    window.localStorage.setItem(
+      cacheKey(chainId, strategy),
+      JSON.stringify(entry),
+    );
+  } catch {
+    /* quota — skip caching */
+  }
+}
+
+function deserializeRounds(entry: CacheEntry): DistributionRound[] {
+  return entry.rounds.map((r) => {
+    const recipients = r.recipients.map((x) => ({
+      recipient: x.recipient,
+      amount: BigInt(x.amount),
+    }));
+    return {
+      chainId: r.chainId,
+      txHash: r.txHash,
+      blockNumber: BigInt(r.blockNumber),
+      timestamp: r.timestamp,
+      total: recipients.reduce((s, x) => s + x.amount, 0n),
+      recipients,
+    };
+  });
+}
+
+/* ------------------------------ public API -------------------------------- */
+
+/**
+ * Load one chain's distribution rounds. Uses the localStorage cache and only
+ * scans the gap up to the latest block (cheap on repeat visits). On the first
+ * scan it looks back `initialLookback` blocks; pass `olderBlocks` to extend the
+ * window further into the past ("load older").
+ */
+export async function loadChainDistributions(
+  target: DistributionTarget,
+  opts: { initialLookback: bigint; maxRange: bigint; olderBlocks?: bigint } = {
+    initialLookback: 200_000n,
+    maxRange: 9_000n,
+  },
+): Promise<DistributionRound[]> {
+  const { chainId, strategy } = target;
+  const client = publicClientFor(chainId);
+  const latest = await client.getBlockNumber();
+  const cached = readCache(chainId, strategy);
+
+  let cachedRounds: DistributionRound[] = [];
+  let scanFrom: bigint;
+  let scanTo: bigint = latest;
+  let coveredFrom: bigint;
+
+  if (cached) {
+    cachedRounds = deserializeRounds(cached);
+    const cachedFrom = BigInt(cached.fromBlock);
+    const cachedTo = BigInt(cached.toBlock);
+    if (opts.olderBlocks && opts.olderBlocks > 0n) {
+      // Extend the window backwards from the oldest scanned block.
+      scanTo = cachedFrom - 1n;
+      scanFrom =
+        scanTo < opts.olderBlocks ? 0n : scanTo - opts.olderBlocks + 1n;
+      coveredFrom = scanFrom < cachedFrom ? scanFrom : cachedFrom;
+    } else {
+      // Top up forward to the latest block.
+      scanFrom = cachedTo + 1n;
+      coveredFrom = cachedFrom;
+    }
+  } else {
+    scanFrom =
+      latest < opts.initialLookback ? 0n : latest - opts.initialLookback + 1n;
+    coveredFrom = scanFrom;
+  }
+
+  let fresh: DistributionRound[] = [];
+  if (scanFrom <= scanTo) {
+    const logs = await fetchDistributedLogs(
+      chainId,
+      strategy,
+      scanFrom,
+      scanTo,
+      opts.maxRange,
+    );
+    fresh = await logsToRounds(chainId, logs);
+  }
+
+  // Merge (dedupe by txHash), newest first.
+  const byTx = new Map<Hex, DistributionRound>();
+  for (const r of [...cachedRounds, ...fresh]) byTx.set(r.txHash, r);
+  const merged = [...byTx.values()].sort(
+    (a, b) =>
+      b.timestamp - a.timestamp || Number(b.blockNumber - a.blockNumber),
+  );
+
+  const newFrom = coveredFrom;
+  const newTo = cached ? bigMax(BigInt(cached.toBlock), latest) : latest;
+  writeCache(chainId, strategy, newFrom, newTo, merged);
+  return merged;
+}
+
+function bigMax(a: bigint, b: bigint): bigint {
+  return a > b ? a : b;
+}
+
+/** Normalize a base-unit amount to a decimal number (for cross-chain sums). */
+export function toDecimal(amount: bigint, decimals: number): number {
+  return Number(formatUnits(amount, decimals));
+}

--- a/src/lib/distribution-history.ts
+++ b/src/lib/distribution-history.ts
@@ -67,6 +67,9 @@ function windows(
 /**
  * Fetch `Distributed` logs for one strategy over [fromBlock, toBlock], chunked
  * by `maxRange` and bisecting any window the RPC rejects (range too large).
+ * `complete` is false if a single-block window still failed after bisection — the
+ * caller must then NOT advance its cache cursor past this range, so the dropped
+ * block is re-scanned next time instead of becoming a permanent gap.
  */
 async function fetchDistributedLogs(
   chainId: number,
@@ -74,10 +77,11 @@ async function fetchDistributedLogs(
   fromBlock: bigint,
   toBlock: bigint,
   maxRange: bigint,
-): Promise<DistLog[]> {
+): Promise<{ logs: DistLog[]; complete: boolean }> {
   const client = publicClientFor(chainId);
   const stack = windows(fromBlock, toBlock, maxRange).reverse();
   const logs: DistLog[] = [];
+  let complete = true;
   while (stack.length > 0) {
     const [lo, hi] = stack.pop()!;
     if (lo > hi) continue;
@@ -94,11 +98,13 @@ async function fetchDistributedLogs(
       if (hi > lo) {
         const mid = lo + (hi - lo) / 2n;
         stack.push([mid + 1n, hi], [lo, mid]);
+      } else {
+        // A single block still failed — the scan is incomplete for this range.
+        complete = false;
       }
-      // A single block that still fails is dropped (next refresh retries).
     }
   }
-  return logs;
+  return { logs, complete };
 }
 
 /** Group per-recipient logs into rounds (one per tx) and attach timestamps. */
@@ -270,15 +276,17 @@ export async function loadChainDistributions(
   }
 
   let fresh: DistributionRound[] = [];
+  let complete = true;
   if (scanFrom <= scanTo) {
-    const logs = await fetchDistributedLogs(
+    const res = await fetchDistributedLogs(
       chainId,
       strategy,
       scanFrom,
       scanTo,
       opts.maxRange,
     );
-    fresh = await logsToRounds(chainId, logs);
+    complete = res.complete;
+    fresh = await logsToRounds(chainId, res.logs);
   }
 
   // Merge (dedupe by txHash), newest first.
@@ -289,9 +297,24 @@ export async function loadChainDistributions(
       b.timestamp - a.timestamp || Number(b.blockNumber - a.blockNumber),
   );
 
-  const newFrom = coveredFrom;
-  const newTo = cached ? bigMax(BigInt(cached.toBlock), latest) : latest;
-  writeCache(chainId, strategy, newFrom, newTo, merged);
+  // Persist the events we found, but only ADVANCE the covered range when the
+  // scan was complete. If a block was dropped, keep the previous cursor (or
+  // don't cache a fresh range at all) so the gap is re-scanned next visit
+  // rather than being permanently skipped.
+  if (complete) {
+    const newTo = cached ? bigMax(BigInt(cached.toBlock), latest) : latest;
+    writeCache(chainId, strategy, coveredFrom, newTo, merged);
+  } else if (cached) {
+    writeCache(
+      chainId,
+      strategy,
+      BigInt(cached.fromBlock),
+      BigInt(cached.toBlock),
+      merged,
+    );
+  }
+  // incomplete + no prior cache → don't cache a covered range; next visit
+  // re-scans fresh (the rounds found this pass are still returned/shown).
   return merged;
 }
 


### PR DESCRIPTION
**Stacked on #156.** Adds a **History** view that shows, for a token family (e.g. RonCoin), how yield was distributed across every chain the community lives on — aggregated into one summary.

## What

A new `/app/history` page (nav: **History**):
- **Total distributed** family-wide, plus payout rounds / recipients / chains.
- **By chain** breakdown (bar per chain, native symbol + round count).
- **Recipient leaderboard** — each recipient's all-time total across chains, with the per-chain split.
- **Payout timeline** — every distribution round newest-first, expandable to per-recipient amounts + an explorer link to the tx.

Single-chain (non-family) instances get the same view scoped to their one chain.

## How — serverless, no indexer

Matches the static-export architecture we just committed to (no server). Every distribution strategy emits `Distributed(recipient, amount)` once per recipient per payout (in the same tx as `DistributionExecuted`). The frontend reads those logs **directly from each chain's RPC** via viem `getLogs`, chunked and **bisecting on RPC range-limit errors**, groups them by transaction into payout rounds, fetches block timestamps, and aggregates.

- Reads are **cached incrementally in localStorage** — repeat visits only scan new blocks; a **"Load older history"** button extends the window further back.
- **Decimals differ per chain** (WXDAI 18-dec on Gnosis vs USDC 6-dec on the L2s), so amounts are normalized to a decimal value before any cross-chain sum; per-chain figures stay in their native symbol.
- Family targets come from the existing `useFamily` sibling resolution; there's no new trust surface.

## Files

- `src/lib/distribution-history.ts` — the indexer (getLogs + bisect + group-by-tx + timestamps + localStorage cache).
- `src/hooks/use-distribution-history.ts` — targets (family or active instance), per-chain token decimals/symbol, aggregation per chain + per recipient.
- `src/app/app/history/page.tsx` + nav link.

## Verification

- `pnpm lint` / `pnpm build` (static export, 14 routes) / `pnpm format:check` green.
- **Validated end-to-end against the live Gnosis instance**: a real `getLogs` scan of the deployed distribution strategy returned `Distributed` events that grouped into a payout round with correct per-recipient totals.

## Scale note

Client-side scanning is bounded (recent window + incremental cache + "load older"), which is ideal for a young protocol and stays fully serverless. For deep history on high-block-rate chains, a natural follow-up is a published `distributions.json` snapshot (a scheduled CI job, mirrored like `addresses.json`) that the hook reads first and tops up with a short client scan — same runtime, instant + complete. Not needed yet.