### PR TITLE
Trim landing sections, move calculator down; fix deploy Connect stuck on authenticated Privy

### DIFF
--- a/src/components/_home/landing-page.tsx
+++ b/src/components/_home/landing-page.tsx
@@ -7,17 +7,9 @@ import {
   Chip,
   Heading2,
   Heading3,
-  Heading4,
   Logo,
 } from "@breadcoop/ui";
-import {
-  ArrowRight,
-  CheckCircle,
-  Coins,
-  ShieldCheck,
-  Target,
-  TrendUp,
-} from "@phosphor-icons/react/dist/ssr";
+import { ArrowRight, CheckCircle } from "@phosphor-icons/react/dist/ssr";
 import { FundingCalculator } from "@/components/_home/funding-calculator";
 import { HowItWorks } from "@/components/_home/how-it-works";
 import { YieldEngine } from "@/components/_home/yield-engine";
@@ -32,12 +24,11 @@ export function LandingPage() {
       <SiteNav />
       <main>
         <Hero />
-        <KeyConcepts />
-        <Features />
         <UnderTheHood />
         <YieldSliceExplainer />
         <HowItWorks />
         <YieldEngine />
+        <CalculatorSection />
         <GetStarted />
         <CtaBand />
       </main>
@@ -59,7 +50,6 @@ function SiteNav() {
           </span>
         </a>
         <div className="hidden items-center gap-8 md:flex">
-          <NavLink href="#features">Features</NavLink>
           <NavLink href="#how-it-works">How it Works</NavLink>
           <NavLink href="#get-started">Get Started</NavLink>
         </div>
@@ -99,22 +89,22 @@ function Hero() {
   return (
     <section
       id="top"
-      className="section-container grid gap-12 py-20 lg:grid-cols-2 lg:py-28"
+      className="section-container py-20 lg:py-28"
     >
-      <div className="flex flex-col justify-center">
+      <div className="mx-auto flex max-w-2xl flex-col justify-center text-center">
         <h1 className="font-breadDisplay text-core-orange text-6xl leading-[1.04] font-extrabold tracking-tight break-words sm:text-7xl">
           Crowdstaking
         </h1>
         <Heading2 className="text-primary-jade mt-2 italic">
           Turning shared funds into shared futures.
         </Heading2>
-        <Body className="text-surface-grey-2 mt-6 max-w-xl text-lg">
+        <Body className="text-surface-grey-2 mx-auto mt-6 max-w-xl text-lg">
           Crowdstaking transforms any pool of money into an interest-generating
           engine to fund your group&apos;s shared goals. Your deposited funds
           remain safely staked and fully withdrawable — only the interest gets
           allocated.
         </Body>
-        <div className="mt-8 flex flex-wrap gap-4">
+        <div className="mt-8 flex flex-wrap justify-center gap-4">
           <Button
             app="fund"
             variant="primary"
@@ -128,7 +118,7 @@ function Hero() {
             Launch App
           </Button>
         </div>
-        <ul className="mt-8 flex flex-wrap gap-x-6 gap-y-2">
+        <ul className="mt-8 flex flex-wrap justify-center gap-x-6 gap-y-2">
           {[
             "Open source protocol",
             "Fully customizable",
@@ -145,112 +135,17 @@ function Hero() {
           ))}
         </ul>
       </div>
-      <div className="flex items-center">
+    </section>
+  );
+}
+
+/* ---------------------------- Calculator --------------------------------- */
+
+function CalculatorSection() {
+  return (
+    <section id="calculator" className="bg-paper-1 py-20">
+      <div className="section-container flex justify-center">
         <FundingCalculator />
-      </div>
-    </section>
-  );
-}
-
-/* ---------------------- Key Concepts & Design Principles ------------------ */
-
-function KeyConcepts() {
-  return (
-    <section id="concepts" className="bg-paper-1 py-20">
-      <div className="section-container">
-        <Heading2 className="text-text-standard text-center">
-          Fund what&apos;s meaningful to you
-        </Heading2>
-        <div className="mt-12 grid gap-12 md:grid-cols-2">
-          <div>
-            <Heading3 className="text-core-orange">Key Concepts</Heading3>
-            <div className="mt-6 space-y-6">
-              <Concept
-                title="Interest Distribution"
-                body="The protocol accumulates interest and distributes it to each user."
-              />
-              <Concept
-                title="Cycle-Based Operations"
-                body="The system operates in fixed-length cycles (measured in blocks), providing predictable distribution schedules while allowing for regular reallocation of resources."
-              />
-            </div>
-          </div>
-          <div>
-            <Heading3 className="text-primary-jade">Design Principles</Heading3>
-            <div className="mt-6 space-y-6">
-              <Concept
-                title="Accessibility"
-                body="Any community can deploy and customize their own instance."
-              />
-              <Concept
-                title="Decentralization"
-                body="No single entity controls interest distribution."
-              />
-              <Concept
-                title="Flexibility"
-                body="Support for adding/removing interest recipients and adjusting parameters."
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function Concept({ title, body }: { title: string; body: string }) {
-  return (
-    <div>
-      <Heading4 className="text-text-standard">{title}</Heading4>
-      <Body className="text-surface-grey-2 mt-1">{body}</Body>
-    </div>
-  );
-}
-
-/* ------------------------------- Features -------------------------------- */
-
-const FEATURES = [
-  {
-    icon: Coins,
-    title: "Automated Yield Generation",
-    body: "Community members deposit funds to generate interest on the principal.",
-  },
-  {
-    icon: ShieldCheck,
-    title: "White-Label Ready",
-    body: "Deploy with your organization's branding and customize the interface to match your community's needs.",
-  },
-  {
-    icon: TrendUp,
-    title: "Interest Optimization",
-    body: "Advanced strategies automatically rebalance funds across DeFi protocols to maximize community returns.",
-  },
-  {
-    icon: Target,
-    title: "Project Tracking",
-    body: "Monitor funded projects with milestone-based payments and transparent progress reporting.",
-  },
-];
-
-function Features() {
-  return (
-    <section id="features" className="py-20">
-      <div className="section-container">
-        <Heading2 className="text-text-standard text-center">Features</Heading2>
-        <div className="mt-12 grid gap-6 sm:grid-cols-2">
-          {FEATURES.map(({ icon: Icon, title, body }) => (
-            <div
-              key={title}
-              className="border-paper-2 bg-paper-0 rounded-2xl border p-6 transition-shadow hover:shadow-lg"
-            >
-              <div className="bg-core-orange/10 flex h-12 w-12 items-center justify-center rounded-xl">
-                <Icon size={24} weight="bold" className="text-core-orange" />
-              </div>
-              <Heading4 className="text-text-standard mt-4">{title}</Heading4>
-              <Body className="text-surface-grey-2 mt-2">{body}</Body>
-            </div>
-          ))}
-        </div>
       </div>
     </section>
   );
@@ -298,7 +193,7 @@ function GetStarted() {
             timeline="24-48 hours"
             technical="None required"
           >
-            <Button app="fund" variant="primary" as="a" href="#get-started">
+            <Button app="fund" variant="primary" as={Link} href="/app/deploy">
               Start Quick Deploy
             </Button>
           </DeployCard>

--- a/src/components/_home/yield-slice-explainer.tsx
+++ b/src/components/_home/yield-slice-explainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Body, Caption, Chip, Heading2, Heading4 } from "@breadcoop/ui";
+import { Body, Caption, Chip, Heading4 } from "@breadcoop/ui";
 import {
   ArrowRight,
   ArrowsClockwise,
@@ -114,10 +114,7 @@ export function YieldSliceExplainer() {
               How the mechanism works
             </Chip>
           </div>
-          <Heading2 className="text-text-standard mt-4">
-            Where the funding comes from
-          </Heading2>
-          <Body className="text-surface-grey-2 mx-auto mt-4 text-lg">
+          <Body className="text-surface-grey-2 mx-auto mt-6 text-lg">
             Your savings do the work while staying yours. Here&apos;s how a
             slice of yield — and only the yield — turns into funding for your
             community.

--- a/src/components/wallet/privy-wallet-actions.tsx
+++ b/src/components/wallet/privy-wallet-actions.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useCallback, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, type ReactNode } from "react";
 import { encodeFunctionData, numberToHex, type Hex } from "viem";
 import { useAccount } from "wagmi";
+import { useSetActiveWallet } from "@privy-io/wagmi";
 import {
   useLogin,
   usePrivy,
   useSendTransaction,
   useWallets,
+  type ConnectedWallet,
 } from "@privy-io/react-auth";
 import {
   WalletActionsContext,
@@ -27,11 +29,41 @@ import {
  */
 export function PrivyWalletActions({ children }: { children: ReactNode }) {
   const { login } = useLogin();
-  const { logout } = usePrivy();
+  const { ready, authenticated, logout } = usePrivy();
   const { wallets } = useWallets();
+  const { setActiveWallet } = useSetActiveWallet();
   const { sendTransaction } = useSendTransaction();
-  const { address } = useAccount();
+  const { address, isConnected } = useAccount();
   const selfPaidWrite = useWalletWrite();
+
+  /**
+   * Prefer the embedded (sponsorable) wallet, else the first connected one.
+   * `wallets` can be briefly empty right after login while the embedded wallet
+   * provisions, so callers must tolerate `undefined`.
+   */
+  const preferredWallet = useCallback((): ConnectedWallet | undefined => {
+    return (
+      wallets.find((w) => w.walletClientType === "privy") ?? wallets[0]
+    );
+  }, [wallets]);
+
+  /**
+   * Bridge the authenticated Privy wallet into wagmi. Privy auth alone does NOT
+   * make wagmi `isConnected` — without this the UI stays on "Connect" forever
+   * and re-clicking calls `login()` on an already-authenticated user (a no-op
+   * that throws "use a `link` helper instead"). Runs once per wallet: a ref
+   * guards against re-entering while `setActiveWallet` is in flight.
+   */
+  const bridging = useRef<string | null>(null);
+  useEffect(() => {
+    if (!ready || !authenticated || isConnected) return;
+    const wallet = preferredWallet();
+    if (!wallet || bridging.current === wallet.address) return;
+    bridging.current = wallet.address;
+    void setActiveWallet(wallet).finally(() => {
+      bridging.current = null;
+    });
+  }, [ready, authenticated, isConnected, preferredWallet, setActiveWallet]);
 
   /** Is the active wallet a Privy embedded wallet (sponsorable)? */
   const activeIsEmbedded = useCallback(() => {
@@ -67,7 +99,17 @@ export function PrivyWalletActions({ children }: { children: ReactNode }) {
   );
 
   const actions: WalletActions = {
-    connect: () => login(),
+    // Already authenticated (e.g. embedded wallet still bridging into wagmi)?
+    // Re-running `login()` throws "already logged in" — instead push the Privy
+    // wallet into wagmi so `isConnected` flips. Otherwise open the login flow.
+    connect: () => {
+      if (authenticated) {
+        const wallet = preferredWallet();
+        if (wallet) void setActiveWallet(wallet);
+        return;
+      }
+      login();
+    },
     disconnect: () => void logout(),
     sendSponsored,
     // Embedded Privy wallets are gas-sponsored; external wallets self-pay.


### PR DESCRIPTION
## Landing page
- Remove **Fund what's meaningful to you** and **Features** sections
- Remove **Where the funding comes from** heading
- Move the funding calculator out of the hero into its own section lower down
- Point **Start Quick Deploy** at `/app/deploy` (was a dead `#get-started` anchor)

## Deploy Connect fix
The deploy page stayed on **Connect** after Privy login. With `@privy-io/wagmi`, Privy auth alone doesn't make wagmi `isConnected` — the wallet must be bridged in via `useSetActiveWallet`. Re-clicking Connect called `login()` on an already-authenticated user, throwing *"use a `link` helper instead"* and looping.
- Bridge the authenticated Privy wallet into wagmi so `isConnected` flips
- `connect()` no longer re-calls `login()` when already authenticated

Verified locally: `tsc --noEmit`, `next lint`, and `next build` (static export, all routes) all pass.