### PR TITLE
fix: compact nav wallet button

### DIFF
--- a/src/components/dapp/dapp-nav.tsx
+++ b/src/components/dapp/dapp-nav.tsx
@@ -84,7 +84,7 @@ export function DappNav() {
         {/* Right: utilities */}
         <div className="ml-auto flex items-center gap-2 lg:ml-0">
           <DemoToggle />
-          <WalletButton />
+          <WalletButton size="sm" />
         </div>
       </nav>
 

--- a/src/components/dapp/wallet-button.tsx
+++ b/src/components/dapp/wallet-button.tsx
@@ -15,7 +15,14 @@ function shortAddress(address: string): string {
  * external wallets, gasless) when configured, else a plain injected wallet.
  * Address + connection come from wagmi, so this one component works in both.
  */
-export function WalletButton({ full = false }: { full?: boolean }) {
+export function WalletButton({
+  full = false,
+  size,
+}: {
+  full?: boolean;
+  /** Button size — the nav passes "sm" so it fits the h-16 row. */
+  size?: "sm";
+}) {
   const { address, isConnected } = useAccount();
   const { connect, disconnect } = useWalletActions();
 
@@ -24,7 +31,8 @@ export function WalletButton({ full = false }: { full?: boolean }) {
       <Button
         app="fund"
         variant="primary"
-        className={full ? "w-full" : undefined}
+        size={size}
+        className={full ? "w-full" : "whitespace-nowrap"}
         onClick={connect}
       >
         Connect wallet
@@ -40,6 +48,7 @@ export function WalletButton({ full = false }: { full?: boolean }) {
       <Button
         app="fund"
         variant="secondary"
+        size={size}
         className="px-2"
         onClick={disconnect}
         leftIcon={<SignOut weight="bold" />}


### PR DESCRIPTION
The @breadcoop/ui Button default size overflowed the h-16 nav row — on phones "Connect wallet" wrapped to two lines and burst out of the header (report: "navbar looks really weird overloaded"). WalletButton now takes a `size` prop; the nav passes `sm` (matching the other nav controls) and the label no longer wraps. Verified by screenshots of the built export at 390px and 1440px; the full-width connect buttons elsewhere are unchanged.