### PR TITLE
fix: route instance deploys through gas sponsorship

### DIFF
--- a/src/app/app/deploy/_components/chain-checklist.tsx
+++ b/src/app/app/deploy/_components/chain-checklist.tsx
@@ -10,6 +10,7 @@ import {
 } from "@phosphor-icons/react";
 import { Button, Caption } from "@breadcoop/ui";
 import { CHAINS, shortChainName, yieldFlavorLabel } from "@/lib/chains";
+import { useWalletActions } from "@/components/wallet/wallet-actions";
 import type { FamilyDeployRow } from "@/hooks/use-deploy-family";
 
 function StateIcon({ state }: { state: FamilyDeployRow["state"] }) {
@@ -71,6 +72,9 @@ export function ChainChecklist({
   onSkip: (chainId: number) => void;
   onUnskip: (chainId: number) => void;
 }) {
+  // Sponsored (embedded) wallets deploy gaslessly — the native-balance
+  // preflight warnings only apply to self-paying wallets.
+  const { sponsored } = useWalletActions();
   return (
     <ul className="space-y-3">
       {rows.map((row) => {
@@ -78,7 +82,8 @@ export function ChainChecklist({
         const blocks = BigInt(
           Math.max(1, Math.ceil(cycleSeconds / (cfg?.blockTimeSeconds ?? 5))),
         );
-        const lowGas = row.balanceWei !== undefined && row.balanceWei === 0n;
+        const lowGas =
+          !sponsored && row.balanceWei !== undefined && row.balanceWei === 0n;
         const inFlight =
           row.state === "checking" ||
           row.state === "signing" ||
@@ -117,7 +122,8 @@ export function ChainChecklist({
                     — fund the wallet before deploying.
                   </Caption>
                 )}
-              {row.balanceWei !== undefined &&
+              {!sponsored &&
+                row.balanceWei !== undefined &&
                 row.balanceWei > 0n &&
                 row.state === "idle" && (
                   <Caption className="text-surface-grey mt-0.5 block">

--- a/src/components/_home/landing-page.tsx
+++ b/src/components/_home/landing-page.tsx
@@ -87,10 +87,7 @@ function NavLink({ href, children }: { href: string; children: ReactNode }) {
 
 function Hero() {
   return (
-    <section
-      id="top"
-      className="section-container py-20 lg:py-28"
-    >
+    <section id="top" className="section-container py-20 lg:py-28">
       <div className="mx-auto flex max-w-2xl flex-col justify-center text-center">
         <h1 className="font-breadDisplay text-core-orange text-6xl leading-[1.04] font-extrabold tracking-tight break-words sm:text-7xl">
           Crowdstaking

--- a/src/components/wallet/privy-wallet-actions.tsx
+++ b/src/components/wallet/privy-wallet-actions.tsx
@@ -42,9 +42,7 @@ export function PrivyWalletActions({ children }: { children: ReactNode }) {
    * provisions, so callers must tolerate `undefined`.
    */
   const preferredWallet = useCallback((): ConnectedWallet | undefined => {
-    return (
-      wallets.find((w) => w.walletClientType === "privy") ?? wallets[0]
-    );
+    return wallets.find((w) => w.walletClientType === "privy") ?? wallets[0];
   }, [wallets]);
 
   /**

--- a/src/hooks/use-deploy-family.ts
+++ b/src/hooks/use-deploy-family.ts
@@ -2,11 +2,12 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { zeroAddress, type Address, type Hex } from "viem";
-import { useAccount, useSwitchChain, useWriteContract } from "wagmi";
+import { useAccount } from "wagmi";
 import { deployerAbi } from "@/lib/abis";
 import { CHAINS } from "@/lib/chains";
 import { publicClientFor, type InstanceAddresses } from "@/lib/instance";
 import { parseTxError } from "@/hooks/use-tx";
+import { useWalletActions } from "@/components/wallet/wallet-actions";
 import {
   familyIdForConfig,
   loadPendingFamily,
@@ -116,8 +117,10 @@ function serializeParams(cfg: FamilyDeployConfig): PendingFamilyParams {
  */
 export function useDeployFamily(config: FamilyDeployConfig | null) {
   const { address } = useAccount();
-  const { switchChainAsync } = useSwitchChain();
-  const { writeContractAsync } = useWriteContract();
+  // Writes go through the wallet-actions layer: gas-sponsored (gasless, chain
+  // targeted per call) on a Privy embedded wallet, else a self-paid write that
+  // chain-switches itself — so no explicit switch here.
+  const { sendSponsored } = useWalletActions();
 
   const familyId: Hex | null = config
     ? familyIdForConfig({
@@ -262,9 +265,8 @@ export function useDeployFamily(config: FamilyDeployConfig | null) {
       }
 
       try {
-        await switchChainAsync({ chainId });
         patchRow(chainId, { state: "signing" });
-        const hash = await writeContractAsync({
+        const hash = await sendSponsored({
           chainId,
           address: deployer,
           abi: deployerAbi,
@@ -300,14 +302,7 @@ export function useDeployFamily(config: FamilyDeployConfig | null) {
         persist();
       }
     },
-    [
-      familyId,
-      persist,
-      patchRow,
-      readSibling,
-      switchChainAsync,
-      writeContractAsync,
-    ],
+    [familyId, persist, patchRow, readSibling, sendSponsored],
   );
 
   /** Skip a chain for now (leaves the family resumable from the Deploy page). */

--- a/src/hooks/use-deploy.ts
+++ b/src/hooks/use-deploy.ts
@@ -1,15 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { decodeEventLog, type Address, type Hex, type Log } from "viem";
-import {
-  useChainId,
-  useWaitForTransactionReceipt,
-  useWriteContract,
-} from "wagmi";
+import { useChainId, useWaitForTransactionReceipt } from "wagmi";
 import { deployerAbi } from "@/lib/abis";
 import { CHAINS } from "@/lib/chains";
 import { parseTxError } from "@/hooks/use-tx";
+import { useWalletActions } from "@/components/wallet/wallet-actions";
 import type { InstanceAddresses } from "@/lib/instance";
 
 export interface DeployParams {
@@ -85,19 +82,26 @@ export function useDeployInstance() {
   const chainId = useChainId();
   const cfg = CHAINS[chainId];
   const deployer = cfg?.deployer ?? null;
-  const {
-    writeContractAsync,
-    data: hash,
-    isPending: isSigning,
-    reset,
-    error: writeError,
-  } = useWriteContract();
+  // Deploys go through the wallet-actions layer like every other write: gas-
+  // sponsored (gasless) on a Privy embedded wallet — which holds no native
+  // token, so a raw self-paid write could never even estimate — else a normal
+  // self-paid wallet tx.
+  const { sendSponsored } = useWalletActions();
+  const [hash, setHash] = useState<Hex | undefined>(undefined);
+  const [isSigning, setIsSigning] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const {
     data: receipt,
     isLoading: isConfirming,
     isSuccess,
     error: receiptError,
   } = useWaitForTransactionReceipt({ hash, chainId });
+
+  const reset = useCallback(() => {
+    setHash(undefined);
+    setIsSigning(false);
+    setSubmitError(null);
+  }, []);
 
   const instance = useMemo<InstanceAddresses | null>(
     () => (receipt ? decodeInstanceFromLogs(receipt.logs) : null),
@@ -110,8 +114,11 @@ export function useDeployInstance() {
         `${cfg?.chain.name ?? `chain ${chainId}`} isn't supported for deploys yet — switch to a supported chain.`,
       );
     }
+    setSubmitError(null);
+    setHash(undefined);
+    setIsSigning(true);
     try {
-      return await writeContractAsync({
+      const h = await sendSponsored({
         chainId,
         address: deployer,
         abi: deployerAbi,
@@ -134,13 +141,19 @@ export function useDeployInstance() {
           },
         ],
       });
+      setHash(h);
+      return h;
     } catch (e) {
-      throw new Error(parseTxError(e));
+      const message = parseTxError(e);
+      setSubmitError(message);
+      throw new Error(message);
+    } finally {
+      setIsSigning(false);
     }
   };
 
   const status: "idle" | "signing" | "confirming" | "success" | "error" =
-    writeError || receiptError
+    submitError || receiptError
       ? "error"
       : isSuccess
         ? "success"
@@ -161,11 +174,7 @@ export function useDeployInstance() {
     status,
     isBusy: isSigning || isConfirming,
     isSuccess,
-    error: writeError
-      ? parseTxError(writeError)
-      : receiptError
-        ? parseTxError(receiptError)
-        : null,
+    error: submitError ?? (receiptError ? parseTxError(receiptError) : null),
     reset,
   };
 }


### PR DESCRIPTION
Fixes the live `gas required exceeds allowance (0)` error on the Deploy page.

**Root cause:** `useDeployInstance` and `useDeployFamily` called wagmi's raw `writeContractAsync` — the self-paid path — instead of the `sendSponsored` wallet-actions layer every other write uses. A fresh Privy embedded wallet holds no native token, so Gnosis nodes cap gas estimation at 0 and the deploy dies before signing. (The reporting wallet `0x2227…cA6e` has its EIP-7702 delegation set from a prior *sponsored* tx, proving sponsorship works — deploys just bypassed it.)

**Fix:**
- Both deploy hooks now submit via `sendSponsored`: gasless on embedded wallets; external wallets keep the identical self-paid fallback (which also handles chain switching, so the family flow's explicit `switchChainAsync` is gone).
- `useDeployInstance` keeps its exact return shape/status machine (local hash/signing/error state instead of `useWriteContract`'s).
- The chain checklist hides native-balance gas warnings for sponsored wallets.
- Separate commit: prettier-formats two files that landed unformatted via #161, restoring the `pnpm format:check` gate.

Verified: `pnpm lint` / `pnpm build` / `pnpm format:check` all green.