### PR TITLE
Multi-asset family mint + both wallet paths (Privy sponsored / self-paid per-chain)

### DIFF
--- a/src/app/app/admin/_components/family-chains-card.tsx
+++ b/src/app/app/admin/_components/family-chains-card.tsx
@@ -11,6 +11,7 @@ import { useFamily, type FamilyChainState } from "@/hooks/use-family";
 import { useRegistryKind } from "@/hooks/use-recipient-voting";
 import { useCrossChainRegistryUpdate } from "@/hooks/use-cross-chain-registry-update";
 import { MultiChainActionStatus } from "@/components/dapp/multi-chain-action-status";
+import { GasModeNote } from "@/components/dapp/gas-mode-note";
 import {
   diffRecipients,
   useMirrorRecipients,
@@ -152,6 +153,9 @@ function SyncEverywhere({
       >
         {drift ? "Sync recipients everywhere" : "Re-sync recipients"}
       </Button>
+      <div className="mt-2">
+        <GasModeNote />
+      </div>
       {sync.error && (
         <Caption className="text-system-red mt-2 block">{sync.error}</Caption>
       )}

--- a/src/app/app/deposit/_components/family-deposit.tsx
+++ b/src/app/app/deposit/_components/family-deposit.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { formatUnits } from "viem";
+import { Body, Button, Caption } from "@breadcoop/ui";
+import {
+  ArrowClockwise,
+  ArrowSquareOut,
+  CheckCircle,
+  Globe,
+  SpinnerGap,
+  Warning,
+} from "@phosphor-icons/react";
+import { Card } from "@/components/dapp/ui";
+import { cn } from "@/lib/utils";
+import { formatAmount, parseAmount } from "@/lib/format";
+import { shortChainName, txUrl } from "@/lib/chains";
+import { useWalletActions } from "@/components/wallet/wallet-actions";
+import type { FamilyState } from "@/hooks/use-family";
+import {
+  useFamilyDeposit,
+  type DepositAllocation,
+  type DepositRow,
+  type FamilyDepositChain,
+} from "@/hooks/use-family-deposit";
+
+const GAS_RESERVE = 10n ** 16n; // ~0.01 native, kept back to pay gas (self-paid)
+
+/**
+ * Multi-asset family mint: deposit into a community token across every chain it
+ * lives on, in whatever asset you hold on each. One panel, per-chain amounts.
+ */
+export function FamilyDeposit({
+  family,
+  tokenSymbol,
+}: {
+  family: FamilyState;
+  tokenSymbol: string;
+}) {
+  const { sponsored } = useWalletActions();
+  const dep = useFamilyDeposit(family);
+  // Per-chain input + asset mode (native chains can pick native or wrapped).
+  const [amounts, setAmounts] = useState<Record<number, string>>({});
+  const [modes, setModes] = useState<Record<number, "native" | "wrapped">>({});
+
+  const modeFor = (c: FamilyDepositChain): "native" | "wrapped" =>
+    modes[c.chainId] ?? (c.yieldKind === "stable" ? "wrapped" : "native");
+
+  const decimalsFor = (c: FamilyDepositChain, mode: "native" | "wrapped") =>
+    mode === "native" ? 18 : c.wrappedDecimals;
+
+  // Balance available for a row's chosen asset (reserve native gas when self-paid).
+  const availableFor = (c: FamilyDepositChain, mode: "native" | "wrapped") => {
+    if (mode === "wrapped") return c.wrappedBalance;
+    return !sponsored && c.nativeBalance > GAS_RESERVE
+      ? c.nativeBalance - GAS_RESERVE
+      : c.nativeBalance;
+  };
+
+  const rowByChain = (chainId: number): DepositRow | undefined =>
+    dep.rows.find((r) => r.chainId === chainId);
+
+  const allocations: DepositAllocation[] = useMemo(
+    () =>
+      dep.chains.map((c) => {
+        const mode = modeFor(c);
+        const parsed = parseAmount(
+          amounts[c.chainId] ?? "",
+          decimalsFor(c, mode),
+        );
+        return { chainId: c.chainId, amount: parsed ?? 0n, mode };
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dep.chains, amounts, modes],
+  );
+
+  // Total minted ≈ sum of per-chain deposit amounts, normalized to decimals.
+  const totalNormalized = allocations.reduce((sum, a) => {
+    const c = dep.chains.find((x) => x.chainId === a.chainId);
+    if (!c || a.amount <= 0n) return sum;
+    return sum + Number(formatUnits(a.amount, decimalsFor(c, a.mode)));
+  }, 0);
+
+  const activeCount = allocations.filter((a) => a.amount > 0n).length;
+  const anyOver = allocations.some((a) => {
+    const c = dep.chains.find((x) => x.chainId === a.chainId);
+    return c && a.amount > availableFor(c, a.mode);
+  });
+  const anyFailed = dep.rows.some((r) => r.state === "failed");
+  const settled =
+    dep.rows.length > 0 &&
+    dep.rows.every((r) => r.state === "confirmed" || r.state === "failed");
+
+  if (dep.isLoading && dep.chains.length === 0) {
+    return (
+      <Card>
+        <Body className="text-surface-grey-2">
+          Reading your balances on each chain…
+        </Body>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <Caption className="text-surface-grey-2 flex items-center gap-1.5">
+        <Globe size={14} weight="fill" className="text-core-orange" />
+        Mint {tokenSymbol} across your chains
+      </Caption>
+      <Body className="text-surface-grey mt-1 text-sm">
+        Deposit whatever you hold on each chain — you mint {tokenSymbol} on
+        every chain from your local balance there.
+      </Body>
+
+      <ul className="mt-4 space-y-4">
+        {dep.chains.map((c) => {
+          const mode = modeFor(c);
+          const dec = decimalsFor(c, mode);
+          const avail = availableFor(c, mode);
+          const parsed = parseAmount(amounts[c.chainId] ?? "", dec);
+          const over = parsed !== null && parsed > avail;
+          const canToggle = c.yieldKind === "native" && c.wrapped !== null;
+          const symbol = mode === "native" ? c.nativeSymbol : c.wrappedSymbol;
+          const row = rowByChain(c.chainId);
+          return (
+            <li
+              key={c.chainId}
+              className="border-paper-2 border-t pt-4 first:border-t-0 first:pt-0"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-text-standard font-breadDisplay font-bold">
+                  {shortChainName(c.chainId)}
+                </span>
+                {canToggle && (
+                  <div className="border-paper-2 inline-flex rounded-lg border p-0.5">
+                    {(["native", "wrapped"] as const).map((m) => (
+                      <button
+                        key={m}
+                        type="button"
+                        onClick={() =>
+                          setModes((p) => ({ ...p, [c.chainId]: m }))
+                        }
+                        className={cn(
+                          "rounded-md px-2.5 py-1 text-xs font-semibold",
+                          mode === m
+                            ? "bg-core-orange text-white"
+                            : "text-surface-grey-2",
+                        )}
+                      >
+                        {m === "native" ? c.nativeSymbol : c.wrappedSymbol}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-2 flex items-center gap-2">
+                <div className="border-paper-2 bg-paper-main focus-within:border-core-orange flex flex-1 items-center gap-2 rounded-xl border px-3 py-2">
+                  <input
+                    inputMode="decimal"
+                    placeholder="0.0"
+                    value={amounts[c.chainId] ?? ""}
+                    onChange={(e) =>
+                      setAmounts((p) => ({ ...p, [c.chainId]: e.target.value }))
+                    }
+                    className="font-breadDisplay text-text-standard placeholder:text-surface-grey w-full bg-transparent text-lg font-bold outline-none"
+                  />
+                  <span className="text-surface-grey-2 text-sm font-bold">
+                    {symbol}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setAmounts((p) => ({
+                      ...p,
+                      [c.chainId]: formatUnits(avail, dec),
+                    }))
+                  }
+                  className="text-core-orange text-xs font-semibold hover:underline"
+                >
+                  MAX
+                </button>
+              </div>
+
+              <div className="mt-1 flex items-center justify-between">
+                <Caption className="text-surface-grey">
+                  Balance: {formatAmount(avail, 4, dec)} {symbol}
+                </Caption>
+                {over && (
+                  <Caption className="text-system-red">Exceeds balance</Caption>
+                )}
+                {row && <DepositRowStatus row={row} />}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="bg-paper-1 mt-5 flex items-center justify-between rounded-xl px-4 py-3">
+        <Caption className="text-surface-grey-2">
+          You mint{" "}
+          {activeCount > 0
+            ? `on ${activeCount} chain${activeCount === 1 ? "" : "s"}`
+            : "—"}
+        </Caption>
+        <span className="font-breadDisplay text-text-standard font-bold">
+          ≈{" "}
+          {totalNormalized.toLocaleString("en-US", {
+            maximumFractionDigits: 2,
+          })}{" "}
+          {tokenSymbol}
+        </span>
+      </div>
+
+      <Caption className="text-surface-grey mt-3 block">
+        {sponsored
+          ? "Gasless — each chain's deposit is submitted for you, no network switching."
+          : "You'll confirm one transaction per chain (a network switch + a deposit, plus an approval for ERC-20 assets) and need a little gas on each."}
+      </Caption>
+
+      <div className="mt-4 flex flex-wrap gap-3">
+        <Button
+          app="fund"
+          variant="primary"
+          isLoading={dep.isBusy}
+          onClick={() => void dep.mint(allocations)}
+          {...(activeCount === 0 || anyOver || dep.isBusy
+            ? { disabled: true }
+            : {})}
+        >
+          {activeCount > 1 ? `Mint on ${activeCount} chains` : "Mint"}
+        </Button>
+        {settled && anyFailed && (
+          <Button
+            app="fund"
+            variant="secondary"
+            isLoading={dep.isBusy}
+            onClick={() => void dep.retryFailed(allocations)}
+            leftIcon={<ArrowClockwise weight="bold" />}
+          >
+            Retry failed
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function DepositRowStatus({ row }: { row: DepositRow }) {
+  if (row.state === "approving")
+    return (
+      <Caption className="text-surface-grey-2 flex items-center gap-1">
+        <SpinnerGap size={12} className="animate-spin" /> Approving…
+      </Caption>
+    );
+  if (row.state === "depositing")
+    return (
+      <Caption className="text-surface-grey-2 flex items-center gap-1">
+        <SpinnerGap size={12} className="animate-spin" /> Depositing…
+      </Caption>
+    );
+  if (row.state === "confirmed")
+    return (
+      <a
+        href={row.txHash ? txUrl(row.txHash, row.chainId) : "#"}
+        target="_blank"
+        rel="noreferrer"
+        className="text-system-green flex items-center gap-1 text-xs font-semibold hover:underline"
+      >
+        <CheckCircle size={13} weight="fill" /> Minted{" "}
+        <ArrowSquareOut size={11} />
+      </a>
+    );
+  if (row.state === "failed")
+    return (
+      <Caption className="text-system-red flex items-center gap-1">
+        <Warning size={12} weight="fill" /> {row.error ?? "Failed"}
+      </Caption>
+    );
+  return null;
+}

--- a/src/app/app/deposit/page.tsx
+++ b/src/app/app/deposit/page.tsx
@@ -10,6 +10,8 @@ import { cn } from "@/lib/utils";
 import { parseAmount } from "@/lib/format";
 import { useAmountFormatter } from "@/components/demo-mode-provider";
 import { useActiveChain, useNativeSymbol } from "@/hooks/use-chain";
+import { useFamily } from "@/hooks/use-family";
+import { FamilyDeposit } from "@/app/app/deposit/_components/family-deposit";
 import {
   useApproveWrapped,
   useDeposit,
@@ -23,14 +25,35 @@ export default function DepositPage() {
   const { symbol } = useInstanceToken();
   const native = useNativeSymbol();
   const { yieldKind, wrappedSymbol } = useActiveChain();
+  const family = useFamily();
   const depositSym = yieldKind === "stable" ? wrappedSymbol : native;
+  const isFamily = family.isFamily && !family.isLoading;
+
   return (
     <div className="mx-auto max-w-lg">
       <PageHeader
         title="Deposit"
-        subtitle={`Stake ${depositSym} to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`}
+        subtitle={
+          isFamily
+            ? `Mint ${symbol} across the chains this community lives on — deposit whatever you hold on each. Your principal stays withdrawable; only the interest is distributed.`
+            : `Stake ${depositSym} to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
+        }
       />
-      <DepositForm />
+      {isFamily ? (
+        <>
+          <FamilyDeposit family={family} tokenSymbol={symbol} />
+          <details className="mt-4">
+            <summary className="text-surface-grey-2 hover:text-text-standard cursor-pointer text-sm font-medium">
+              Or deposit on just this chain
+            </summary>
+            <div className="mt-3">
+              <DepositForm />
+            </div>
+          </details>
+        </>
+      ) : (
+        <DepositForm />
+      )}
     </div>
   );
 }

--- a/src/app/app/recipients/page.tsx
+++ b/src/app/app/recipients/page.tsx
@@ -49,6 +49,7 @@ import {
   type CrossChainProposal,
 } from "@/hooks/use-cross-chain-proposals";
 import { MultiChainActionStatus } from "@/components/dapp/multi-chain-action-status";
+import { GasModeNote } from "@/components/dapp/gas-mode-note";
 import type { ChainActionRow } from "@/lib/cross-chain-action";
 
 export default function RecipientsPage() {
@@ -1066,6 +1067,11 @@ function FamilyDemocraticRecipients({
             Propose
           </Button>
         </div>
+        {amRecipient && (
+          <div className="mt-2">
+            <GasModeNote />
+          </div>
+        )}
         {!amRecipient && (
           <Caption className="text-system-warning mt-2 block">
             {isConnected

--- a/src/app/app/vote/page.tsx
+++ b/src/app/app/vote/page.tsx
@@ -12,6 +12,7 @@ import {
   ProgressBar,
 } from "@/components/dapp/ui";
 import { ActionButton } from "@/components/dapp/action-button";
+import { GasModeNote } from "@/components/dapp/gas-mode-note";
 import { TxStatus } from "@/components/dapp/tx-status";
 import { useRecipients } from "@/hooks/use-recipients";
 import { useVote, useVotingState } from "@/hooks/use-voting";
@@ -379,6 +380,9 @@ function FamilyVoteForm({ family }: { family: ReturnType<typeof useFamily> }) {
         >
           {alreadyVoted ? "Update vote" : "Cast vote"}
         </ActionButton>
+        <div className="mt-2 text-center">
+          <GasModeNote />
+        </div>
       </div>
 
       {!anyAllocated && (

--- a/src/components/dapp/gas-mode-note.tsx
+++ b/src/components/dapp/gas-mode-note.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Caption } from "@breadcoop/ui";
+import { HandTap, Lightning } from "@phosphor-icons/react";
+import { useWalletActions } from "@/components/wallet/wallet-actions";
+
+/**
+ * Tells the user how a cross-chain action will be delivered by their wallet:
+ * gaslessly (Privy embedded — no prompts, no switching) or self-paid (one
+ * confirmation per chain, gas needed on each). Renders nothing decisive until a
+ * wallet is connected — it just reflects the current wallet's capability.
+ */
+export function GasModeNote({ className = "" }: { className?: string }) {
+  const { sponsored } = useWalletActions();
+  return sponsored ? (
+    <Caption
+      className={`text-system-green inline-flex items-center gap-1 ${className}`}
+    >
+      <Lightning size={12} weight="fill" /> Gasless — submitted on every chain
+      for you, no network switching.
+    </Caption>
+  ) : (
+    <Caption
+      className={`text-surface-grey inline-flex items-center gap-1 ${className}`}
+    >
+      <HandTap size={12} /> You&apos;ll confirm one transaction per chain and
+      need a little gas on each.
+    </Caption>
+  );
+}

--- a/src/components/dapp/gas-mode-note.tsx
+++ b/src/components/dapp/gas-mode-note.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAccount } from "wagmi";
 import { Caption } from "@breadcoop/ui";
 import { HandTap, Lightning } from "@phosphor-icons/react";
 import { useWalletActions } from "@/components/wallet/wallet-actions";
@@ -7,11 +8,13 @@ import { useWalletActions } from "@/components/wallet/wallet-actions";
 /**
  * Tells the user how a cross-chain action will be delivered by their wallet:
  * gaslessly (Privy embedded — no prompts, no switching) or self-paid (one
- * confirmation per chain, gas needed on each). Renders nothing decisive until a
- * wallet is connected — it just reflects the current wallet's capability.
+ * confirmation per chain, gas needed on each). Renders nothing until a wallet is
+ * connected — it just reflects the current wallet's capability.
  */
 export function GasModeNote({ className = "" }: { className?: string }) {
+  const { isConnected } = useAccount();
   const { sponsored } = useWalletActions();
+  if (!isConnected) return null;
   return sponsored ? (
     <Caption
       className={`text-system-green inline-flex items-center gap-1 ${className}`}

--- a/src/components/wallet/privy-wallet-actions.tsx
+++ b/src/components/wallet/privy-wallet-actions.tsx
@@ -70,6 +70,8 @@ export function PrivyWalletActions({ children }: { children: ReactNode }) {
     connect: () => login(),
     disconnect: () => void logout(),
     sendSponsored,
+    // Embedded Privy wallets are gas-sponsored; external wallets self-pay.
+    sponsored: activeIsEmbedded(),
   };
 
   return (

--- a/src/components/wallet/wallet-actions.tsx
+++ b/src/components/wallet/wallet-actions.tsx
@@ -2,8 +2,9 @@
 
 import { createContext, useCallback, useContext, type ReactNode } from "react";
 import type { Abi, Address, Hex } from "viem";
+import { getChainId } from "@wagmi/core";
 import {
-  useAccount,
+  useConfig,
   useConnect,
   useDisconnect,
   useSwitchChain,
@@ -31,6 +32,12 @@ export interface WalletActions {
    * a normal self-paid wallet tx (switching chain first). Returns the tx hash.
    */
   sendSponsored: (req: SponsoredTxRequest) => Promise<Hex>;
+  /**
+   * True when the active wallet is gas-sponsored (Privy embedded): cross-chain
+   * actions land automatically with no prompt or network switch. False for a
+   * self-paid wallet — the user confirms one tx per chain and needs gas on each.
+   */
+  sponsored: boolean;
 }
 
 export const WalletActionsContext = createContext<WalletActions | null>(null);
@@ -49,14 +56,19 @@ export function useWalletActions(): WalletActions {
  * Shared self-paid path: switch the wallet to the target chain if needed, then
  * write. Used verbatim by the fallback provider and by the Privy provider when
  * the active wallet is an EXTERNAL wallet (which can't be gas-sponsored).
+ *
+ * The current chain is read LIVE via `getChainId(config)` — not a stale
+ * `useAccount()` closure — so a sequential per-chain fan-out (e.g. voting on N
+ * chains, minting across N chains) switches correctly for every chain even
+ * though React doesn't re-render between the awaited submissions.
  */
 export function useWalletWrite() {
-  const { chainId: walletChainId } = useAccount();
+  const config = useConfig();
   const { switchChainAsync } = useSwitchChain();
   const { writeContractAsync } = useWriteContract();
   return useCallback(
     async (req: SponsoredTxRequest): Promise<Hex> => {
-      if (walletChainId !== req.chainId) {
+      if (getChainId(config) !== req.chainId) {
         await switchChainAsync({ chainId: req.chainId });
       }
       return writeContractAsync({
@@ -68,7 +80,7 @@ export function useWalletWrite() {
         ...(req.value !== undefined ? { value: req.value } : {}),
       } as Parameters<typeof writeContractAsync>[0]);
     },
-    [walletChainId, switchChainAsync, writeContractAsync],
+    [config, switchChainAsync, writeContractAsync],
   );
 }
 
@@ -88,6 +100,7 @@ export function WagmiWalletActions({ children }: { children: ReactNode }) {
     },
     disconnect: () => disconnect(),
     sendSponsored: write,
+    sponsored: false, // injected wallets always self-pay
   };
 
   return (

--- a/src/hooks/use-family-deposit.ts
+++ b/src/hooks/use-family-deposit.ts
@@ -129,6 +129,8 @@ export function useFamilyDeposit(family: FamilyState) {
   useEffect(() => {
     if (!address || found.length === 0) {
       setChains([]);
+      setRows([]);
+      setBusyChain(null);
       setIsLoading(false);
       return;
     }

--- a/src/hooks/use-family-deposit.ts
+++ b/src/hooks/use-family-deposit.ts
@@ -1,0 +1,257 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { erc20Abi, zeroAddress, type Address, type Hex } from "viem";
+import { useAccount } from "wagmi";
+import { tokenAbi } from "@/lib/abis";
+import { chainConfig } from "@/lib/chains";
+import { publicClientFor } from "@/lib/instance";
+import { parseTxError } from "@/hooks/use-tx";
+import { useWalletActions } from "@/components/wallet/wallet-actions";
+import type { FamilyState } from "@/hooks/use-family";
+
+/** Per-chain deposit metadata + the connected wallet's balances there. */
+export interface FamilyDepositChain {
+  chainId: number;
+  yieldKind: "native" | "stable";
+  /** The instance's yield token (what we mint). */
+  token: Address;
+  /** The ERC-20 deposit asset (WXDAI / USDC), or null on pure-native chains. */
+  wrapped: Address | null;
+  nativeSymbol: string;
+  wrappedSymbol: string;
+  /** Decimals of the wrapped/stable asset (native is always 18). */
+  wrappedDecimals: number;
+  nativeBalance: bigint;
+  wrappedBalance: bigint;
+  /** Wrapped → token allowance (0 when there's no wrapped asset). */
+  allowance: bigint;
+}
+
+export type DepositRowState =
+  "idle" | "approving" | "depositing" | "confirmed" | "failed";
+
+export interface DepositRow {
+  chainId: number;
+  state: DepositRowState;
+  txHash?: Hex;
+  error?: string;
+}
+
+/** One chain's requested deposit: how much of which asset. */
+export interface DepositAllocation {
+  chainId: number;
+  amount: bigint;
+  mode: "native" | "wrapped";
+}
+
+async function loadChain(
+  chainId: number,
+  token: Address,
+  owner: Address,
+): Promise<FamilyDepositChain> {
+  const cfg = chainConfig(chainId);
+  const client = publicClientFor(chainId);
+  const wrapped = cfg.wrappedToken;
+
+  const [nativeBalance, wrappedBalance, allowance, wrappedDecimals] =
+    await Promise.all([
+      client.getBalance({ address: owner }).catch(() => 0n),
+      wrapped
+        ? client
+            .readContract({
+              address: wrapped,
+              abi: erc20Abi,
+              functionName: "balanceOf",
+              args: [owner],
+            })
+            .catch(() => 0n)
+        : Promise.resolve(0n),
+      wrapped
+        ? client
+            .readContract({
+              address: wrapped,
+              abi: erc20Abi,
+              functionName: "allowance",
+              args: [owner, token],
+            })
+            .catch(() => 0n)
+        : Promise.resolve(0n),
+      wrapped
+        ? client
+            .readContract({
+              address: wrapped,
+              abi: erc20Abi,
+              functionName: "decimals",
+            })
+            .catch(() => 18)
+        : Promise.resolve(18),
+    ]);
+
+  return {
+    chainId,
+    yieldKind: cfg.yieldKind,
+    token,
+    wrapped,
+    nativeSymbol: cfg.chain.nativeCurrency.symbol,
+    wrappedSymbol: cfg.wrappedSymbol,
+    wrappedDecimals: Number(wrappedDecimals),
+    nativeBalance,
+    wrappedBalance,
+    allowance,
+  };
+}
+
+/**
+ * Multi-asset family mint: deposit into a community token on several chains at
+ * once, in whatever asset you hold on each (native xDAI on Gnosis, USDC on the
+ * L2s, …). Each chain mints its OWN local token to you from your local balance
+ * — deposits move real funds, so this is a real per-chain transaction fan-out
+ * (not a signature replay): gas-sponsored automatically on a Privy embedded
+ * wallet, or one confirmation per chain (with gas needed on each) on a
+ * self-paid wallet.
+ */
+export function useFamilyDeposit(family: FamilyState) {
+  const { address } = useAccount();
+  const { sendSponsored } = useWalletActions();
+
+  const [chains, setChains] = useState<FamilyDepositChain[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [rows, setRows] = useState<DepositRow[]>([]);
+  const [busyChain, setBusyChain] = useState<number | null>(null);
+  const [seq, setSeq] = useState(0);
+
+  const found = family.perChain.filter(
+    (c) => c.status === "found" && c.instance,
+  );
+  const targetKey = found.map((c) => c.chainId).join(",");
+
+  useEffect(() => {
+    if (!address || found.length === 0) {
+      setChains([]);
+      setIsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setIsLoading(true);
+    void (async () => {
+      const loaded = await Promise.all(
+        found.map((c) => loadChain(c.chainId, c.instance!.token, address)),
+      );
+      if (!cancelled) {
+        setChains(loaded);
+        setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, targetKey, seq]);
+
+  const refetch = useCallback(() => setSeq((s) => s + 1), []);
+
+  const setRow = useCallback((chainId: number, patch: Partial<DepositRow>) => {
+    setRows((prev) => {
+      const i = prev.findIndex((r) => r.chainId === chainId);
+      if (i === -1) return [...prev, { chainId, state: "idle", ...patch }];
+      const next = [...prev];
+      next[i] = { ...next[i], ...patch };
+      return next;
+    });
+  }, []);
+
+  /** Deposit on one chain: (approve if needed) → mint → wait for receipt. */
+  const depositOnChain = useCallback(
+    async (alloc: DepositAllocation) => {
+      const meta = chains.find((c) => c.chainId === alloc.chainId);
+      if (!meta || !address || alloc.amount <= 0n) return;
+      const client = publicClientFor(alloc.chainId);
+      setBusyChain(alloc.chainId);
+      try {
+        // ERC-20 deposit needs an allowance to the token first.
+        if (alloc.mode === "wrapped" && meta.wrapped) {
+          if (meta.allowance < alloc.amount) {
+            setRow(alloc.chainId, { state: "approving", error: undefined });
+            const approveHash = await sendSponsored({
+              chainId: alloc.chainId,
+              address: meta.wrapped,
+              abi: erc20Abi,
+              functionName: "approve",
+              args: [meta.token, alloc.amount],
+            });
+            await client.waitForTransactionReceipt({ hash: approveHash });
+          }
+        }
+
+        setRow(alloc.chainId, { state: "depositing", error: undefined });
+        const mintHash =
+          alloc.mode === "native"
+            ? await sendSponsored({
+                chainId: alloc.chainId,
+                address: meta.token,
+                abi: tokenAbi,
+                functionName: "mint",
+                args: [address],
+                value: alloc.amount,
+              })
+            : await sendSponsored({
+                chainId: alloc.chainId,
+                address: meta.token,
+                abi: tokenAbi,
+                functionName: "mint",
+                args: [address, alloc.amount],
+              });
+        await client.waitForTransactionReceipt({ hash: mintHash });
+        setRow(alloc.chainId, { state: "confirmed", txHash: mintHash });
+      } catch (e) {
+        setRow(alloc.chainId, { state: "failed", error: parseTxError(e) });
+      } finally {
+        setBusyChain(null);
+      }
+    },
+    [chains, address, sendSponsored, setRow],
+  );
+
+  /** Deposit the requested mix across chains, sequentially. */
+  const mint = useCallback(
+    async (allocations: DepositAllocation[]) => {
+      const live = allocations.filter((a) => a.amount > 0n);
+      setRows(live.map((a) => ({ chainId: a.chainId, state: "idle" })));
+      for (const a of live) {
+        await depositOnChain(a);
+      }
+      refetch();
+    },
+    [depositOnChain, refetch],
+  );
+
+  /** Retry every chain whose deposit failed. */
+  const retryFailed = useCallback(
+    async (allocations: DepositAllocation[]) => {
+      for (const r of rows) {
+        if (r.state !== "failed") continue;
+        const a = allocations.find((x) => x.chainId === r.chainId);
+        if (a && a.amount > 0n) await depositOnChain(a);
+      }
+      refetch();
+    },
+    [rows, depositOnChain, refetch],
+  );
+
+  const reset = useCallback(() => setRows([]), []);
+
+  return {
+    chains,
+    isLoading,
+    rows,
+    busyChain,
+    mint,
+    depositOnChain,
+    retryFailed,
+    reset,
+    refetch,
+    isBusy: busyChain !== null,
+    receiver: address ?? zeroAddress,
+  };
+}


### PR DESCRIPTION
Two related additions on top of the merged cross-chain stack.

## 1. Multi-asset family mint

On a **family** (multi-chain) token, the Deposit page now lets you **mint across every chain the community lives on in one panel**, depositing whatever you hold on each — native xDAI on Gnosis, USDC on the L2s, etc. You enter an amount per chain (with a native/wrapped toggle where both exist), and it mints that chain's local token to you from your local balance there.

Deposits move real funds, so this is a genuine **per-chain transaction fan-out** (approve + mint on each), not a signature replay. Non-family instances keep the classic single-chain form unchanged (family instances get the multi-chain panel plus an "or just this chain" fallback).

- `src/hooks/use-family-deposit.ts` — reads each family chain's deposit asset + your balances/allowance; a sequential executor that does (approve if needed → wait → mint → wait) per chain, with per-chain state + retry-failed.
- `src/app/app/deposit/_components/family-deposit.tsx` — the per-chain amount UI + status.

## 2. Both wallet paths work everywhere cross-chain

Made the two paths explicit and correct across **every** cross-chain flow (vote, propose/approve-deny, admin sync, and the new family mint):

- **Privy embedded wallet** → gas-**sponsored**: no prompts, no network switching, all chains submitted for you.
- **Self-paid wallet** (injected, or an external wallet connected through Privy) → **one confirmation per chain** (network switch + tx, plus an approval for ERC-20 assets), and you need gas on each chain. Exactly the behaviour requested: *"on a native wallet you must have gas yourself on all those chains, but it prompts you for each chain."* Failed chains are retryable per chain.

Fixes + surfacing:
- `wallet-actions`: the self-paid writer now reads the **live** chain via `getChainId(config)` instead of a stale `useAccount()` closure. Without this, a sequential per-chain fan-out could skip a switch and hit a `ChainMismatch` when the wallet didn't start on the first target chain. Also exposes a `sponsored` flag on the wallet-actions context.
- new `GasModeNote` component shows which mode you're in (⚡ gasless vs. 👆 confirm-on-each-chain) on the vote / propose / admin-sync buttons; the family-mint panel shows the same inline.

## Verification

Frontend only — **contracts/relay untouched**. `pnpm lint` + static `build` (both with Privy configured and in the injected fallback) + `format:check` all green. Traced both wallet paths end-to-end across all four fan-out flows.