### PR TITLE
fix: label shared instance links by token name

### DIFF
--- a/src/components/instance-provider.tsx
+++ b/src/components/instance-provider.tsx
@@ -21,6 +21,7 @@ import {
   loadActiveManager,
   loadKnownInstances,
   resolveInstance,
+  resolveInstanceLabel,
   saveActiveManager,
   saveKnownInstances,
   type InstanceAddresses,
@@ -89,8 +90,12 @@ export function InstanceProvider({ children }: { children: ReactNode }) {
         return;
       }
       const addresses = await resolveInstance(dm, chainId); // may throw
+      // Label shared links by the community's token name, not a hex address.
+      const label =
+        (await resolveInstanceLabel(addresses.token, chainId)) ??
+        shortenAddress(dm, 4);
       if (cancelled) return;
-      const inst = { label: shortenAddress(dm, 4), chainId, addresses };
+      const inst = { label, chainId, addresses };
       setKnown((prev) => {
         const next = [...prev, inst];
         saveKnownInstances(next);

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -14,7 +14,7 @@ import {
   type InstanceAddresses,
 } from "@/lib/chains";
 import { TOKEN_SYMBOL } from "@/lib/constants";
-import { distributionManagerAbi, votingModuleAbi } from "@/lib/abis";
+import { distributionManagerAbi, tokenAbi, votingModuleAbi } from "@/lib/abis";
 
 export type { InstanceAddresses } from "@/lib/chains";
 
@@ -139,6 +139,27 @@ export async function resolveInstance(
     distributionStrategy: getAddress(strategy as Address),
     votingPowerStrategy: getAddress(vpStrategies[0]),
   };
+}
+
+/**
+ * Human label for a resolved instance: its token's on-chain name. Null when
+ * the token has no usable name (fail-soft — callers fall back to a shortened
+ * address).
+ */
+export async function resolveInstanceLabel(
+  token: Address,
+  chainId: number,
+): Promise<string | null> {
+  try {
+    const name = (await publicClientFor(chainId).readContract({
+      address: token,
+      abi: tokenAbi,
+      functionName: "name",
+    })) as string;
+    return name.trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 /* --------------------------- localStorage helpers -------------------------- */


### PR DESCRIPTION
Opening a shared `?i=<manager>` link (or a Telegram `startapp` deep link) on a fresh device labeled the instance with the shortened hex address — e.g. the just-deployed Convent community showed `0xC6bC…11E6` as its brand in the nav. The wizard-deployed device got a proper label, so this only bit shared links.

`resolveInstanceLabel` reads the token's on-chain `name()` during resolution (fail-soft to the shortened address for tokens without a usable name), so shared links now brand as the community name.

Gates: lint / format:check / build green.