### PR TITLE
feat: per-user yield split (give vs keep)

### DIFF
--- a/contracts/src/abstract/AbstractToken.sol
+++ b/contracts/src/abstract/AbstractToken.sol
@@ -18,7 +18,8 @@ interface IContractURI {
 /// @author BreadKit
 /// @notice Abstract base contract for yield-bearing ERC20 tokens with voting delegation
 /// @dev Extends ERC20VotesUpgradeable with yield claiming, a two-phase yield claimer transfer
-///      mechanism (14-day timelock), and automatic delegation on transfers/mints.
+///      mechanism (14-day timelock), automatic delegation on transfers/mints, and per-holder
+///      yield splits (each holder chooses how much of their yield share to keep vs donate).
 ///      Inheriting contracts must implement _deposit, _remit, and _yieldAccrued.
 abstract contract AbstractToken is ERC20VotesUpgradeable, Ownable, IToken {
     /// @notice Thrown when attempting to mint zero tokens
@@ -31,6 +32,8 @@ abstract contract AbstractToken is ERC20VotesUpgradeable, Ownable, IToken {
     error YieldInsufficient();
     /// @notice Thrown when a non-claimer address attempts to claim yield
     error OnlyClaimer();
+    /// @notice Thrown when a yield split exceeds 100% (10,000 bps)
+    error InvalidYieldSplit();
     /// @notice Thrown when finalizing with no pending claimer
     error NoPendingClaimer();
     /// @notice Thrown when preparing a new claimer while one is already pending
@@ -65,6 +68,45 @@ abstract contract AbstractToken is ERC20VotesUpgradeable, Ownable, IToken {
     function _getAbstractTokenStorage() internal pure returns (AbstractTokenStorage storage $) {
         assembly {
             $.slot := ABSTRACT_TOKEN_STORAGE
+        }
+    }
+
+    // ============ Yield Split Storage ============
+
+    /// @notice Basis-points denominator for yield splits (100% = 10,000)
+    uint256 public constant YIELD_SPLIT_BPS = 10_000;
+
+    /// @dev Precision scale for the yield-per-token accumulator. High enough that the
+    ///      truncation lost per accrual (supply / YIELD_PRECISION wei) stays sub-wei for
+    ///      any realistic supply; any dust lands in the donated pool.
+    uint256 private constant YIELD_PRECISION = 1e27;
+
+    /// @custom:storage-location erc7201:crowdstake.storage.YieldSplit
+    struct YieldSplitStorage {
+        /// @notice Cumulative yield attributed per token, scaled by YIELD_PRECISION
+        uint256 accYieldPerToken;
+        /// @notice Raw yield already pushed through the accumulator (falls when claims mint)
+        uint256 accountedYield;
+        /// @notice Sum of balance * keepBps over all holders with a nonzero split
+        uint256 keepWeight;
+        /// @notice Sum of balance * keepBps * index over the same holders
+        uint256 keepWeightIndex;
+        /// @notice Total settled kept yield awaiting claims
+        uint256 keptYieldTotal;
+        /// @notice Share of each holder's yield they keep, in bps (default 0 = donate all)
+        mapping(address => uint16) keepBps;
+        /// @notice accYieldPerToken at each holder's last settlement
+        mapping(address => uint256) index;
+        /// @notice Settled, claimable kept yield per holder
+        mapping(address => uint256) keptYield;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.YieldSplit")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant YIELD_SPLIT_STORAGE = 0xf738586bf43cceca564b7190bdeb6371d7e569504429f728e4554e1d8c5e6400;
+
+    function _getYieldSplitStorage() internal pure returns (YieldSplitStorage storage $) {
+        assembly {
+            $.slot := YIELD_SPLIT_STORAGE
         }
     }
 
@@ -111,6 +153,10 @@ abstract contract AbstractToken is ERC20VotesUpgradeable, Ownable, IToken {
     event PendingYieldClaimerSet(address yieldClaimer);
     /// @notice Emitted when yield is claimed
     event ClaimedYield(uint256 amount);
+    /// @notice Emitted when a holder updates their yield split
+    event YieldSplitSet(address indexed account, uint16 keepBps);
+    /// @notice Emitted when a holder claims their kept yield
+    event KeptYieldClaimed(address indexed account, address receiver, uint256 amount);
 
     /// @dev MUST implement in derived contract
     /// logic to deposit user collateral into yield bearing position
@@ -178,22 +224,85 @@ abstract contract AbstractToken is ERC20VotesUpgradeable, Ownable, IToken {
         emit Burned(receiver_, amount_);
     }
 
-    /// @notice Claims accrued yield and mints it as tokens to the receiver
-    /// @dev Only callable by the authorized yield claimer
+    /// @notice Claims accrued donated yield and mints it as tokens to the receiver
+    /// @dev Only callable by the authorized yield claimer. Only the donated portion of the
+    ///      vault surplus is claimable here; holders' kept shares stay reserved for them.
     /// @param amount_ Amount of yield to claim
     /// @param receiver_ Address to receive the minted yield tokens
     function claimYield(uint256 amount_, address receiver_) external virtual {
         AbstractTokenStorage storage $ = _getAbstractTokenStorage();
         if (msg.sender != $.yieldClaimer) revert OnlyClaimer();
         if (amount_ == 0) revert ClaimZero();
-        uint256 yield = _yieldAccrued();
+        _accrueGlobalYield();
+        uint256 yield = _donatedYieldAccrued();
         if (yield == 0) revert YieldInsufficient();
         if (yield < amount_) revert YieldInsufficient();
 
         _mint(receiver_, amount_);
         if (this.delegates(receiver_) == address(0)) _delegate(receiver_, receiver_);
+        // The minted claim consumed vault surplus; keep the high-water mark in sync.
+        _getYieldSplitStorage().accountedYield -= amount_;
 
         emit ClaimedYield(amount_);
+    }
+
+    // ============ Yield Split ============
+
+    /// @notice Sets the caller's yield split: the share of their yield they keep for themselves
+    /// @dev Applies from now on — yield attributed before this call keeps the previous split.
+    /// @param keepBps_ Basis points (0–10,000) of the caller's yield share to keep; the rest is donated
+    function setYieldSplit(uint16 keepBps_) external {
+        if (keepBps_ > YIELD_SPLIT_BPS) revert InvalidYieldSplit();
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        _accrueGlobalYield();
+        _settleAndDetach(msg.sender);
+        // Re-baseline so only yield accrued after this change uses the new split.
+        $.index[msg.sender] = $.accYieldPerToken;
+        $.keepBps[msg.sender] = keepBps_;
+        _attach(msg.sender);
+
+        emit YieldSplitSet(msg.sender, keepBps_);
+    }
+
+    /// @notice Returns the share of their yield an account keeps, in bps (0 = donates all)
+    function yieldSplitOf(address account_) external view returns (uint16) {
+        return _getYieldSplitStorage().keepBps[account_];
+    }
+
+    /// @notice Returns an account's kept yield: settled balance plus unsettled share at its current split
+    function keptYieldOf(address account_) external view returns (uint256) {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 kept = $.keptYield[account_];
+        uint256 bps = $.keepBps[account_];
+        if (bps == 0) return kept;
+        uint256 acc = _simulatedAccYieldPerToken();
+        uint256 idx = $.index[account_];
+        if (acc > idx) {
+            kept += balanceOf(account_) * (acc - idx) / YIELD_PRECISION * bps / YIELD_SPLIT_BPS;
+        }
+        return kept;
+    }
+
+    /// @notice Claims the caller's kept yield, minting it as tokens to the receiver
+    /// @param receiver_ Address to receive the minted yield tokens
+    function claimKeptYield(address receiver_) external {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        _accrueGlobalYield();
+        _settleAndDetach(msg.sender);
+        _attach(msg.sender);
+
+        uint256 amount = $.keptYield[msg.sender];
+        if (amount == 0) revert ClaimZero();
+        if (_yieldAccrued() < amount) revert YieldInsufficient();
+        $.keptYield[msg.sender] = 0;
+        $.keptYieldTotal -= amount;
+
+        _mint(receiver_, amount);
+        if (this.delegates(receiver_) == address(0)) _delegate(receiver_, receiver_);
+        // The minted claim consumed vault surplus; keep the high-water mark in sync.
+        $.accountedYield -= amount;
+
+        emit KeptYieldClaimed(msg.sender, receiver_, amount);
     }
 
     /// @notice Sets the initial yield claimer address (one-time only)
@@ -253,9 +362,104 @@ abstract contract AbstractToken is ERC20VotesUpgradeable, Ownable, IToken {
         return true;
     }
 
-    /// @notice Returns the total unclaimed accrued yield
+    /// @notice Returns the unclaimed donated yield — the pool the yield claimer can distribute
+    /// @dev Excludes holders' kept shares (settled and unsettled). Equals the full vault
+    ///      surplus while no holder has set a nonzero yield split.
     function yieldAccrued() external view returns (uint256) {
+        return _donatedYieldAccrued();
+    }
+
+    /// @notice Returns the total unclaimed vault surplus: donated pool plus all kept shares
+    function totalYieldAccrued() external view returns (uint256) {
         return _yieldAccrued();
+    }
+
+    // ============ Yield Split Internals ============
+
+    /// @dev Attributes any fresh vault surplus to current holders via the accumulator.
+    ///      With no holders the surplus stays in the donated pool.
+    function _accrueGlobalYield() internal {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 raw = _yieldAccrued();
+        uint256 accounted = $.accountedYield;
+        if (raw <= accounted) return;
+        uint256 supply = totalSupply();
+        if (supply > 0) {
+            $.accYieldPerToken += (raw - accounted) * YIELD_PRECISION / supply;
+        }
+        $.accountedYield = raw;
+    }
+
+    /// @dev The accumulator as if _accrueGlobalYield ran now — lets views stay current
+    ///      without mutating state.
+    function _simulatedAccYieldPerToken() private view returns (uint256 acc) {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        acc = $.accYieldPerToken;
+        uint256 raw = _yieldAccrued();
+        uint256 accounted = $.accountedYield;
+        uint256 supply = totalSupply();
+        if (raw > accounted && supply > 0) {
+            acc += (raw - accounted) * YIELD_PRECISION / supply;
+        }
+    }
+
+    /// @dev Vault surplus minus every holder's kept share (settled and unsettled).
+    ///      The keep-weight aggregates make this O(1): the unsettled kept yield across
+    ///      all holders is (acc * Σbal·bps − Σbal·bps·idx) / precision / bps-scale.
+    function _donatedYieldAccrued() private view returns (uint256) {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 raw = _yieldAccrued();
+        uint256 unsettledKept =
+            (_simulatedAccYieldPerToken() * $.keepWeight - $.keepWeightIndex) / YIELD_PRECISION / YIELD_SPLIT_BPS;
+        uint256 reserved = $.keptYieldTotal + unsettledKept;
+        return raw > reserved ? raw - reserved : 0;
+    }
+
+    /// @dev Credits an account's pending kept yield and removes its terms from the
+    ///      keep-weight aggregates. Callers must _attach again after any balance or
+    ///      split change. No-op for accounts that donate everything (keepBps == 0).
+    function _settleAndDetach(address account_) internal {
+        if (account_ == address(0)) return;
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 bps = $.keepBps[account_];
+        if (bps == 0) return;
+        uint256 balance = balanceOf(account_);
+        uint256 acc = $.accYieldPerToken;
+        uint256 idx = $.index[account_];
+        if (acc > idx) {
+            uint256 kept = balance * (acc - idx) / YIELD_PRECISION * bps / YIELD_SPLIT_BPS;
+            if (kept > 0) {
+                $.keptYield[account_] += kept;
+                $.keptYieldTotal += kept;
+            }
+        }
+        uint256 weight = balance * bps;
+        $.keepWeight -= weight;
+        $.keepWeightIndex -= weight * idx;
+        $.index[account_] = acc;
+    }
+
+    /// @dev Adds an account's current balance/split terms to the keep-weight aggregates.
+    ///      Must mirror a prior _settleAndDetach so each account is counted exactly once.
+    function _attach(address account_) internal {
+        if (account_ == address(0)) return;
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 bps = $.keepBps[account_];
+        if (bps == 0) return;
+        uint256 weight = balanceOf(account_) * bps;
+        $.keepWeight += weight;
+        $.keepWeightIndex += weight * $.index[account_];
+    }
+
+    /// @dev Settles both parties' yield-split accounting around every balance change so
+    ///      each account's kept share reflects its balance over time.
+    function _update(address from_, address to_, uint256 value_) internal virtual override {
+        _accrueGlobalYield();
+        _settleAndDetach(from_);
+        if (to_ != from_) _settleAndDetach(to_);
+        super._update(from_, to_, value_);
+        _attach(from_);
+        if (to_ != from_) _attach(to_);
     }
 
     /// @dev Mints tokens to the receiver and auto-delegates if no delegate is set

--- a/contracts/src/interfaces/IToken.sol
+++ b/contracts/src/interfaces/IToken.sol
@@ -12,4 +12,9 @@ interface IToken is IERC20 {
     function finalizeNewYieldClaimer() external;
     function setYieldClaimer(address yieldClaimer) external;
     function yieldAccrued() external view returns (uint256);
+    function totalYieldAccrued() external view returns (uint256);
+    function setYieldSplit(uint16 keepBps) external;
+    function yieldSplitOf(address account) external view returns (uint16);
+    function keptYieldOf(address account) external view returns (uint256);
+    function claimKeptYield(address receiver) external;
 }

--- a/contracts/test/YieldSplit.t.sol
+++ b/contracts/test/YieldSplit.t.sol
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {AbstractToken} from "../src/abstract/AbstractToken.sol";
+import {StableYield} from "../src/implementation/token/StableYield.sol";
+import {MockUSDC, MockStableVault} from "./StableYield.t.sol";
+
+/// Minimal AbstractToken with simulated vault backing: `assets` moves exactly like the
+/// real implementations' vault positions (deposits/remits move it, yield claims don't),
+/// so raw yield = assets - totalSupply with no rounding — ideal for exact assertions.
+contract HarnessToken is AbstractToken {
+    uint256 public assets;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(string memory name_, string memory symbol_, address owner_) external initializer {
+        __ERC20_init(name_, symbol_);
+        _initializeOwner(owner_);
+    }
+
+    function _deposit(uint256 amount_) internal override {
+        assets += amount_;
+    }
+
+    function _remit(address, uint256 amount_) internal override {
+        assets -= amount_;
+    }
+
+    function _yieldAccrued() internal view override returns (uint256) {
+        uint256 supply = totalSupply();
+        return assets > supply ? assets - supply : 0;
+    }
+
+    function addYield(uint256 amount_) external {
+        assets += amount_;
+    }
+
+    /// Simulates a vault loss event (backing worth less than before).
+    function slashAssets(uint256 amount_) external {
+        assets -= amount_;
+    }
+}
+
+contract YieldSplitTest is Test {
+    HarnessToken token;
+    address claimer = address(0xCAFE);
+    address alice = address(0xA11CE);
+    address bob = address(0xB0B);
+
+    uint16 constant BPS = 10_000;
+
+    function setUp() public {
+        HarnessToken impl = new HarnessToken();
+        bytes memory data = abi.encodeWithSelector(HarnessToken.initialize.selector, "Stake", "STK", address(this));
+        token = HarnessToken(address(new ERC1967Proxy(address(impl), data)));
+        token.setYieldClaimer(claimer);
+    }
+
+    function _mintFor(address who, uint256 amount) internal {
+        vm.prank(who);
+        token.mint(who, amount);
+    }
+
+    /* ------------------------- default behavior ------------------------- */
+
+    function test_DefaultDonatesEverything() public {
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        assertEq(token.yieldAccrued(), 10 ether, "all yield donated by default");
+        assertEq(token.totalYieldAccrued(), 10 ether, "raw surplus");
+        assertEq(token.keptYieldOf(alice), 0, "nothing kept by default");
+
+        vm.prank(claimer);
+        token.claimYield(10 ether, claimer);
+        assertEq(token.balanceOf(claimer), 10 ether, "claimer minted the yield");
+        assertEq(token.yieldAccrued(), 0, "pool drained");
+        assertEq(token.totalYieldAccrued(), 0, "surplus consumed");
+    }
+
+    function test_ClaimYieldStillClaimerGated() public {
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+        vm.prank(alice);
+        vm.expectRevert(AbstractToken.OnlyClaimer.selector);
+        token.claimYield(1 ether, alice);
+    }
+
+    /* --------------------------- setYieldSplit --------------------------- */
+
+    function test_SetYieldSplit_ReadsBackAndEmits() public {
+        vm.prank(alice);
+        vm.expectEmit(true, false, false, true);
+        emit AbstractToken.YieldSplitSet(alice, 2500);
+        token.setYieldSplit(2500);
+        assertEq(token.yieldSplitOf(alice), 2500, "split stored");
+    }
+
+    function test_SetYieldSplit_RevertsAbove100Percent() public {
+        vm.prank(alice);
+        vm.expectRevert(AbstractToken.InvalidYieldSplit.selector);
+        token.setYieldSplit(BPS + 1);
+    }
+
+    function test_SplitAppliesOnlyGoingForward() public {
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        vm.prank(alice);
+        token.setYieldSplit(5000);
+        assertEq(token.keptYieldOf(alice), 0, "past yield stays donated");
+        assertEq(token.yieldAccrued(), 10 ether, "donated pool untouched");
+
+        token.addYield(10 ether);
+        assertEq(token.keptYieldOf(alice), 5 ether, "half of new yield kept");
+        assertEq(token.yieldAccrued(), 15 ether, "old 10 + new donated 5");
+    }
+
+    /* ------------------------- keeping + claiming ------------------------ */
+
+    function test_SingleHolderKeepsHalf() public {
+        vm.prank(alice);
+        token.setYieldSplit(5000);
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        assertEq(token.keptYieldOf(alice), 5 ether, "kept half");
+        assertEq(token.yieldAccrued(), 5 ether, "donated half");
+        assertEq(token.totalYieldAccrued(), 10 ether, "raw is the sum");
+
+        // The claimer cannot touch the kept share.
+        vm.prank(claimer);
+        vm.expectRevert(AbstractToken.YieldInsufficient.selector);
+        token.claimYield(6 ether, claimer);
+
+        vm.prank(claimer);
+        token.claimYield(5 ether, claimer);
+
+        vm.prank(alice);
+        token.claimKeptYield(alice);
+        assertEq(token.balanceOf(alice), 105 ether, "kept yield minted to alice");
+        assertEq(token.keptYieldOf(alice), 0, "kept claimed");
+        assertEq(token.totalYieldAccrued(), 0, "everything consumed");
+
+        vm.prank(alice);
+        vm.expectRevert(AbstractToken.ClaimZero.selector);
+        token.claimKeptYield(alice);
+    }
+
+    function test_ClaimKeptYield_EmitsAndPaysReceiver() public {
+        vm.prank(alice);
+        token.setYieldSplit(BPS);
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        vm.prank(alice);
+        vm.expectEmit(true, false, false, true);
+        emit AbstractToken.KeptYieldClaimed(alice, bob, 10 ether);
+        token.claimKeptYield(bob);
+
+        assertEq(token.balanceOf(bob), 10 ether, "receiver got the tokens");
+        assertEq(token.getVotes(bob), 10 ether, "receiver auto-delegated");
+    }
+
+    function test_TwoHoldersDifferentSplits() public {
+        vm.prank(alice);
+        token.setYieldSplit(BPS); // keeps everything
+        _mintFor(alice, 100 ether); // 25% of supply
+        _mintFor(bob, 300 ether); // donates everything
+
+        token.addYield(40 ether);
+        assertEq(token.keptYieldOf(alice), 10 ether, "alice keeps her quarter");
+        assertEq(token.keptYieldOf(bob), 0, "bob donates");
+        assertEq(token.yieldAccrued(), 30 ether, "bob's share is donated");
+    }
+
+    /* ------------------------ transfers + settling ----------------------- */
+
+    function test_TransferSettlesSender() public {
+        vm.prank(alice);
+        token.setYieldSplit(5000);
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        vm.prank(alice);
+        token.transfer(bob, 100 ether);
+        assertEq(token.keptYieldOf(alice), 5 ether, "pending kept settled on transfer");
+
+        token.addYield(10 ether);
+        assertEq(token.keptYieldOf(alice), 5 ether, "no balance, no new kept yield");
+        assertEq(token.yieldAccrued(), 15 ether, "bob's new yield all donated");
+    }
+
+    function test_TransferToKeeperGrowsTheirShare() public {
+        vm.prank(alice);
+        token.setYieldSplit(BPS);
+        _mintFor(alice, 100 ether);
+        _mintFor(bob, 100 ether);
+
+        token.addYield(10 ether); // alice keeps 5
+        vm.prank(bob);
+        token.transfer(alice, 100 ether); // alice now holds everything
+
+        token.addYield(10 ether); // alice keeps all of it
+        assertEq(token.keptYieldOf(alice), 15 ether, "5 from half + 10 from all");
+        assertEq(token.yieldAccrued(), 5 ether, "only bob's pre-transfer share donated");
+    }
+
+    function test_SelfTransferDoesNotDoubleCount() public {
+        vm.prank(alice);
+        token.setYieldSplit(5000);
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        vm.prank(alice);
+        token.transfer(alice, 40 ether);
+
+        assertEq(token.keptYieldOf(alice), 5 ether, "kept unchanged");
+        assertEq(token.yieldAccrued(), 5 ether, "donated unchanged");
+        token.addYield(10 ether);
+        assertEq(token.keptYieldOf(alice), 10 ether, "accounting still healthy");
+    }
+
+    function test_MintAfterYieldGetsNoRetroactiveShare() public {
+        _mintFor(bob, 100 ether);
+        token.addYield(10 ether);
+
+        vm.prank(alice);
+        token.setYieldSplit(BPS);
+        _mintFor(alice, 100 ether);
+        assertEq(token.keptYieldOf(alice), 0, "no share of prior yield");
+
+        token.addYield(10 ether);
+        assertEq(token.keptYieldOf(alice), 5 ether, "half of new yield only");
+        assertEq(token.yieldAccrued(), 15 ether, "prior 10 + bob's 5");
+    }
+
+    /* -------------------------- changing splits -------------------------- */
+
+    function test_ChangeSplitSettlesAtOldRate() public {
+        vm.prank(alice);
+        token.setYieldSplit(BPS);
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        vm.prank(alice);
+        token.setYieldSplit(0); // stop keeping
+        assertEq(token.keptYieldOf(alice), 10 ether, "pre-change yield kept at old split");
+
+        token.addYield(10 ether);
+        assertEq(token.keptYieldOf(alice), 10 ether, "new yield donated");
+        assertEq(token.yieldAccrued(), 10 ether, "new yield in the pool");
+    }
+
+    /* ----------------------------- burning ------------------------------- */
+
+    function test_BurnSettlesAndKeptSurvivesExit() public {
+        vm.prank(alice);
+        token.setYieldSplit(5000);
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        vm.prank(alice);
+        token.burn(100 ether, alice);
+        assertEq(token.balanceOf(alice), 0, "fully exited");
+        assertEq(token.keptYieldOf(alice), 5 ether, "kept yield survives exit");
+
+        vm.prank(alice);
+        token.claimKeptYield(alice);
+        assertEq(token.balanceOf(alice), 5 ether, "claimed after exit");
+        assertEq(token.yieldAccrued(), 5 ether, "donated half still claimable");
+    }
+
+    /* ------------------------- adversarial cases ------------------------- */
+
+    function test_TransferFromSettlesLikeTransfer() public {
+        vm.prank(alice);
+        token.setYieldSplit(5000);
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        vm.prank(alice);
+        token.approve(bob, 100 ether);
+        vm.prank(bob);
+        token.transferFrom(alice, bob, 100 ether);
+
+        assertEq(token.keptYieldOf(alice), 5 ether, "settled through transferFrom");
+        token.addYield(10 ether);
+        assertEq(token.keptYieldOf(alice), 5 ether, "no balance, no new kept");
+        assertEq(token.yieldAccrued(), 15 ether, "aggregates stayed consistent");
+    }
+
+    function test_ZeroValueTransferKeepsAggregatesIntact() public {
+        vm.prank(alice);
+        token.setYieldSplit(5000);
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+
+        vm.prank(alice);
+        token.transfer(bob, 0);
+
+        assertEq(token.keptYieldOf(alice), 5 ether, "kept intact");
+        assertEq(token.yieldAccrued(), 5 ether, "donated intact");
+        token.addYield(10 ether);
+        assertEq(token.keptYieldOf(alice), 10 ether, "accrual still works");
+    }
+
+    /// The donated pool pre-counts keepers' unsettled donated halves; make sure a
+    /// full manager claim followed by a late settlement can't double-spend them.
+    function test_ManagerClaimThenLateSettleCannotDoubleSpend() public {
+        vm.prank(alice);
+        token.setYieldSplit(5000);
+        _mintFor(alice, 100 ether);
+        _mintFor(bob, 100 ether);
+        token.addYield(20 ether); // alice: 5 kept / 5 donated; bob: 10 donated
+
+        vm.prank(claimer);
+        token.claimYield(15 ether, claimer); // drains the whole donated pool
+
+        // Alice settles only now (first touch since the yield event)...
+        vm.prank(alice);
+        token.transfer(alice, 0);
+        // ...and her settlement must not conjure new donated yield.
+        assertEq(token.yieldAccrued(), 0, "no donated yield re-appears");
+        assertEq(token.keptYieldOf(alice), 5 ether, "her kept share is intact");
+
+        vm.prank(alice);
+        token.claimKeptYield(alice);
+        assertEq(token.totalYieldAccrued(), 0, "fully consumed, nothing double-spent");
+    }
+
+    /// Accrual runs before balances change, so a just-in-time deposit cannot
+    /// capture yield that arrived before it — even at a 100% keep split.
+    function test_JitDepositCannotCaptureEarlierYield() public {
+        _mintFor(bob, 100 ether);
+        token.addYield(10 ether); // arrives while bob is the only holder
+
+        vm.startPrank(alice);
+        token.setYieldSplit(BPS);
+        token.mint(alice, 900 ether); // 90% of supply, right after the yield
+        vm.stopPrank();
+
+        assertEq(token.keptYieldOf(alice), 0, "nothing captured retroactively");
+        assertEq(token.yieldAccrued(), 10 ether, "prior yield fully donated");
+    }
+
+    function test_VaultLossFreezesKeptClaimsUntilRecovery() public {
+        vm.prank(alice);
+        token.setYieldSplit(BPS);
+        _mintFor(alice, 100 ether);
+        token.addYield(10 ether);
+        vm.prank(alice);
+        token.transfer(alice, 0); // settle the 10 into her kept balance
+
+        token.slashAssets(105 ether); // deep loss: surplus now 5 < kept 10
+
+        assertEq(token.yieldAccrued(), 0, "donated pool clamps to zero");
+        vm.prank(alice);
+        vm.expectRevert(AbstractToken.YieldInsufficient.selector);
+        token.claimKeptYield(alice); // unbacked mint is refused
+
+        token.addYield(105 ether); // vault recovers
+        vm.prank(alice);
+        token.claimKeptYield(alice);
+        assertEq(token.balanceOf(alice), 110 ether, "kept share survives the loss");
+    }
+
+    function test_RepeatedClaimsAcrossYieldEvents() public {
+        vm.prank(alice);
+        token.setYieldSplit(5000);
+        _mintFor(alice, 100 ether);
+
+        token.addYield(10 ether);
+        vm.prank(alice);
+        token.claimKeptYield(alice); // +5
+
+        token.addYield(21 ether); // alice now holds 105 of 105 supply
+        assertEq(token.keptYieldOf(alice), 10.5 ether, "full share of second event");
+        vm.prank(alice);
+        token.claimKeptYield(alice);
+        assertEq(token.balanceOf(alice), 115.5 ether, "both claims minted");
+
+        vm.prank(claimer);
+        token.claimYield(15.5 ether, claimer); // 5 + 10.5 donated
+        assertEq(token.totalYieldAccrued(), 0, "conserved across repeated claims");
+    }
+
+    /* --------------------------- conservation ---------------------------- */
+
+    function testFuzz_KeptPlusDonatedNeverExceedRaw(uint16 bpsA, uint16 bpsB, uint96 y1, uint96 y2, uint96 moved)
+        public
+    {
+        bpsA = uint16(bound(bpsA, 0, BPS));
+        bpsB = uint16(bound(bpsB, 0, BPS));
+        y1 = uint96(bound(y1, 0, 1_000_000 ether));
+        y2 = uint96(bound(y2, 0, 1_000_000 ether));
+        moved = uint96(bound(moved, 0, 100 ether));
+
+        vm.prank(alice);
+        token.setYieldSplit(bpsA);
+        vm.prank(bob);
+        token.setYieldSplit(bpsB);
+        _mintFor(alice, 100 ether);
+        _mintFor(bob, 200 ether);
+
+        token.addYield(y1);
+        if (moved > 0) {
+            vm.prank(alice);
+            token.transfer(bob, moved);
+        }
+        token.addYield(y2);
+
+        uint256 raw = token.totalYieldAccrued();
+        uint256 attributed = token.keptYieldOf(alice) + token.keptYieldOf(bob) + token.yieldAccrued();
+        assertLe(attributed, raw, "attribution never exceeds the vault surplus");
+        // Truncation dust always lands in the donated pool; a couple of floor
+        // divisions per settlement bound it to a handful of wei.
+        assertApproxEqAbs(attributed, raw, 10, "nothing material leaks");
+
+        // Everyone can actually exit with their full attribution.
+        uint256 donated = token.yieldAccrued();
+        if (donated > 0) {
+            vm.prank(claimer);
+            token.claimYield(donated, claimer);
+        }
+        if (token.keptYieldOf(alice) > 0) {
+            vm.prank(alice);
+            token.claimKeptYield(alice);
+        }
+        if (token.keptYieldOf(bob) > 0) {
+            vm.prank(bob);
+            token.claimKeptYield(bob);
+        }
+        assertLe(token.totalYieldAccrued(), 10, "only dust remains");
+    }
+
+    function testFuzz_SplitMatchesProRataShare(uint16 keep, uint96 yieldAmount) public {
+        keep = uint16(bound(keep, 0, BPS));
+        yieldAmount = uint96(bound(yieldAmount, 0, 1_000_000 ether));
+
+        vm.prank(alice);
+        token.setYieldSplit(keep);
+        _mintFor(alice, 400 ether); // 40% of supply
+        _mintFor(bob, 600 ether);
+
+        token.addYield(yieldAmount);
+
+        uint256 aliceShare = (uint256(yieldAmount) * 400) / 1000;
+        uint256 expectedKept = (aliceShare * keep) / BPS;
+        assertApproxEqAbs(token.keptYieldOf(alice), expectedKept, 2, "kept = share * split");
+        assertApproxEqAbs(token.yieldAccrued(), yieldAmount - expectedKept, 2, "donated = rest");
+    }
+}
+
+/// End-to-end sanity on a real token implementation (StableYield + ERC-4626-style
+/// vault with 6-decimal underlying), exercising the same yield-split surface.
+contract YieldSplitStableYieldTest is Test {
+    MockUSDC usdc;
+    MockStableVault vault;
+    StableYield token;
+    address claimer = address(0xCAFE);
+    address user = address(0xBEEF);
+
+    uint256 constant ONE = 1e6;
+
+    function setUp() public {
+        usdc = new MockUSDC();
+        vault = new MockStableVault(address(usdc));
+        StableYield impl = new StableYield(address(usdc), address(vault));
+        bytes memory data = abi.encodeWithSelector(StableYield.initialize.selector, "Stake", "STK", address(this));
+        token = StableYield(payable(address(new ERC1967Proxy(address(impl), data))));
+        token.setYieldClaimer(claimer);
+        usdc.mintTo(user, 1_000 * ONE);
+    }
+
+    function test_KeepSplitOnRealImplementation() public {
+        vm.startPrank(user);
+        token.setYieldSplit(4000); // keep 40%
+        usdc.approve(address(token), 100 * ONE);
+        token.mint(user, 100 * ONE);
+        vm.stopPrank();
+
+        vault.setRateBps(10_500); // +5% → 5 USDC of yield
+        usdc.mintTo(address(vault), 5 * ONE); // back the appreciation with real USDC
+        assertEq(token.totalYieldAccrued(), 5 * ONE, "raw surplus");
+        assertEq(token.keptYieldOf(user), 2 * ONE, "40% kept");
+        assertEq(token.yieldAccrued(), 3 * ONE, "60% donated");
+
+        vm.prank(user);
+        token.claimKeptYield(user);
+        assertEq(token.balanceOf(user), 102 * ONE, "kept yield minted");
+
+        vm.prank(claimer);
+        token.claimYield(3 * ONE, claimer);
+        assertEq(token.balanceOf(claimer), 3 * ONE, "donated pool distributed");
+        assertEq(token.yieldAccrued(), 0, "drained");
+
+        // Withdrawing principal + kept yield redeems 1:1 for the underlying.
+        vm.prank(user);
+        token.burn(102 * ONE, user);
+        assertEq(usdc.balanceOf(user), 1_002 * ONE, "principal + kept yield redeemed");
+    }
+}

--- a/src/app/app/deposit/page.tsx
+++ b/src/app/app/deposit/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useAccount } from "wagmi";
 import { Body, Caption } from "@breadcoop/ui";
 import { Card, PageHeader } from "@/components/dapp/ui";
 import { AmountField } from "@/components/dapp/amount-field";
@@ -17,6 +19,7 @@ import {
   useNativeBalance,
   useTokenBalance,
   useWrapped,
+  useYieldSplit,
 } from "@/hooks/use-token";
 
 export default function DepositPage() {
@@ -162,6 +165,25 @@ function DepositForm() {
           {fmt(stake.data)} {symbol}
         </span>
       </Body>
+
+      <YieldSplitHint />
     </Card>
+  );
+}
+
+/** Reminds depositors of their current yield split, when the token supports it. */
+function YieldSplitHint() {
+  const { keepBps, supported } = useYieldSplit();
+  const { isConnected } = useAccount();
+  if (!supported || !isConnected || keepBps === undefined) return null;
+  const give = 100 - keepBps / 100;
+  return (
+    <Caption className="text-surface-grey mt-2 block">
+      Yield split: you give {give}% of your yield to recipients
+      {keepBps > 0 ? ` and keep ${100 - give}%` : ""} —{" "}
+      <Link href="/app/yield" className="text-core-orange underline">
+        adjust
+      </Link>
+    </Caption>
   );
 }

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -129,6 +129,9 @@ export default function PortfolioPage() {
         >
           Deposit
         </Button>
+        <Button app="fund" variant="secondary" as={Link} href="/app/yield">
+          Yield split
+        </Button>
         <Button app="fund" variant="secondary" as={Link} href="/app/vote">
           Vote
         </Button>

--- a/src/app/app/yield/page.tsx
+++ b/src/app/app/yield/page.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Body, Caption } from "@breadcoop/ui";
+import { Card, PageHeader } from "@/components/dapp/ui";
+import { ActionButton } from "@/components/dapp/action-button";
+import { TxStatus } from "@/components/dapp/tx-status";
+import { cn } from "@/lib/utils";
+import { useAmountFormatter } from "@/components/demo-mode-provider";
+import { useBaseAssetSymbol } from "@/hooks/use-chain";
+import {
+  useClaimKeptYield,
+  useInstanceToken,
+  useKeptYield,
+  useSetYieldSplit,
+  useTokenBalance,
+  useYieldSplit,
+} from "@/hooks/use-token";
+
+const GIVE_PRESETS = [100, 75, 50, 25, 0] as const;
+
+export default function YieldPage() {
+  return (
+    <div className="mx-auto max-w-lg">
+      <PageHeader
+        title="Yield split"
+        subtitle="Choose how much of the yield your stake earns goes to the community's recipients and how much you keep for yourself."
+      />
+      <SplitForm />
+      <KeptYieldCard />
+    </div>
+  );
+}
+
+function SplitForm() {
+  const { keepBps, supported, refetch } = useYieldSplit();
+  const { setSplit, ...tx } = useSetYieldSplit();
+  // The slider anchors on the on-chain split until the user drags it.
+  const [draftGive, setDraftGive] = useState<number | null>(null);
+
+  const chainGive = keepBps !== undefined ? 100 - keepBps / 100 : 100;
+  const give = draftGive ?? chainGive;
+  const keep = 100 - give;
+  const dirty = draftGive !== null && draftGive !== chainGive;
+
+  useEffect(() => {
+    if (tx.isSuccess) {
+      void refetch();
+      setDraftGive(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tx.isSuccess]);
+
+  if (supported === false) {
+    return (
+      <Card>
+        <Body className="text-surface-grey-2">
+          This instance&apos;s token predates yield splitting — all yield goes
+          to the community pool. A token upgrade is required to enable
+          per-staker splits.
+        </Body>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div className="flex items-baseline justify-between">
+        <Caption className="text-surface-grey-2">Give to recipients</Caption>
+        <span className="font-breadDisplay text-text-standard text-2xl font-bold">
+          {give}%
+        </span>
+      </div>
+
+      {/* Proportion bar: orange = given, grey = kept. */}
+      <div className="bg-paper-2 mt-3 flex h-3 w-full overflow-hidden rounded-full">
+        <div
+          className="bg-core-orange h-full transition-all"
+          style={{ width: `${give}%` }}
+        />
+      </div>
+
+      <input
+        type="range"
+        min={0}
+        max={100}
+        step={1}
+        value={give}
+        onChange={(e) => setDraftGive(Number(e.target.value))}
+        aria-label="Share of your yield given to recipients, percent"
+        aria-valuetext={`Give ${give} percent, keep ${keep} percent`}
+        className="bg-paper-2 accent-core-orange mt-4 h-2 w-full cursor-pointer appearance-none rounded-full"
+      />
+
+      <div className="mt-3 flex gap-2">
+        {GIVE_PRESETS.map((p) => (
+          <button
+            key={p}
+            onClick={() => setDraftGive(p)}
+            className={cn(
+              "rounded-lg border px-3 py-1.5 text-xs font-semibold transition-colors",
+              give === p
+                ? "border-core-orange bg-core-orange text-white"
+                : "border-paper-2 text-surface-grey-2 hover:text-text-standard",
+            )}
+          >
+            {p === 100 ? "Give all" : p === 0 ? "Keep all" : `${p}%`}
+          </button>
+        ))}
+      </div>
+
+      <div className="bg-paper-1 mt-4 flex items-center justify-between rounded-xl px-4 py-3">
+        <Caption className="text-surface-grey-2">You keep</Caption>
+        <span className="font-breadDisplay text-text-standard font-bold">
+          {keep}% of your yield
+        </span>
+      </div>
+
+      <div className="mt-6">
+        <ActionButton
+          isLoading={tx.isBusy}
+          disabled={!dirty || supported === undefined}
+          onClick={() => setSplit((100 - give) * 100)}
+        >
+          Update split
+        </ActionButton>
+      </div>
+
+      <TxStatus
+        status={tx.status}
+        hash={tx.hash}
+        error={tx.error}
+        successLabel="Split updated"
+      />
+
+      <Body className="text-surface-grey mt-6 text-sm">
+        Applies from now on — yield already earned keeps your previous split.
+        Your voting power and withdrawable principal are unaffected.
+      </Body>
+    </Card>
+  );
+}
+
+function KeptYieldCard() {
+  const { symbol } = useInstanceToken();
+  const baseSym = useBaseAssetSymbol();
+  const { supported } = useYieldSplit();
+  const kept = useKeptYield();
+  const balance = useTokenBalance();
+  const { claim, ...tx } = useClaimKeptYield();
+  const fmt = useAmountFormatter();
+
+  useEffect(() => {
+    if (tx.isSuccess) {
+      void kept.refetch();
+      void balance.refetch();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tx.isSuccess]);
+
+  if (supported === false) return null;
+
+  return (
+    <Card className="mt-6">
+      <Caption className="text-surface-grey-2">Your kept yield</Caption>
+      <div className="font-breadDisplay text-text-standard mt-1 text-3xl font-bold">
+        {fmt(kept.data)} {symbol}
+      </div>
+
+      <div className="mt-6">
+        <ActionButton
+          isLoading={tx.isBusy}
+          disabled={!kept.data}
+          onClick={() => claim()}
+        >
+          Claim to wallet
+        </ActionButton>
+      </div>
+
+      <TxStatus
+        status={tx.status}
+        hash={tx.hash}
+        error={tx.error}
+        successLabel="Yield claimed"
+      />
+
+      <Body className="text-surface-grey mt-6 text-sm">
+        Claiming mints your kept yield as {symbol}, redeemable 1:1 for {baseSym}{" "}
+        on the withdraw page.
+      </Body>
+    </Card>
+  );
+}

--- a/src/components/dapp/dapp-nav.tsx
+++ b/src/components/dapp/dapp-nav.tsx
@@ -31,6 +31,7 @@ const LINKS = [
   { href: "/app", label: "Portfolio" },
   { href: "/app/deposit", label: "Deposit" },
   { href: "/app/withdraw", label: "Withdraw" },
+  { href: "/app/yield", label: "Yield" },
   { href: "/app/vote", label: "Vote" },
   { href: "/app/distribute", label: "Distribute" },
   { href: "/app/history", label: "History" },

--- a/src/hooks/use-token.ts
+++ b/src/hooks/use-token.ts
@@ -88,6 +88,53 @@ export function useTokenStats() {
   };
 }
 
+/**
+ * The share of their yield an account keeps (bps, 0 = donates all), plus
+ * whether the instance's token supports yield splits at all — deployments
+ * that predate the feature revert on the read, so `supported` doubles as
+ * feature detection. Probes with the zero address before a wallet connects.
+ */
+export function useYieldSplit(account?: Address) {
+  const a = useInstance();
+  const chainId = useActiveChainId();
+  const { address } = useAccount();
+  const owner = account ?? address;
+  const read = useReadContract({
+    address: a.token,
+    abi: tokenAbi,
+    functionName: "yieldSplitOf",
+    args: [owner ?? zeroAddress],
+    chainId,
+    query: { retry: false },
+  });
+  return {
+    keepBps: read.data as number | undefined,
+    supported: read.isError
+      ? false
+      : read.data !== undefined
+        ? true
+        : undefined,
+    isLoading: read.isLoading,
+    refetch: read.refetch,
+  };
+}
+
+/** An account's claimable kept yield (settled + still-accruing share). */
+export function useKeptYield(account?: Address) {
+  const a = useInstance();
+  const chainId = useActiveChainId();
+  const { address } = useAccount();
+  const owner = account ?? address;
+  return useReadContract({
+    address: a.token,
+    abi: tokenAbi,
+    functionName: "keptYieldOf",
+    args: owner ? [owner] : undefined,
+    chainId,
+    query: { enabled: Boolean(owner), retry: false, ...LIVE },
+  });
+}
+
 export function useVotes(account?: Address) {
   const a = useInstance();
   const chainId = useActiveChainId();
@@ -223,6 +270,35 @@ export function useWithdraw() {
       args: [amount, receiver ?? address ?? zeroAddress],
     });
   return { withdraw, ...tx };
+}
+
+/** Update the caller's yield split: keepBps of their yield share is kept, the rest donated. */
+export function useSetYieldSplit() {
+  const a = useInstance();
+  const tx = useTx();
+  const setSplit = (keepBps: number) =>
+    tx.run({
+      address: a.token,
+      abi: tokenAbi,
+      functionName: "setYieldSplit",
+      args: [keepBps],
+    });
+  return { setSplit, ...tx };
+}
+
+/** Claim the caller's kept yield, minted as the project token to `receiver`. */
+export function useClaimKeptYield() {
+  const a = useInstance();
+  const { address } = useAccount();
+  const tx = useTx();
+  const claim = (receiver?: Address) =>
+    tx.run({
+      address: a.token,
+      abi: tokenAbi,
+      functionName: "claimKeptYield",
+      args: [receiver ?? address ?? zeroAddress],
+    });
+  return { claim, ...tx };
 }
 
 /** Manually (re)delegate voting power to an address (self by default). */

--- a/src/lib/abis/token.ts
+++ b/src/lib/abis/token.ts
@@ -30,6 +30,13 @@ export const tokenAbi = [
   },
   {
     type: "function",
+    name: "YIELD_SPLIT_BPS",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "allowance",
     inputs: [
       { name: "owner", type: "address", internalType: "address" },
@@ -91,6 +98,13 @@ export const tokenAbi = [
       },
     ],
     stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "claimKeptYield",
+    inputs: [{ name: "receiver_", type: "address", internalType: "address" }],
+    outputs: [],
+    stateMutability: "nonpayable",
   },
   {
     type: "function",
@@ -212,6 +226,13 @@ export const tokenAbi = [
   },
   {
     type: "function",
+    name: "keptYieldOf",
+    inputs: [{ name: "account_", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "mint",
     inputs: [
       { name: "receiver_", type: "address", internalType: "address" },
@@ -322,6 +343,13 @@ export const tokenAbi = [
   },
   {
     type: "function",
+    name: "setYieldSplit",
+    inputs: [{ name: "keepBps_", type: "uint16", internalType: "uint16" }],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
     name: "symbol",
     inputs: [],
     outputs: [{ name: "", type: "string", internalType: "string" }],
@@ -330,6 +358,13 @@ export const tokenAbi = [
   {
     type: "function",
     name: "totalSupply",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "totalYieldAccrued",
     inputs: [],
     outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
     stateMutability: "view",
@@ -374,6 +409,13 @@ export const tokenAbi = [
     name: "yieldClaimer",
     inputs: [],
     outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "yieldSplitOf",
+    inputs: [{ name: "account_", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "uint16", internalType: "uint16" }],
     stateMutability: "view",
   },
   {
@@ -499,6 +541,31 @@ export const tokenAbi = [
   },
   {
     type: "event",
+    name: "KeptYieldClaimed",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "receiver",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+      {
+        name: "amount",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
     name: "Minted",
     inputs: [
       {
@@ -602,6 +669,25 @@ export const tokenAbi = [
     ],
     anonymous: false,
   },
+  {
+    type: "event",
+    name: "YieldSplitSet",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "keepBps",
+        type: "uint16",
+        indexed: false,
+        internalType: "uint16",
+      },
+    ],
+    anonymous: false,
+  },
   { type: "error", name: "AlreadyInitialized", inputs: [] },
   { type: "error", name: "AlreadySetClaimer", inputs: [] },
   { type: "error", name: "BurnZero", inputs: [] },
@@ -682,6 +768,7 @@ export const tokenAbi = [
     ],
   },
   { type: "error", name: "InvalidInitialization", inputs: [] },
+  { type: "error", name: "InvalidYieldSplit", inputs: [] },
   { type: "error", name: "IsCollateral", inputs: [] },
   { type: "error", name: "MintZero", inputs: [] },
   { type: "error", name: "NativeTransferFailed", inputs: [] },


### PR DESCRIPTION
## Summary

- Adds per-staker yield split to `AbstractToken` via a 1e27-scaled accumulator and EIP-7201 namespaced storage — zero changes to `SexyDaiYield`, `StableYield`, managers, strategies, or the deployer. Each staker calls `setYieldSplit(keepBps)` to choose what fraction of their yield share to keep; `yieldAccrued()` now returns the donated pool only, so all existing distribution logic works unchanged.
- Adds `claimKeptYield(receiver)`, `keptYieldOf(address)`, `totalYieldAccrued()`, and `yieldSplitOf(address)` to both `AbstractToken` and `IToken`; 23 new Foundry tests cover default behavior, split changes, transfers, adversarial double-spend and JIT-deposit attacks, fuzz invariants, and a full StableYield integration test (408 tests total, 0 failures).
- Adds a `/app/yield` page with a give/keep slider, proportion bar, and preset buttons; a "Your kept yield" claim card; a "Yield" nav link; a portfolio quick-action; and a deposit-page hint showing the current split. Feature-detects old token deployments (pre-upgrade instances show an explanatory card rather than broken controls).

## Test plan

- [ ] `forge test` — 408 tests pass
- [ ] `pnpm build` — 15/15 static pages including `/app/yield`
- [ ] `pnpm lint && pnpm format:check` — clean
- [ ] On a deployed instance: connect wallet, set a non-zero split, confirm `YieldSplitSet` event, verify deposit hint updates
- [ ] On an old (pre-upgrade) deployment: confirm `/app/yield` shows the "upgrade required" card and the deposit hint is hidden