### PR TITLE
feat: measured APY + family-wide stats + distribution overview

### DIFF
--- a/src/app/app/distribute/page.tsx
+++ b/src/app/app/distribute/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo } from "react";
-import { Body, Caption } from "@breadcoop/ui";
+import { Body, Caption, Heading4 } from "@breadcoop/ui";
 import { CheckCircle, XCircle } from "@phosphor-icons/react";
 import { Card, PageHeader, StatCard } from "@/components/dapp/ui";
 import { ActionButton } from "@/components/dapp/action-button";
@@ -11,6 +11,11 @@ import { useCycle } from "@/hooks/use-cycle";
 import { useRecipients } from "@/hooks/use-recipients";
 import { useVotingState } from "@/hooks/use-voting";
 import { useInstanceToken, useTokenStats } from "@/hooks/use-token";
+import { useLiveYieldDetails } from "@/hooks/use-live-yield";
+import { useApy } from "@/hooks/use-apy";
+import { useActiveChain } from "@/hooks/use-chain";
+import { useAmountFormatter } from "@/components/demo-mode-provider";
+import { ProgressBar } from "@/components/dapp/ui";
 import { LiveYield } from "@/components/dapp/live-yield";
 
 export default function DistributePage() {
@@ -34,11 +39,30 @@ function Distribute() {
   const tokenStats = useTokenStats();
   const { yieldAccrued } = tokenStats;
   const { symbol } = useInstanceToken();
+  const { live, ratePerMs } = useLiveYieldDetails();
+  const apy = useApy();
+  const { blockTimeSeconds } = useActiveChain();
+  const fmt = useAmountFormatter();
 
   const totalVotes = useMemo(
     () => voting.distribution.reduce((a, b) => a + b, 0n),
     [voting.distribution],
   );
+
+  // Projected pot at cycle end: current accrual + measured rate × time left
+  // (crowdstaking-v2's "Est. after 30 days", generalized to any cycle length).
+  const projected = useMemo(() => {
+    if (live === undefined) return undefined;
+    if (cycle.isComplete || ratePerMs <= 0) return live;
+    const remainingMs = Number(cycle.blocksUntilNext) * blockTimeSeconds * 1000;
+    return live + BigInt(Math.floor(ratePerMs * remainingMs));
+  }, [
+    live,
+    ratePerMs,
+    cycle.isComplete,
+    cycle.blocksUntilNext,
+    blockTimeSeconds,
+  ]);
 
   const checks = [
     { label: "Cycle complete", ok: cycle.isComplete },
@@ -74,9 +98,34 @@ function Distribute() {
           accent
         />
         <StatCard
-          label="Cycle"
-          value={`#${cycle.cycleNumber?.toString() ?? "—"}`}
-          sub={cycle.isComplete ? "Complete" : "In progress"}
+          label="Projected at cycle end"
+          value={`${fmt(projected)} ${symbol}`}
+          sub={
+            apy !== undefined
+              ? `≈ ${apy.toFixed(1)}% APY, measured live`
+              : "Measuring accrual rate…"
+          }
+        />
+        {/* Not a StatCard: its `sub` renders inside a <p>, where the progress
+            bar's <div> would be invalid HTML (hydration error on load). */}
+        <Card>
+          <Caption className="text-surface-grey-2">Cycle</Caption>
+          <Heading4 className="text-text-standard mt-2">
+            #{cycle.cycleNumber?.toString() ?? "—"}
+          </Heading4>
+          <div className="mt-2">
+            <ProgressBar value={cycle.isComplete ? 1 : cycle.progress} />
+          </div>
+          <Caption className="text-surface-grey mt-1 block">
+            {cycle.isComplete
+              ? "Complete — distribution can run"
+              : `${Math.round(cycle.progress * 100)}% elapsed`}
+          </Caption>
+        </Card>
+        <StatCard
+          label="Recipients"
+          value={recipients.length}
+          sub="Will share this round"
         />
       </div>
 

--- a/src/components/dapp/instance-header.tsx
+++ b/src/components/dapp/instance-header.tsx
@@ -6,6 +6,7 @@ import {
   ArrowsClockwise,
   Coins,
   Gavel,
+  Percent,
   ShieldCheck,
   TrendUp,
   UsersThree,
@@ -16,7 +17,15 @@ import { useInstanceToken, useTokenStats } from "@/hooks/use-token";
 import { useRecipients } from "@/hooks/use-recipients";
 import { useCycle } from "@/hooks/use-cycle";
 import { useRegistryKind } from "@/hooks/use-recipient-voting";
-import { useAmountFormatter } from "@/components/demo-mode-provider";
+import { useApy } from "@/hooks/use-apy";
+import { useFamily } from "@/hooks/use-family";
+import { useFamilyStats } from "@/hooks/use-family-stats";
+import {
+  useAmountFormatter,
+  useDemoMode,
+  DEMO_MULTIPLIER,
+} from "@/components/demo-mode-provider";
+import { formatAmount } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 /** cs2-style stat pill: orange-outlined chip with an icon + label + value. */
@@ -56,8 +65,18 @@ export function InstanceHeader() {
   const cycle = useCycle();
   const { kind } = useRegistryKind();
   const fmt = useAmountFormatter();
+  const apy = useApy();
+  const family = useFamily();
+  const fstats = useFamilyStats(family);
+  const { demo } = useDemoMode();
 
   const democratic = kind === "voting";
+  // Families: headline the whole community (all chains summed, 18-dp
+  // normalized), not just the chain being viewed.
+  const familyMode = family.isFamily && fstats.totalStaked18 !== undefined;
+  const fmt18 = (v: bigint | undefined) =>
+    formatAmount(v !== undefined && demo ? v * DEMO_MULTIPLIER : v, 4, 18);
+  const chainsNote = familyMode ? ` · ${fstats.chains} chains` : "";
 
   return (
     <div className="border-paper-2 bg-paper-0 mb-8 rounded-2xl border p-5 sm:p-6">
@@ -91,11 +110,26 @@ export function InstanceHeader() {
       </div>
 
       <div className="mt-5 flex flex-wrap gap-2.5">
-        <Chip icon={<Coins size={18} weight="fill" />} label="Total staked">
-          {fmt(totalSupply)} {symbol}
+        <Chip
+          icon={<Coins size={18} weight="fill" />}
+          label={`Total staked${chainsNote}`}
+        >
+          {familyMode
+            ? `${fmt18(fstats.totalStaked18)} ${symbol}`
+            : `${fmt(totalSupply)} ${symbol}`}
         </Chip>
-        <Chip icon={<TrendUp size={18} weight="fill" />} label="Live yield">
-          <LiveYield symbol={symbol} />
+        <Chip
+          icon={<TrendUp size={18} weight="fill" />}
+          label={`Live yield${chainsNote}`}
+        >
+          {familyMode ? (
+            `${fmt18(fstats.yieldAccrued18)} ${symbol}`
+          ) : (
+            <LiveYield symbol={symbol} />
+          )}
+        </Chip>
+        <Chip icon={<Percent size={18} weight="fill" />} label="APY">
+          {apy !== undefined ? `≈ ${apy.toFixed(1)}%` : "—"}
         </Chip>
         <Chip icon={<UsersThree size={18} weight="fill" />} label="Recipients">
           {recipients.length}

--- a/src/hooks/use-apy.ts
+++ b/src/hooks/use-apy.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useLiveYieldDetails } from "@/hooks/use-live-yield";
+import { useTokenStats } from "@/hooks/use-token";
+import { useActiveChainId, useInstance } from "@/components/instance-provider";
+
+const MS_PER_YEAR = 365 * 24 * 60 * 60 * 1000;
+const CACHE_PREFIX = "crowdstake.apy.v1";
+/** A remeasured APY older than this is shown from cache but re-measured. */
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Estimated APY (percent) for the active instance. These vault-agnostic tokens
+ * expose no `vaultAPY()` oracle (unlike crowdstaking-v2's sDAI adaptor), so we
+ * annualize the observed `yieldAccrued()` growth rate against `totalSupply` —
+ * no archive reads, works on any chain/vault. Two on-chain readings (~one
+ * stats interval) are needed before a fresh measurement lands, so the last
+ * measurement is cached per token for instant display on revisits. Donated
+ * yield only: a community keeping part of its yield reads slightly low.
+ */
+export function useApy(): number | undefined {
+  const { ratePerMs } = useLiveYieldDetails();
+  const { totalSupply } = useTokenStats();
+  const a = useInstance();
+  const chainId = useActiveChainId();
+  const cacheKey = `${CACHE_PREFIX}:${chainId}:${a.token.toLowerCase()}`;
+
+  // The cache is read in an effect — never during render — so the prerendered
+  // HTML and the first client paint agree ("—"), then the cached value pops in
+  // (the DemoModeProvider hydration pattern). Keyed on the instance so an
+  // in-place switch re-reads the right token's entry.
+  const [cached, setCached] = useState<number | undefined>(undefined);
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(cacheKey);
+      if (!raw) {
+        setCached(undefined);
+        return;
+      }
+      const { apy, t } = JSON.parse(raw) as { apy: number; t: number };
+      setCached(Date.now() - t < CACHE_TTL_MS ? apy : undefined);
+    } catch {
+      setCached(undefined);
+    }
+  }, [cacheKey]);
+
+  // A live measurement supersedes (and refreshes) the cache.
+  const measured =
+    totalSupply && totalSupply > 0n && ratePerMs > 0
+      ? (ratePerMs * MS_PER_YEAR * 100) / Number(totalSupply)
+      : undefined;
+
+  useEffect(() => {
+    if (measured === undefined || !Number.isFinite(measured)) return;
+    setCached(measured);
+    try {
+      window.localStorage.setItem(
+        cacheKey,
+        JSON.stringify({ apy: measured, t: Date.now() }),
+      );
+    } catch {
+      /* storage full/blocked — stay measurement-only */
+    }
+  }, [measured, cacheKey]);
+
+  // Note: token decimals cancel out of rate/supply (both are in the token's
+  // own units), so no scaling is needed.
+  return measured ?? cached;
+}

--- a/src/hooks/use-family-stats.ts
+++ b/src/hooks/use-family-stats.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { erc20Abi } from "viem";
+import { tokenAbi } from "@/lib/abis";
+import { publicClientFor } from "@/lib/instance";
+import type { FamilyState } from "@/hooks/use-family";
+
+/** Aggregated live stats across every reachable chain of a family. */
+export interface FamilyStats {
+  /** Σ totalSupply across siblings, normalized to 18 decimals. */
+  totalStaked18?: bigint;
+  /** Σ yieldAccrued across siblings, normalized to 18 decimals. */
+  yieldAccrued18?: bigint;
+  /** Chains included in the sums. */
+  chains: number;
+  /** True when at least one sibling was unreachable (sums are a floor). */
+  partial: boolean;
+}
+
+const POLL_MS = 12_000; // match the single-chain token stats cadence
+const scaleTo18 = (value: bigint, decimals: number) =>
+  decimals >= 18 ? value : value * 10n ** BigInt(18 - decimals);
+
+/**
+ * Family-wide staked/yield totals: fans out `totalSupply()` + `yieldAccrued()`
+ * to every sibling chain's token, normalizes to 18 decimals (the L2 tokens
+ * mirror USDC's 6), and sums. Fail-soft per chain — a dead RPC drops that
+ * chain from the sums and flags `partial`. Inert (all-undefined) for classic
+ * single-chain instances.
+ */
+export function useFamilyStats(family: FamilyState): FamilyStats {
+  const [stats, setStats] = useState<FamilyStats>({
+    chains: 0,
+    partial: false,
+  });
+  // decimals never change per token — read once per sibling, then reuse.
+  const decimalsCache = useRef(new Map<string, number>());
+
+  // Key the effect on the family's membership, not object identity.
+  const memberKey = family.isFamily
+    ? family.perChain
+        .filter((c) => c.instance)
+        .map((c) => `${c.chainId}:${c.instance!.token.toLowerCase()}`)
+        .sort()
+        .join(",")
+    : "";
+
+  useEffect(() => {
+    if (!memberKey) {
+      setStats({ chains: 0, partial: false });
+      return;
+    }
+    const members = memberKey.split(",").map((m) => {
+      const [chainId, token] = m.split(":");
+      return { chainId: Number(chainId), token: token as `0x${string}` };
+    });
+
+    let cancelled = false;
+    const load = async () => {
+      const perChain = await Promise.all(
+        members.map(async (m) => {
+          try {
+            const client = publicClientFor(m.chainId);
+            const key = `${m.chainId}:${m.token}`;
+            let decimals = decimalsCache.current.get(key);
+            if (decimals === undefined) {
+              decimals = await client.readContract({
+                address: m.token,
+                abi: erc20Abi,
+                functionName: "decimals",
+              });
+              decimalsCache.current.set(key, decimals);
+            }
+            const [supply, accrued] = await Promise.all([
+              client.readContract({
+                address: m.token,
+                abi: erc20Abi,
+                functionName: "totalSupply",
+              }),
+              client.readContract({
+                address: m.token,
+                abi: tokenAbi,
+                functionName: "yieldAccrued",
+              }) as Promise<bigint>,
+            ]);
+            return {
+              staked: scaleTo18(supply, decimals),
+              accrued: scaleTo18(accrued, decimals),
+            };
+          } catch {
+            return null; // chain unreachable — sum what we can
+          }
+        }),
+      );
+      if (cancelled) return;
+      const ok = perChain.filter((c) => c !== null);
+      setStats({
+        totalStaked18: ok.length
+          ? ok.reduce((s, c) => s + c.staked, 0n)
+          : undefined,
+        yieldAccrued18: ok.length
+          ? ok.reduce((s, c) => s + c.accrued, 0n)
+          : undefined,
+        chains: ok.length,
+        partial: ok.length < members.length,
+      });
+    };
+
+    void load();
+    const id = setInterval(() => void load(), POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [memberKey]);
+
+  return stats;
+}

--- a/src/hooks/use-live-yield.ts
+++ b/src/hooks/use-live-yield.ts
@@ -2,19 +2,42 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useTokenStats } from "@/hooks/use-token";
+import { useActiveChainId, useInstance } from "@/components/instance-provider";
+
+export interface LiveYieldDetails {
+  /** Extrapolated accrued yield, in wei. */
+  live: bigint | undefined;
+  /** Measured accrual rate in wei/ms (0 until two on-chain readings landed). */
+  ratePerMs: number;
+}
 
 /**
  * A continuously-ticking accrued-yield value. It anchors on the on-chain
  * `yieldAccrued()` (refetched on the token stats' interval), estimates the
  * growth rate from successive readings (smoothed against RPC jitter), and
  * extrapolates between them so the number visibly counts up. Resets (after a
- * distribution) just re-anchor lower. Returns wei (bigint) or undefined.
+ * distribution) just re-anchor lower. The measured rate is exposed so derived
+ * stats (APY, projected-at-cycle-end) share one estimator.
  */
-export function useLiveYield(): bigint | undefined {
+export function useLiveYieldDetails(): LiveYieldDetails {
   const { yieldAccrued } = useTokenStats();
+  const a = useInstance();
+  const chainId = useActiveChainId();
+  const tokenKey = `${chainId}:${a.token.toLowerCase()}`;
   const anchor = useRef<{ value: bigint; t: number } | null>(null);
   const rate = useRef(0); // wei per ms
   const [live, setLive] = useState<bigint | undefined>(undefined);
+  const [ratePerMs, setRatePerMs] = useState(0);
+
+  // Instance switches happen IN PLACE (no remount): drop the previous token's
+  // anchor and rate, or a cross-token delta over a tiny dt would masquerade as
+  // an absurd accrual rate (and poison the APY estimate downstream).
+  useEffect(() => {
+    anchor.current = null;
+    rate.current = 0;
+    setRatePerMs(0);
+    setLive(undefined);
+  }, [tokenKey]);
 
   // Recalibrate on each fresh on-chain reading.
   useEffect(() => {
@@ -24,6 +47,7 @@ export function useLiveYield(): bigint | undefined {
     if (prev && yieldAccrued > prev.value && now > prev.t) {
       const r = Number(yieldAccrued - prev.value) / (now - prev.t);
       rate.current = rate.current === 0 ? r : rate.current * 0.5 + r * 0.5;
+      setRatePerMs(rate.current);
     }
     anchor.current = { value: yieldAccrued, t: now };
     setLive(yieldAccrued);
@@ -40,5 +64,10 @@ export function useLiveYield(): bigint | undefined {
     return () => clearInterval(id);
   }, []);
 
-  return live;
+  return { live, ratePerMs };
+}
+
+/** Just the ticking accrued-yield value, in wei. */
+export function useLiveYield(): bigint | undefined {
+  return useLiveYieldDetails().live;
 }


### PR DESCRIPTION
First slice of adopting the crowdstaking-v2 dashboards ([inventory](https://github.com/BreadchainCoop/crowdstaking-v2) surfaces), adapted to this app's constraints: any instance, multichain families, pure static hosting (no Dune/subgraph/API routes).

**New surfaces**
- **APY chip** (portfolio header): v2 reads `vaultAPY()` from its sDAI adaptor; our vault-agnostic tokens have no oracle, so `useApy()` annualizes the measured `yieldAccrued()` growth rate against `totalSupply`. Works on every chain/vault with zero extra RPC surface; per-token localStorage cache makes revisits instant (effect-read, hydration-safe).
- **Family-wide header stats**: `useFamilyStats()` fans out supply+yield to every sibling chain, normalizes decimals, and sums — the portfolio headline shows the whole community ("· 3 chains"), not just the viewed chain. Fail-soft per chain.
- **Distribution overview** (distribute page): v2's DistributionOverview generalized — live accrued ticker, **projected at cycle end** (measured rate × blocks remaining × chain block time), cycle progress bar, recipients count.

**Correctness** (adversarially reviewed; 4 findings fixed pre-merge): estimator resets on in-place instance switches so a cross-token delta can't fabricate an APY and poison the cache; APY cache read moved out of render (prerender/first-paint agree); the cycle progress bar renders in valid block context (no `<div>`-in-`<p>` hydration error); cache re-keys on instance switch.

**Verified**: lint/format/build green; screenshots of both pages against the live default instance; zero console/page errors on the rebuilt export.

Next slices: richer history breakdowns (per-round % + strategy split), personal stats (projected annual donation, votes cast), holder counts.