### PR TITLE
fix: self-pay value-carrying txs from embedded wallets

### DIFF
--- a/src/app/app/deposit/_components/family-deposit.tsx
+++ b/src/app/app/deposit/_components/family-deposit.tsx
@@ -25,11 +25,11 @@ import {
 } from "@/hooks/use-family-deposit";
 
 const GAS_RESERVE = 10n ** 16n; // ~0.01 native, kept back to pay gas (self-paid)
-// Sponsored (4337) wallets pay no gas, but the bundler's simulation still
-// debits the account before the paymaster settles — a native deposit of the
-// FULL balance reverts in simulation ("UserOperation reverted … reason: 0x").
-// Keep a sliver back so MAX survives simulation.
-const SIM_HEADROOM = 10n ** 15n; // ~0.001 native
+// Native deposits are the one SELF-PAID case even for sponsored wallets
+// (Privy's sponsorship simulation rejects value-carrying ops — see
+// privy-wallet-actions.tsx), so MAX keeps a sliver back for their gas
+// (a mint is ~350k gas; cheap-native chains only).
+const SPONSORED_NATIVE_RESERVE = 10n ** 15n; // ~0.001 native
 
 /**
  * Multi-asset family mint: deposit into a community token across every chain it
@@ -58,7 +58,7 @@ export function FamilyDeposit({
   // reserve: gas for self-paying wallets, simulation headroom for sponsored.
   const availableFor = (c: FamilyDepositChain, mode: "native" | "wrapped") => {
     if (mode === "wrapped") return c.wrappedBalance;
-    const reserve = sponsored ? SIM_HEADROOM : GAS_RESERVE;
+    const reserve = sponsored ? SPONSORED_NATIVE_RESERVE : GAS_RESERVE;
     return c.nativeBalance > reserve ? c.nativeBalance - reserve : 0n;
   };
 

--- a/src/app/app/deposit/page.tsx
+++ b/src/app/app/deposit/page.tsx
@@ -87,15 +87,15 @@ function DepositForm() {
   // Native is always 18-dp; the wrapped/stable asset uses the token's decimals.
   const depositDecimals = mode === "native" ? 18 : decimals;
   const parsed = parseAmount(amount, depositDecimals);
-  // Native deposits always hold back a reserve: self-paying wallets fund gas
-  // from the same balance (otherwise MAX can't fund the tx), and sponsored
-  // (4337) wallets need a sliver of headroom — the bundler's simulation debits
-  // the account before the paymaster settles, so a full-balance native send
-  // reverts in simulation.
+  // Native deposits always hold back a gas reserve: they're self-paid even on
+  // sponsored wallets (Privy's sponsorship simulation rejects value-carrying
+  // ops — see privy-wallet-actions.tsx). Sponsored wallets need only a sliver
+  // (~350k-gas mint on a cheap-native chain); self-paying external wallets
+  // keep the roomier classic reserve.
   const { sponsored } = useWalletActions();
   const GAS_RESERVE = 10n ** 16n; // ~0.01 of the native token (self-paid)
-  const SIM_HEADROOM = 10n ** 15n; // ~0.001 (sponsored)
-  const reserve = sponsored ? SIM_HEADROOM : GAS_RESERVE;
+  const SPONSORED_NATIVE_RESERVE = 10n ** 15n; // ~0.001 (sponsored)
+  const reserve = sponsored ? SPONSORED_NATIVE_RESERVE : GAS_RESERVE;
   const rawBalance = mode === "native" ? native.data?.value : wrapped.balance;
   const balance =
     mode === "native" && rawBalance !== undefined

--- a/src/components/wallet/privy-wallet-actions.tsx
+++ b/src/components/wallet/privy-wallet-actions.tsx
@@ -75,7 +75,14 @@ export function PrivyWalletActions({ children }: { children: ReactNode }) {
   const sendSponsored = useCallback(
     async (req: SponsoredTxRequest): Promise<Hex> => {
       // External wallet → normal self-paid write (can't be sponsored).
-      if (!activeIsEmbedded()) return selfPaidWrite(req);
+      // Value-carrying txs (native deposits) also self-pay: Privy's sponsorship
+      // simulation doesn't credit the account's native balance, so ANY op with
+      // value reverts there ("UserOperation reverted during simulation with
+      // reason: 0x") — while the same op passes a public bundler's simulation.
+      // A wallet sending native value holds native funds by definition, so the
+      // (tiny) gas comes from the same balance the deposit UI already reserves.
+      if (!activeIsEmbedded() || (req.value !== undefined && req.value > 0n))
+        return selfPaidWrite(req);
 
       const data = encodeFunctionData({
         abi: req.abi as Parameters<typeof encodeFunctionData>[0]["abi"],


### PR DESCRIPTION
Root cause of the Gnosis xDAI mint failing with `UserOperation reverted during simulation with reason: 0x` while the USDC legs minted fine.

**Proof chain** (all reproduced): the mint succeeds via direct `eth_call` at every tried amount → succeeds via Kernel v3.3 `execute` from the EntryPoint → and the full PackedUserOperation **passes `eth_estimateUserOperationGas` on Pimlico's public Gnosis bundler** (call phase ≈324k gas). Only Privy's sponsorship simulation rejects it, and only when `value > 0` — their simulation doesn't credit the account's native balance, so any value-carrying sponsored op reverts bare. Amount is irrelevant (full-balance and 0.001-of-0.009 both failed identically).

**Fix:** `sendSponsored` routes value-carrying requests to the existing self-paid write path even for embedded wallets. A wallet depositing native funds holds them by definition, and the deposit forms (family + single-chain) already hold back a reserve — comments/constants updated to reflect that this reserve now covers real gas (~350k-gas mint, cheap-native chains only). Everything without native value stays fully gasless.

Gates: lint / format:check / build green.