### PR TITLE
fix: close out the sponsorship + stale-ABI audit findings

### DIFF
--- a/src/app/app/admin/page.tsx
+++ b/src/app/app/admin/page.tsx
@@ -182,6 +182,20 @@ function InstanceMetadataCard() {
   const inputClass =
     "border-paper-2 bg-paper-main text-text-standard focus:border-core-orange w-full rounded-xl border px-4 py-2.5 font-mono text-sm outline-none";
 
+  // Older distribution managers predate instance artwork — the setter would
+  // revert, so explain instead of offering a guaranteed-to-fail write.
+  if (meta.supported === false) {
+    return (
+      <Card>
+        <Caption className="text-surface-grey-2">Instance artwork</Caption>
+        <Body className="text-surface-grey-2 mt-1">
+          This instance&apos;s contracts predate on-chain artwork — a contract
+          upgrade is required before token and header images can be set.
+        </Body>
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <Caption className="text-surface-grey-2">Instance artwork</Caption>

--- a/src/app/app/deposit/page.tsx
+++ b/src/app/app/deposit/page.tsx
@@ -10,6 +10,7 @@ import { ActionButton } from "@/components/dapp/action-button";
 import { TxStatus } from "@/components/dapp/tx-status";
 import { cn } from "@/lib/utils";
 import { parseAmount } from "@/lib/format";
+import { useWalletActions } from "@/components/wallet/wallet-actions";
 import { useAmountFormatter } from "@/components/demo-mode-provider";
 import { useActiveChain, useNativeSymbol } from "@/hooks/use-chain";
 import { useFamily } from "@/hooks/use-family";
@@ -86,12 +87,14 @@ function DepositForm() {
   // Native is always 18-dp; the wrapped/stable asset uses the token's decimals.
   const depositDecimals = mode === "native" ? 18 : decimals;
   const parsed = parseAmount(amount, depositDecimals);
-  // Native deposits pay gas in the native token too, so reserve a little for
-  // gas — otherwise a MAX deposit sends the whole balance and can't fund the tx.
+  // Self-paying wallets fund gas from the same native balance, so reserve a
+  // little — otherwise a MAX deposit sends the whole balance and can't fund
+  // the tx. Sponsored (embedded) wallets deposit gas-free: no reserve.
+  const { sponsored } = useWalletActions();
   const GAS_RESERVE = 10n ** 16n; // ~0.01 of the native token
   const rawBalance = mode === "native" ? native.data?.value : wrapped.balance;
   const balance =
-    mode === "native" && rawBalance !== undefined
+    mode === "native" && rawBalance !== undefined && !sponsored
       ? rawBalance > GAS_RESERVE
         ? rawBalance - GAS_RESERVE
         : 0n

--- a/src/hooks/use-instance-metadata.ts
+++ b/src/hooks/use-instance-metadata.ts
@@ -8,7 +8,8 @@ import { useTx } from "@/hooks/use-tx";
 /**
  * The active instance's on-chain artwork URIs, read from its distribution
  * manager (the canonical instance key). Instances on the older implementation
- * simply revert these reads, so the hook degrades to undefined (no image).
+ * simply revert these reads, so the hook degrades to undefined (no image) and
+ * `supported` doubles as feature detection (same pattern as useYieldSplit).
  */
 export function useInstanceMetadata() {
   const a = useInstance();
@@ -29,6 +30,12 @@ export function useInstanceMetadata() {
   return {
     tokenImageURI: (tokenImage.data as string | undefined) || undefined,
     bannerImageURI: (bannerImage.data as string | undefined) || undefined,
+    /** false = the live DM predates instance artwork (writes would revert). */
+    supported: tokenImage.isError
+      ? false
+      : tokenImage.data !== undefined
+        ? true
+        : undefined,
     refetch: () => {
       void tokenImage.refetch();
       void bannerImage.refetch();

--- a/src/hooks/use-mirror-recipients.ts
+++ b/src/hooks/use-mirror-recipients.ts
@@ -2,10 +2,10 @@
 
 import { useCallback, useState } from "react";
 import type { Address } from "viem";
-import { useSwitchChain, useWriteContract } from "wagmi";
 import { recipientRegistryAbi } from "@/lib/abis";
 import { publicClientFor } from "@/lib/instance";
 import { parseTxError } from "@/hooks/use-tx";
+import { useWalletActions } from "@/components/wallet/wallet-actions";
 
 /**
  * The membership delta needed to bring a sibling chain's recipient set in line
@@ -34,12 +34,13 @@ export type MirrorState = "idle" | "signing" | "confirming" | "done" | "error";
 /**
  * Mirror a sibling chain's admin recipient registry to match the reference set:
  * queue the additions/removals, then processQueue — all on that sibling's chain
- * (switches the wallet, waits on the sibling's own viem client). Admin-registry
- * only; democratic families aren't offered multi-chain.
+ * (receipts awaited on the sibling's own viem client). Admin-registry only;
+ * democratic families aren't offered multi-chain. Writes go through the
+ * wallet-actions layer: gas-sponsored (gasless, chain targeted per call) on a
+ * Privy embedded wallet, else a self-paid write that chain-switches itself.
  */
 export function useMirrorRecipients() {
-  const { switchChainAsync } = useSwitchChain();
-  const { writeContractAsync } = useWriteContract();
+  const { sendSponsored } = useWalletActions();
   const [busyChain, setBusyChain] = useState<number | null>(null);
   const [state, setState] = useState<MirrorState>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -52,10 +53,9 @@ export function useMirrorRecipients() {
       setState("signing");
       const client = publicClientFor(chainId);
       try {
-        await switchChainAsync({ chainId });
         // Queue additions and removals (batched calls where there's > 0).
         if (diff.toAdd.length > 0) {
-          const hash = await writeContractAsync({
+          const hash = await sendSponsored({
             chainId,
             address: registry,
             abi: recipientRegistryAbi,
@@ -67,7 +67,7 @@ export function useMirrorRecipients() {
         }
         if (diff.toRemove.length > 0) {
           setState("signing");
-          const hash = await writeContractAsync({
+          const hash = await sendSponsored({
             chainId,
             address: registry,
             abi: recipientRegistryAbi,
@@ -79,7 +79,7 @@ export function useMirrorRecipients() {
         }
         // Apply the queued changes.
         setState("signing");
-        const processHash = await writeContractAsync({
+        const processHash = await sendSponsored({
           chainId,
           address: registry,
           abi: recipientRegistryAbi,
@@ -96,7 +96,7 @@ export function useMirrorRecipients() {
         setBusyChain(null);
       }
     },
-    [switchChainAsync, writeContractAsync],
+    [sendSponsored],
   );
 
   return { mirror, busyChain, state, error };


### PR DESCRIPTION
Follow-up sweep after the deploy fixes (#163): a 4-dimension audit (raw writes, frontend-ABI-vs-live-bytecode, gas UX, approval flows) with adversarial verification over every dapp flow. Three confirmed findings, all fixed:

1. **useMirrorRecipients** (admin → "Mirror to chain" fallback) was the **last remaining raw-wagmi write path** — three txs (queueRecipientsAddition/Removal, processQueue) bypassed `sendSponsored`, so a Privy embedded wallet (zero native balance) failed gas estimation, leaving an embedded-wallet admin no working per-chain recovery when the sign-once sync isn't usable. Now routed through the wallet-actions layer (which also owns chain switching).
2. **Admin "Instance artwork" card** called `setInstanceMetadata` unconditionally, but the live Gnosis default-instance distribution manager predates the feature (verified on-chain: selectors `0xfce58c17`/`0xd03e959e`/`0xc6b59e5d` absent from the beacon implementation) — the write was guaranteed to revert. `useInstanceMetadata` now exposes `supported` (the `useYieldSplit` feature-detect pattern) and the card explains the needed upgrade instead.
3. **Single-chain DepositForm** subtracted the 0.01 native gas reserve from the usable balance even for sponsored wallets; now `!sponsored`-gated, matching FamilyDeposit.

The audit's remaining verified-clean ground: every other write goes through `sendSponsored`/`useTx`; all other frontend-called functions exist on the live modules; approval flows already sponsored.

Gates: `pnpm lint` / `format:check` / `build` green.