### PR TITLE
feat: run the dapp as a Telegram Mini App

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ Monorepo: a **Next.js frontend at the repo root** and the **Foundry smart contra
 contracts/            Foundry project (the protocol)
   src/ test/ script/  Solidity + tests + deploy scripts
   foundry.toml        contracts build config (FOUNDRY_PROFILE=ci in CI)
+telegram/             Telegram Mini App launcher (zero-dep bot scripts + setup guide);
+                      the in-app side lives in src/lib/telegram.ts + telegram-provider.tsx
 .github/workflows/    CI (contracts build/test today; etherform + web deploy to follow)
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a monorepo:
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/` (root)   | **Next.js frontend** — landing page + dapp (App Router, React 19, Tailwind v4, [`@breadcoop/ui`](https://github.com/BreadchainCoop/bread-ui-kit) design system). |
 | `contracts/` | **Foundry smart contracts** — the on-chain protocol (distribution, voting, automation, registries).                                                              |
+| `telegram/`  | **Telegram Mini App launcher** — bot setup scripts + guide for running the dapp inside Telegram ([telegram/README.md](./telegram/README.md)).                    |
 
 ## Quick start
 

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -368,7 +368,7 @@ function FlowSection({ flow, eager }: { flow: Flow; eager?: boolean }) {
 
 function DocsNav() {
   return (
-    <header className="border-paper-2 bg-paper-main/80 sticky top-0 z-50 border-b backdrop-blur">
+    <header className="border-paper-2 bg-paper-main/80 tg-safe-top sticky top-0 z-50 border-b backdrop-blur">
       <nav className="section-container flex h-16 items-center justify-between">
         <Link href="/" className="flex items-center gap-2">
           <Logo variant="square" color="orange" size={32} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,6 +34,18 @@ body {
   }
 }
 
+/* --- Telegram Mini App (html.tg-app set by the boot script in layout.tsx) ---
+   Fullscreen mini apps draw under the device status bar / Telegram controls;
+   telegram-web-app.js exposes the insets as CSS vars (0px in the regular
+   presentation and on clients that predate Bot API 8.0, so this is inert
+   outside fullscreen). Scoped under .tg-app so the web build never changes. */
+html.tg-app .tg-safe-top {
+  padding-top: calc(
+    var(--tg-safe-area-inset-top, 0px) +
+      var(--tg-content-safe-area-inset-top, 0px)
+  );
+}
+
 /* --- Yield-slice explainer animations (respect reduced-motion via JS) --- */
 @keyframes fade-in {
   from {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,12 +8,54 @@ export const metadata: Metadata = {
     "Transform any pool of money into a democratic, interest-generating engine for your group's shared goals. Open source, free, and customizable.",
 };
 
+/**
+ * Telegram Mini App boot — must run before hydration so every consumer sees a
+ * settled URL/DOM (see src/lib/telegram.ts and telegram/README.md). Telegram
+ * launches the app with #tgWebAppData=…&tgWebAppStartParam=… in the fragment;
+ * in-app navigation drops the hash, so detection persists in sessionStorage.
+ * When inside Telegram: tag <html> (scopes the .tg-app CSS), inject the
+ * official SDK (viewport/back-button/theme bridge — the app degrades
+ * gracefully without it), and promote a `startapp` deep-link payload
+ * (<distributionManager> or <distributionManager>_<chainId>) to the ?i=/&c=
+ * params InstanceProvider already reads. The hash itself is left untouched —
+ * Privy's seamless Telegram auth reads #tgWebAppData directly.
+ */
+const TELEGRAM_BOOT_SCRIPT = `(function () {
+  try {
+    var KEY = "crowdstake.telegram.v1";
+    var hash = window.location.hash;
+    var flagged = null;
+    try { flagged = sessionStorage.getItem(KEY); } catch (e) {}
+    if (hash.indexOf("tgWebApp") === -1 && flagged !== "1") return;
+    try { sessionStorage.setItem(KEY, "1"); } catch (e) {}
+    document.documentElement.classList.add("tg-app");
+    var s = document.createElement("script");
+    s.src = "https://telegram.org/js/telegram-web-app.js";
+    s.async = false;
+    document.head.appendChild(s);
+    var m = /(?:^#|&)tgWebAppStartParam=([^&]*)/.exec(hash);
+    var start = m && decodeURIComponent(m[1]);
+    var p = start && /^(0x[0-9a-fA-F]{40})(?:_([0-9]+))?$/.exec(start);
+    if (p) {
+      var url = new URL(window.location.href);
+      if (!url.searchParams.get("i")) {
+        url.searchParams.set("i", p[1]);
+        if (p[2]) url.searchParams.set("c", p[2]);
+        window.history.replaceState(null, "", url);
+      }
+    }
+  } catch (e) {}
+})();`;
+
 export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en">
+    // The boot script adds .tg-app to <html> before hydration inside Telegram;
+    // suppress React's dev-only attribute diff for it (next-themes pattern).
+    <html lang="en" suppressHydrationWarning>
       <body>
+        <script dangerouslySetInnerHTML={{ __html: TELEGRAM_BOOT_SCRIPT }} />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/components/_home/landing-page.tsx
+++ b/src/components/_home/landing-page.tsx
@@ -50,7 +50,7 @@ export function LandingPage() {
 
 function SiteNav() {
   return (
-    <header className="border-paper-2 bg-paper-main/80 sticky top-0 z-50 border-b backdrop-blur">
+    <header className="border-paper-2 bg-paper-main/80 tg-safe-top sticky top-0 z-50 border-b backdrop-blur">
       <nav className="section-container flex h-16 items-center justify-between">
         <a href="#top" className="flex items-center gap-2">
           <Logo variant="square" color="orange" size={32} />

--- a/src/components/dapp/dapp-nav.tsx
+++ b/src/components/dapp/dapp-nav.tsx
@@ -58,7 +58,7 @@ export function DappNav() {
   const links = useNavLinks();
 
   return (
-    <header className="border-paper-2 bg-paper-main/80 sticky top-0 z-50 border-b backdrop-blur">
+    <header className="border-paper-2 bg-paper-main/80 tg-safe-top sticky top-0 z-50 border-b backdrop-blur">
       <nav className="section-container flex h-16 items-center gap-3">
         {/* Left: the instance IS the brand (white-label) — its badge + name. */}
         <InstanceSwitcher />

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -12,7 +12,9 @@ import { WagmiWalletActions } from "@/components/wallet/wallet-actions";
 import { PrivyWalletActions } from "@/components/wallet/privy-wallet-actions";
 import { InstanceProvider } from "@/components/instance-provider";
 import { DemoModeProvider } from "@/components/demo-mode-provider";
+import { TelegramProvider } from "@/components/telegram-provider";
 import { hydrateRemoteAddresses } from "@/lib/remote-addresses";
+import { isTelegramMiniApp } from "@/lib/telegram";
 
 export function Providers({ children }: { children: ReactNode }) {
   // One QueryClient per browser session; hashFn keeps bigint query keys stable.
@@ -48,6 +50,14 @@ export function Providers({ children }: { children: ReactNode }) {
   useEffect(() => setMounted(true), []);
   const usePrivyTree = privyConfigured() && mounted;
 
+  // Telegram's webview injects no wallet; inside a Mini App launch Privy's
+  // seamless Telegram auth (dashboard: Telegram login + seamless enabled)
+  // signs the user into an embedded wallet with zero clicks — it reads the
+  // #tgWebAppData launch hash on its own. Offering `telegram` in the modal is
+  // scoped to that context so the web experience is unchanged. Evaluated only
+  // in the mounted (client) Privy tree, so the value is settled when read.
+  const inTelegram = isTelegramMiniApp();
+
   const app = (
     <InstanceProvider key={addressesVersion}>
       <DemoModeProvider>{children}</DemoModeProvider>
@@ -55,33 +65,37 @@ export function Providers({ children }: { children: ReactNode }) {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>
-      {usePrivyTree ? (
-        // Embedded wallets + native ("App pays", EIP-7702) gas sponsorship, so
-        // cross-chain governance is submitted gaslessly from the browser.
-        <PrivyProvider
-          appId={PRIVY_APP_ID}
-          config={{
-            embeddedWallets: {
-              ethereum: { createOnLogin: "users-without-wallets" },
-              showWalletUIs: false,
-            },
-            defaultChain: CHAINS[DEFAULT_CHAIN_ID].chain,
-            supportedChains: [...SUPPORTED_CHAINS],
-            appearance: { accentColor: "#EA5817" },
-            loginMethods: ["email", "wallet"],
-          }}
-        >
-          <PrivyWagmiProvider config={privyWagmiConfig}>
-            <PrivyWalletActions>{app}</PrivyWalletActions>
-          </PrivyWagmiProvider>
-        </PrivyProvider>
-      ) : (
-        // No Privy (SSR, local dev, e2e) → plain wagmi/injected, self-paid gas.
-        <WagmiProvider config={fallbackWagmiConfig}>
-          <WagmiWalletActions>{app}</WagmiWalletActions>
-        </WagmiProvider>
-      )}
-    </QueryClientProvider>
+    <TelegramProvider>
+      <QueryClientProvider client={queryClient}>
+        {usePrivyTree ? (
+          // Embedded wallets + native ("App pays", EIP-7702) gas sponsorship, so
+          // cross-chain governance is submitted gaslessly from the browser.
+          <PrivyProvider
+            appId={PRIVY_APP_ID}
+            config={{
+              embeddedWallets: {
+                ethereum: { createOnLogin: "users-without-wallets" },
+                showWalletUIs: false,
+              },
+              defaultChain: CHAINS[DEFAULT_CHAIN_ID].chain,
+              supportedChains: [...SUPPORTED_CHAINS],
+              appearance: { accentColor: "#EA5817" },
+              loginMethods: inTelegram
+                ? ["telegram", "email", "wallet"]
+                : ["email", "wallet"],
+            }}
+          >
+            <PrivyWagmiProvider config={privyWagmiConfig}>
+              <PrivyWalletActions>{app}</PrivyWalletActions>
+            </PrivyWagmiProvider>
+          </PrivyProvider>
+        ) : (
+          // No Privy (SSR, local dev, e2e) → plain wagmi/injected, self-paid gas.
+          <WagmiProvider config={fallbackWagmiConfig}>
+            <WagmiWalletActions>{app}</WagmiWalletActions>
+          </WagmiProvider>
+        )}
+      </QueryClientProvider>
+    </TelegramProvider>
   );
 }

--- a/src/components/telegram-provider.tsx
+++ b/src/components/telegram-provider.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  isTelegramMiniApp,
+  telegramWebApp,
+  type TelegramWebApp,
+} from "@/lib/telegram";
+
+/** paper-main — keep Telegram's own chrome the same color as the app. */
+const TELEGRAM_CHROME_COLOR = "#f6f3eb";
+
+interface TelegramContextValue {
+  /** True when running inside Telegram's webview (Mini App launch). */
+  isTelegram: boolean;
+}
+
+const TelegramContext = createContext<TelegramContextValue>({
+  isTelegram: false,
+});
+
+/** With `trailingSlash: true` a hard load reports "/app/" while client nav
+ * reports "/app" — normalize before comparing. */
+const normalizePath = (pathname: string | null) =>
+  pathname ? pathname.replace(/\/+$/, "") || "/" : "";
+
+/**
+ * Telegram Mini App shell: inert everywhere except inside Telegram, where it
+ * hands the webview over (ready/expand), keeps scroll gestures from collapsing
+ * the app, matches Telegram's chrome to the paper background, and mirrors
+ * in-app depth on Telegram's native back button. Login is not handled here:
+ * Privy's seamless Telegram auth reads the launch hash on its own (see
+ * providers.tsx).
+ */
+export function TelegramProvider({ children }: { children: ReactNode }) {
+  const [isTelegram, setIsTelegram] = useState(false);
+  const [webApp, setWebApp] = useState<TelegramWebApp | null>(null);
+  const pathname = usePathname();
+  const router = useRouter();
+
+  // Detect the Telegram launch (flag set by the boot script in layout.tsx),
+  // then wait for telegram-web-app.js — injected by the same script — to land.
+  // Everything is optional-chained and try-wrapped: the app must keep working
+  // if telegram.org is unreachable or the client predates an API.
+  useEffect(() => {
+    if (!isTelegramMiniApp()) return;
+    setIsTelegram(true);
+    let cancelled = false;
+    let tries = 0;
+    const init = () => {
+      if (cancelled) return;
+      const wa = telegramWebApp();
+      if (!wa) {
+        // The SDK script loads async from telegram.org; poll ~5s then give up.
+        if (++tries < 50) setTimeout(init, 100);
+        return;
+      }
+      // Each call gets its own try: e.g. clients on Bot API 6.1–6.8 throw on
+      // hex header colors but do accept the background call that follows.
+      const attempt = (fn: (() => void) | undefined) => {
+        try {
+          fn?.();
+        } catch {
+          /* cosmetic call on a stale client */
+        }
+      };
+      attempt(wa.ready?.bind(wa));
+      attempt(wa.expand?.bind(wa));
+      attempt(wa.disableVerticalSwipes?.bind(wa));
+      attempt(() => wa.setHeaderColor?.(TELEGRAM_CHROME_COLOR));
+      attempt(() => wa.setBackgroundColor?.(TELEGRAM_CHROME_COLOR));
+      setWebApp(wa);
+    };
+    init();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Telegram's native back button mirrors dapp depth: visible on subpages,
+  // returns to the portfolio. (InstanceProvider's URL sync restores the ?i=
+  // param after navigation, same as the regular nav links.)
+  useEffect(() => {
+    const back = webApp?.BackButton;
+    if (!back) return;
+    const path = normalizePath(pathname);
+    const onSubpage = path.startsWith("/app") && path !== "/app";
+    try {
+      if (!onSubpage) {
+        back.hide();
+        return;
+      }
+      const goHome = () => router.push("/app");
+      back.onClick(goHome);
+      back.show();
+      return () => {
+        back.offClick(goHome);
+        back.hide();
+      };
+    } catch {
+      /* stale client without BackButton support */
+    }
+  }, [webApp, pathname, router]);
+
+  return (
+    <TelegramContext.Provider value={{ isTelegram }}>
+      {children}
+    </TelegramContext.Provider>
+  );
+}
+
+/** Telegram context — `isTelegram` is false everywhere outside Telegram. */
+export function useTelegram(): TelegramContextValue {
+  return useContext(TelegramContext);
+}

--- a/src/lib/telegram.ts
+++ b/src/lib/telegram.ts
@@ -1,0 +1,55 @@
+/**
+ * Telegram Mini App detection + SDK bridge.
+ *
+ * The dapp runs unchanged inside Telegram's webview (launched from a bot's
+ * menu button or a t.me/<bot>/<app> direct link — see telegram/README.md).
+ * Telegram identifies itself by putting launch params in the URL fragment
+ * (#tgWebAppData=…&tgWebAppPlatform=…). The boot script in src/app/layout.tsx
+ * runs before hydration: it persists a sessionStorage flag (in-app navigation
+ * drops the hash), tags <html> with `tg-app` for CSS, and injects the official
+ * telegram-web-app.js. Everything here just reads that state.
+ */
+
+/** sessionStorage flag set by the boot script on first load inside Telegram. */
+export const TELEGRAM_FLAG_KEY = "crowdstake.telegram.v1";
+
+/** The slice of the telegram-web-app.js SDK this app calls. Every member is
+ * optional: clients predating an API simply skip the nicety. */
+export interface TelegramWebApp {
+  initData?: string;
+  platform?: string;
+  ready?: () => void;
+  expand?: () => void;
+  disableVerticalSwipes?: () => void;
+  setHeaderColor?: (color: string) => void;
+  setBackgroundColor?: (color: string) => void;
+  BackButton?: {
+    show: () => void;
+    hide: () => void;
+    onClick: (cb: () => void) => void;
+    offClick: (cb: () => void) => void;
+  };
+}
+
+declare global {
+  interface Window {
+    Telegram?: { WebApp?: TelegramWebApp };
+  }
+}
+
+/** True when this session was launched from inside Telegram. */
+export function isTelegramMiniApp(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    if (sessionStorage.getItem(TELEGRAM_FLAG_KEY) === "1") return true;
+  } catch {
+    /* sessionStorage blocked — fall through to the launch hash */
+  }
+  return window.location.hash.includes("tgWebApp");
+}
+
+/** The Telegram SDK object, once the boot-injected script has loaded. */
+export function telegramWebApp(): TelegramWebApp | null {
+  if (typeof window === "undefined") return null;
+  return window.Telegram?.WebApp ?? null;
+}

--- a/telegram/README.md
+++ b/telegram/README.md
@@ -1,0 +1,87 @@
+# Crowdstake as a Telegram Mini App
+
+The dapp runs unchanged inside Telegram — same static export, same contracts.
+This folder holds the launcher config: a one-time setup script and an optional
+reply bot. Nothing here is part of the web build.
+
+## How it works
+
+- **Detection.** Telegram opens the app with launch params in the URL fragment
+  (`#tgWebAppData=…`). A boot script in `src/app/layout.tsx` runs before
+  hydration: it persists the detection in `sessionStorage` (in-app navigation
+  drops the hash), tags `<html class="tg-app">` for Telegram-scoped CSS, and
+  injects the official `telegram-web-app.js`.
+- **Shell.** `src/components/telegram-provider.tsx` signals `ready()`, expands
+  the webview, disables swipe-to-collapse, matches Telegram's chrome to the
+  paper background, and drives Telegram's native back button on dapp subpages.
+  Outside Telegram it is inert.
+- **Login & wallet.** Telegram's webview injects no wallet. With Telegram login
+  enabled in the Privy dashboard (below), Privy's **seamless auth** signs users
+  into an embedded wallet with zero clicks on launch, and the app's existing
+  "App pays" sponsorship makes every governance action gasless. Without the
+  dashboard config the normal Privy modal (email) still works.
+- **Instance deep links.** A `startapp` payload of `<distributionManager>` or
+  `<distributionManager>_<chainId>` is promoted to the `?i=`/`&c=` params the
+  app already understands:
+  `https://t.me/<bot>/<shortname>?startapp=0xB38B15ad418202D3FdC1A139cEc51A8c13f59CB6`
+
+## Setup
+
+### 1. Create the bot (@BotFather)
+
+1. `/newbot` → pick a name and username; save the token.
+2. `/setdomain` → the dapp's domain (`crowdstake.fun`).
+   **Required for Privy's Telegram login.**
+3. `/newapp` → attach a Direct-Link Mini App to the bot: set the **Web App
+   URL** to the dapp's `/app/` page (e.g.
+   `https://crowdstake.fun/app/`) and pick a short
+   name → the app opens at `t.me/<bot>/<shortname>`.
+4. Optional: **Bot Settings → Configure Mini App → Enable Mini App** to make it
+   the bot's _main_ app (`t.me/<bot>?startapp`, plus an "Open App" button on
+   the bot's profile).
+
+### 2. Menu button + commands (Bot API)
+
+```bash
+TELEGRAM_BOT_TOKEN=123456:ABC-... \
+WEBAPP_URL=https://crowdstake.fun/app/ \
+node telegram/setup.mjs
+```
+
+Idempotent; re-run whenever the URL changes.
+
+### 3. Privy dashboard (seamless login)
+
+In the [Privy dashboard](https://dashboard.privy.io) for the app id baked into
+the deployment (`NEXT_PUBLIC_PRIVY_APP_ID`):
+
+1. **Login methods → Socials → Telegram**: enable, and provide the **bot
+   token** and **bot handle** from step 1.
+2. Toggle **Enable seamless auth** — this is what logs Mini App users in with
+   zero clicks (the frontend already offers `telegram` as a login method when
+   it detects a Telegram launch).
+3. Add `https://web.telegram.org` to the app's allowed domains so the Mini App
+   also works in Telegram's web clients.
+
+### 4. Optional reply bot
+
+The menu button and t.me links need no server. If the bot should also _answer_
+`/start` and `/app` messages with an open-app button:
+
+```bash
+TELEGRAM_BOT_TOKEN=... WEBAPP_URL=... \
+DIRECT_LINK=https://t.me/<bot>/<shortname> \
+node telegram/bot.mjs
+```
+
+`/start 0x<manager>[_<chainId>]` deep-links that instance, mirroring the
+`startapp` format.
+
+## Local development
+
+Telegram requires HTTPS, so point a tunnel (e.g. `cloudflared tunnel --url
+http://localhost:3001`) at `pnpm dev` and use the tunnel URL as the Mini App /
+`/setdomain` URL. To iterate on the Telegram-only UI in a normal browser, open
+the app with a fake launch hash: `http://localhost:3001/app/#tgWebAppPlatform=web`
+(detection keys off `tgWebApp` in the fragment; Privy seamless login still
+needs real launch data, so test login inside Telegram itself).

--- a/telegram/bot.mjs
+++ b/telegram/bot.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Optional long-polling bot: replies to /start and /app with a button that
+ * opens the mini app. The menu button and t.me direct links work without any
+ * running bot (they're BotFather/API config — see ./setup.mjs and ./README.md);
+ * run this only if the bot should also answer messages. Zero dependencies
+ * (Node 18+, global fetch).
+ *
+ * Usage:
+ *   TELEGRAM_BOT_TOKEN=123456:ABC-... \
+ *   WEBAPP_URL=https://crowdstake.fun/app/ \
+ *   [DIRECT_LINK=https://t.me/<bot>/<shortname>] \
+ *   node telegram/bot.mjs
+ *
+ * DIRECT_LINK is the /newapp Direct-Link Mini App; when set, group chats get
+ * a t.me link button (web_app buttons only work in private chats).
+ */
+
+const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const WEBAPP_URL = process.env.WEBAPP_URL;
+const DIRECT_LINK = process.env.DIRECT_LINK;
+
+if (!TOKEN || !WEBAPP_URL) {
+  console.error("Set TELEGRAM_BOT_TOKEN and WEBAPP_URL.");
+  process.exit(1);
+}
+
+async function api(method, params) {
+  const res = await fetch(`https://api.telegram.org/bot${TOKEN}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(params ?? {}),
+  });
+  const body = await res.json();
+  if (!body.ok) throw new Error(`${method}: ${body.description}`);
+  return body.result;
+}
+
+/** /start payloads deep-link an instance: <manager> or <manager>_<chainId> —
+ * the same format the frontend accepts as a `startapp` param. */
+const parseInstance = (payload) =>
+  /^(0x[0-9a-fA-F]{40})(?:_(\d+))?$/.exec(payload ?? "");
+
+const webAppUrl = (payload) => {
+  const m = parseInstance(payload);
+  if (!m) return WEBAPP_URL;
+  const sep = WEBAPP_URL.includes("?") ? "&" : "?";
+  return `${WEBAPP_URL}${sep}i=${m[1]}${m[2] ? `&c=${m[2]}` : ""}`;
+};
+
+const directUrl = (payload) =>
+  parseInstance(payload)
+    ? `${DIRECT_LINK}?startapp=${payload}`
+    : `${DIRECT_LINK}`;
+
+async function onMessage(msg) {
+  const m = /^\/(?:start|app)(?:@(\w+))?(?:\s+(\S+))?\s*$/.exec(msg.text ?? "");
+  if (!m) return;
+  // Ignore commands addressed to a different bot (/start@someotherbot).
+  if (m[1] && m[1].toLowerCase() !== me.username.toLowerCase()) return;
+  const payload = m[2];
+  // web_app buttons are private-chat only; groups get the t.me direct link.
+  const button =
+    msg.chat.type === "private"
+      ? { text: "Open Crowdstake", web_app: { url: webAppUrl(payload) } }
+      : DIRECT_LINK
+        ? { text: "Open Crowdstake", url: directUrl(payload) }
+        : { text: "Open Crowdstake", url: webAppUrl(payload) };
+  await api("sendMessage", {
+    chat_id: msg.chat.id,
+    text: "Crowdstake — stake together, fund what matters.",
+    reply_markup: { inline_keyboard: [[button]] },
+  });
+}
+
+const me = await api("getMe");
+console.log(`@${me.username} polling for updates… (ctrl-c to stop)`);
+
+let offset = 0;
+for (;;) {
+  try {
+    const updates = await api("getUpdates", {
+      offset,
+      timeout: 50,
+      allowed_updates: ["message"],
+    });
+    for (const u of updates) {
+      offset = u.update_id + 1;
+      if (u.message)
+        await onMessage(u.message).catch((e) => console.error(e.message));
+    }
+  } catch (e) {
+    console.error(e.message);
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+}

--- a/telegram/setup.mjs
+++ b/telegram/setup.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * One-time Bot API config for the Crowdstake Telegram Mini App: points the
+ * bot's menu button at the dapp and registers its commands. Zero dependencies
+ * (Node 18+, global fetch). BotFather steps that have no API — creating the
+ * bot, /newapp, /setdomain — are in ./README.md.
+ *
+ * Usage:
+ *   TELEGRAM_BOT_TOKEN=123456:ABC-... \
+ *   WEBAPP_URL=https://crowdstake.fun/app/ \
+ *   node telegram/setup.mjs
+ */
+
+const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const WEBAPP_URL = process.env.WEBAPP_URL;
+
+if (!TOKEN || !WEBAPP_URL) {
+  console.error(
+    "Set TELEGRAM_BOT_TOKEN (from @BotFather) and WEBAPP_URL (HTTPS URL of the dapp's /app/ page).",
+  );
+  process.exit(1);
+}
+
+async function api(method, params) {
+  const res = await fetch(`https://api.telegram.org/bot${TOKEN}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(params ?? {}),
+  });
+  const body = await res.json();
+  if (!body.ok) throw new Error(`${method}: ${body.description}`);
+  return body.result;
+}
+
+const me = await api("getMe");
+console.log(`Configuring @${me.username}…`);
+
+// Menu button: the paperclip-area button in every private chat with the bot.
+await api("setChatMenuButton", {
+  menu_button: {
+    type: "web_app",
+    text: "Open App",
+    web_app: { url: WEBAPP_URL },
+  },
+});
+console.log(`✓ menu button → ${WEBAPP_URL}`);
+
+await api("setMyCommands", {
+  commands: [
+    { command: "start", description: "Open the crowdstaking app" },
+    { command: "app", description: "Open the crowdstaking app" },
+  ],
+});
+console.log("✓ commands (/start, /app)");
+
+await api("setMyShortDescription", {
+  short_description:
+    "Community-powered funding — stake together, fund what matters.",
+});
+console.log("✓ short description");
+
+console.log(`
+Done. Next (manual, in @BotFather — see telegram/README.md):
+  1. /setdomain → ${new URL(WEBAPP_URL).hostname} (required for Privy Telegram login)
+  2. /newapp → Direct-Link Mini App (t.me/${me.username}/<shortname>)
+  3. Bot Settings > Configure Mini App > Enable Mini App (t.me/${me.username}?startapp)
+`);


### PR DESCRIPTION
The dapp runs unchanged inside Telegram, launched from **@crowdstake_bot** (menu button already points at https://crowdstake.fun/app/).

## How it works
- A pre-hydration boot script in `src/app/layout.tsx` detects Telegram's `#tgWebApp…` launch fragment, persists the detection in sessionStorage (in-app navigation drops the hash), tags `<html class="tg-app">`, injects the official `telegram-web-app.js`, and promotes `startapp` deep-link payloads (`<manager>` or `<manager>_<chainId>`) to the existing `?i=`/`&c=` instance params.
- `TelegramProvider` signals ready/expand, disables swipe-to-collapse, matches Telegram's chrome to the paper background, and drives Telegram's native back button on dapp subpages. Inert outside Telegram.
- Privy seamless Telegram auth signs mini-app users into an embedded wallet with zero clicks; `telegram` is offered as a login method only inside Telegram, so the web experience is byte-identical.
- `telegram/` holds zero-dep bot setup scripts + the BotFather/Privy dashboard guide.

## Verification
- `pnpm lint` / `pnpm build` / `pnpm format:check` green against the pinned lockfile.
- 13/13 Playwright smoke checks on the built export: Telegram launch (class/flag/SDK/startapp promotion/hash preservation/nav survival), plain-web no-op, `#calc=` hash no-op.
- Multi-agent adversarial review: 3 confirmed minor findings, all fixed (suppressHydrationWarning on `<html>`, anchored bot command regex + @mention filtering, per-call try isolation for old Telegram clients).