### PR TITLE
chore: point baked-in deployer fallbacks at the v2 deployers

### DIFF
--- a/contracts/deployments/l2-deployers.json
+++ b/contracts/deployments/l2-deployers.json
@@ -4,8 +4,8 @@
     "42161": {
       "name": "Arbitrum One",
       "yieldKind": "stable",
-      "deployer": "0x976724aC0d83dC3624920f720b91B1Aa5691E28A",
-      "factory": "0x83C637C270e47d10B48EED0FCb91c5A40cc92F16",
+      "deployer": "0x4480909dD3fC3ADE8586Dd3758F628A7c9B38A30",
+      "factory": "0xAbC995e02a22AE7134fdAd95bEF0A28505976134",
       "asset": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "assetSymbol": "USDC",
       "yieldVault": "0x5c0C306Aaa9F877de636f4d5822cA9F2E81563BA",
@@ -14,8 +14,8 @@
     "10": {
       "name": "OP Mainnet",
       "yieldKind": "stable",
-      "deployer": "0x86054D9d62Fd33FcC30731FCC31A556259810ec2",
-      "factory": "0x3178cf7ba399b48Bb383592B2ddc87D47e478417",
+      "deployer": "0xCf1Fe91A1946E56D12c2B685a18Cc3d7c1F0c361",
+      "factory": "0xbD01a0F13d06227cF0c1752E685d1ee3281FE908",
       "asset": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
       "assetSymbol": "USDC",
       "yieldVault": "0xC30ce6A5758786e0F640cC5f881Dd96e9a1C5C59",

--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -106,7 +106,7 @@ export const CHAINS: Record<number, ChainConfig> = {
     rpcUrl: or(process.env.NEXT_PUBLIC_RPC_URL, "https://rpc.gnosischain.com"),
     deployer: or(
       process.env.NEXT_PUBLIC_DEPLOYER_ADDRESS,
-      "0x4D6178572690B39D04d2E790E1D0c776f2cBBC95",
+      "0xD9dbc941C5e66D1cC67C6612d221263eD1A27C55", // v2 (family-aware), 2026-07-11
     ) as Address,
     defaultInstance: GNOSIS_INSTANCE,
     wrappedToken: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d" as Address, // WXDAI
@@ -126,7 +126,7 @@ export const CHAINS: Record<number, ChainConfig> = {
     // address manifest supersedes this fallback on redeploys.
     deployer: or(
       process.env.NEXT_PUBLIC_DEPLOYER_42161,
-      "0x976724aC0d83dC3624920f720b91B1Aa5691E28A",
+      "0x4480909dD3fC3ADE8586Dd3758F628A7c9B38A30", // v2 (family-aware), 2026-07-11
     ) as Address,
     defaultInstance: null,
     wrappedToken: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831" as Address, // native USDC
@@ -146,7 +146,7 @@ export const CHAINS: Record<number, ChainConfig> = {
     // address manifest supersedes this fallback on redeploys.
     deployer: or(
       process.env.NEXT_PUBLIC_DEPLOYER_10,
-      "0x86054D9d62Fd33FcC30731FCC31A556259810ec2",
+      "0xCf1Fe91A1946E56D12c2B685a18Cc3d7c1F0c361", // v2 (family-aware), 2026-07-11
     ) as Address,
     defaultInstance: null,
     wrappedToken: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" as Address, // native USDC


### PR DESCRIPTION
Companion to today's v2 deployer redeploys (contracts-deploy runs on Gnosis/Arbitrum/Optimism). The rolling `contract-addresses` manifest already serves the new addresses at runtime; this updates the `chains.ts` and `l2-deployers.json` baked-in fallbacks so an offline/failed manifest fetch can't fall back to the v1 deployers, which revert on the current `deploy(...)` ABI (that revert was the root cause of the Deploy page failure — see the manifest for the new addresses: Gnosis `0xD9db…7C55`, Arbitrum `0x4480…8A30`, Optimism `0xCf1F…c361`).