### PR TITLE
fix: keep simulation headroom on sponsored native MAX deposits

### DIFF
--- a/src/app/app/deposit/_components/family-deposit.tsx
+++ b/src/app/app/deposit/_components/family-deposit.tsx
@@ -25,6 +25,11 @@ import {
 } from "@/hooks/use-family-deposit";
 
 const GAS_RESERVE = 10n ** 16n; // ~0.01 native, kept back to pay gas (self-paid)
+// Sponsored (4337) wallets pay no gas, but the bundler's simulation still
+// debits the account before the paymaster settles — a native deposit of the
+// FULL balance reverts in simulation ("UserOperation reverted … reason: 0x").
+// Keep a sliver back so MAX survives simulation.
+const SIM_HEADROOM = 10n ** 15n; // ~0.001 native
 
 /**
  * Multi-asset family mint: deposit into a community token across every chain it
@@ -49,12 +54,12 @@ export function FamilyDeposit({
   const decimalsFor = (c: FamilyDepositChain, mode: "native" | "wrapped") =>
     mode === "native" ? 18 : c.wrappedDecimals;
 
-  // Balance available for a row's chosen asset (reserve native gas when self-paid).
+  // Balance available for a row's chosen asset. Native rows always hold back a
+  // reserve: gas for self-paying wallets, simulation headroom for sponsored.
   const availableFor = (c: FamilyDepositChain, mode: "native" | "wrapped") => {
     if (mode === "wrapped") return c.wrappedBalance;
-    return !sponsored && c.nativeBalance > GAS_RESERVE
-      ? c.nativeBalance - GAS_RESERVE
-      : c.nativeBalance;
+    const reserve = sponsored ? SIM_HEADROOM : GAS_RESERVE;
+    return c.nativeBalance > reserve ? c.nativeBalance - reserve : 0n;
   };
 
   const rowByChain = (chainId: number): DepositRow | undefined =>

--- a/src/app/app/deposit/page.tsx
+++ b/src/app/app/deposit/page.tsx
@@ -87,16 +87,20 @@ function DepositForm() {
   // Native is always 18-dp; the wrapped/stable asset uses the token's decimals.
   const depositDecimals = mode === "native" ? 18 : decimals;
   const parsed = parseAmount(amount, depositDecimals);
-  // Self-paying wallets fund gas from the same native balance, so reserve a
-  // little — otherwise a MAX deposit sends the whole balance and can't fund
-  // the tx. Sponsored (embedded) wallets deposit gas-free: no reserve.
+  // Native deposits always hold back a reserve: self-paying wallets fund gas
+  // from the same balance (otherwise MAX can't fund the tx), and sponsored
+  // (4337) wallets need a sliver of headroom — the bundler's simulation debits
+  // the account before the paymaster settles, so a full-balance native send
+  // reverts in simulation.
   const { sponsored } = useWalletActions();
-  const GAS_RESERVE = 10n ** 16n; // ~0.01 of the native token
+  const GAS_RESERVE = 10n ** 16n; // ~0.01 of the native token (self-paid)
+  const SIM_HEADROOM = 10n ** 15n; // ~0.001 (sponsored)
+  const reserve = sponsored ? SIM_HEADROOM : GAS_RESERVE;
   const rawBalance = mode === "native" ? native.data?.value : wrapped.balance;
   const balance =
-    mode === "native" && rawBalance !== undefined && !sponsored
-      ? rawBalance > GAS_RESERVE
-        ? rawBalance - GAS_RESERVE
+    mode === "native" && rawBalance !== undefined
+      ? rawBalance > reserve
+        ? rawBalance - reserve
         : 0n
       : rawBalance;
   const overBalance =


### PR DESCRIPTION
User report: family mint succeeded for Optimism USDC but the Gnosis xDAI leg failed with `UserOperation reverted during simulation with reason: 0x`.

**Diagnosis** (all reproduced on-chain): the wallet held exactly 0.01 xDAI and deposited all of it. The mint itself is fine — it succeeds via direct `eth_call` with the full value AND via Kernel v3.3 `execute` from the EntryPoint. Only the bundler/Privy simulation fails: it debits the account for gas before the paymaster settles, so a native send of the entire balance comes up short in simulation and reverts bare. ERC-20 mints carry no native value, which is why the USDC legs pass.

**Fix:** native deposit rows always hold back a reserve from the usable balance — 0.01 native for self-paying wallets (existing gas reserve) and 0.001 for sponsored wallets (simulation headroom) — in both the family panel and the single-chain form.

Gates: lint / format:check / build green.