### PR TITLE
fix: rate families across all chains — APY, position, live yield

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -14,11 +14,17 @@ import {
   useNativeBalance,
   useInstanceToken,
 } from "@/hooks/use-token";
+import { useFamily } from "@/hooks/use-family";
+import { useFamilyPosition } from "@/hooks/use-family-stats";
+import { shortChainName } from "@/lib/chains";
 import { useCycle } from "@/hooks/use-cycle";
 import { useDistributionReady } from "@/hooks/use-distribution";
 import { useIsRecipient } from "@/hooks/use-recipients";
 import { formatAmount, blocksToDuration } from "@/lib/format";
-import { useAmountFormatter } from "@/components/demo-mode-provider";
+import {
+  useAmountFormatter,
+  useAmountFormatter18,
+} from "@/components/demo-mode-provider";
 import {
   useActiveChain,
   useBaseAssetSymbol,
@@ -35,9 +41,23 @@ export default function PortfolioPage() {
   const isRecipient = useIsRecipient();
   const { symbol: tokenSymbol } = useInstanceToken();
   const fmt = useAmountFormatter();
+  const fmt18 = useAmountFormatter18();
   const nativeSym = useNativeSymbol();
   const baseSym = useBaseAssetSymbol();
   const { blockTimeSeconds } = useActiveChain();
+
+  // Families: your position is your holdings on EVERY chain, not just the one
+  // being viewed (a member usually minted on several).
+  const family = useFamily();
+  const fpos = useFamilyPosition(family);
+  const familyMode = family.isFamily && fpos.balance18 !== undefined;
+  const heldChains = fpos.perChain.filter((c) => c.balance18 > 0n);
+  const balanceBreakdown =
+    familyMode && heldChains.length > 0
+      ? heldChains
+          .map((c) => `${fmt18(c.balance18)} on ${shortChainName(c.chainId)}`)
+          .join(" · ")
+      : null;
 
   return (
     <div>
@@ -60,14 +80,24 @@ export default function PortfolioPage() {
       <Heading4 className="text-text-standard">Your position</Heading4>
       <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <StatCard
-          label={`Your ${tokenSymbol}`}
-          value={`${fmt(balance.data)} ${tokenSymbol}`}
-          sub={`Redeemable 1:1 for ${baseSym}`}
+          label={
+            familyMode
+              ? `Your ${tokenSymbol} · all chains`
+              : `Your ${tokenSymbol}`
+          }
+          value={
+            familyMode
+              ? `${fmt18(fpos.balance18)} ${tokenSymbol}`
+              : `${fmt(balance.data)} ${tokenSymbol}`
+          }
+          sub={balanceBreakdown ?? `Redeemable 1:1 for ${baseSym}`}
           accent
         />
         <StatCard
-          label="Your voting power"
-          value={fmt(votes.data)}
+          label={
+            familyMode ? "Your voting power · all chains" : "Your voting power"
+          }
+          value={familyMode ? fmt18(fpos.votes18) : fmt(votes.data)}
           sub="Delegated automatically on deposit"
         />
         <StatCard

--- a/src/components/dapp/instance-header.tsx
+++ b/src/components/dapp/instance-header.tsx
@@ -22,10 +22,8 @@ import { useFamily } from "@/hooks/use-family";
 import { useFamilyStats } from "@/hooks/use-family-stats";
 import {
   useAmountFormatter,
-  useDemoMode,
-  DEMO_MULTIPLIER,
+  useAmountFormatter18,
 } from "@/components/demo-mode-provider";
-import { formatAmount } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 /** cs2-style stat pill: orange-outlined chip with an icon + label + value. */
@@ -65,17 +63,25 @@ export function InstanceHeader() {
   const cycle = useCycle();
   const { kind } = useRegistryKind();
   const fmt = useAmountFormatter();
-  const apy = useApy();
+  const fmt18 = useAmountFormatter18();
   const family = useFamily();
   const fstats = useFamilyStats(family);
-  const { demo } = useDemoMode();
+  // Families are rated across ALL their chains — the browsed chain alone can
+  // be empty while the community earns elsewhere.
+  const apy = useApy(
+    family.isFamily
+      ? {
+          familyId: family.familyId,
+          ratePerMs: fstats.ratePerMs,
+          totalStaked18: fstats.totalStaked18,
+        }
+      : undefined,
+  );
 
   const democratic = kind === "voting";
   // Families: headline the whole community (all chains summed, 18-dp
   // normalized), not just the chain being viewed.
   const familyMode = family.isFamily && fstats.totalStaked18 !== undefined;
-  const fmt18 = (v: bigint | undefined) =>
-    formatAmount(v !== undefined && demo ? v * DEMO_MULTIPLIER : v, 4, 18);
   const chainsNote = familyMode ? ` · ${fstats.chains} chains` : "";
 
   return (
@@ -123,7 +129,9 @@ export function InstanceHeader() {
           label={`Live yield${chainsNote}`}
         >
           {familyMode ? (
-            `${fmt18(fstats.yieldAccrued18)} ${symbol}`
+            // 6 fractional digits like the ticking single-chain counter —
+            // young families accrue amounts a 4-dp display rounds to zero.
+            `${fmt18(fstats.yieldAccrued18, 6)} ${symbol}`
           ) : (
             <LiveYield symbol={symbol} />
           )}

--- a/src/components/demo-mode-provider.tsx
+++ b/src/components/demo-mode-provider.tsx
@@ -75,3 +75,18 @@ export function useAmountFormatter(): (value?: bigint) => string {
       ? formatAmount(value, 4, decimals)
       : formatAmount(demo ? value * DEMO_MULTIPLIER : value, 4, decimals);
 }
+
+/**
+ * Formatter for 18-decimal-normalized values (family-wide sums, which mix
+ * 18-dp native tokens with 6-dp USDC mirrors). Demo-scaled like the rest.
+ */
+export function useAmountFormatter18(): (
+  value?: bigint,
+  maxFrac?: number,
+) => string {
+  const { demo } = useDemoMode();
+  return (value?: bigint, maxFrac = 4) =>
+    value === undefined || value === null
+      ? formatAmount(value, maxFrac, 18)
+      : formatAmount(demo ? value * DEMO_MULTIPLIER : value, maxFrac, 18);
+}

--- a/src/hooks/use-apy.ts
+++ b/src/hooks/use-apy.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { Hex } from "viem";
 import { useLiveYieldDetails } from "@/hooks/use-live-yield";
 import { useTokenStats } from "@/hooks/use-token";
 import { useActiveChainId, useInstance } from "@/components/instance-provider";
@@ -10,6 +11,13 @@ const CACHE_PREFIX = "crowdstake.apy.v1";
 /** A remeasured APY older than this is shown from cache but re-measured. */
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
+/** Family-wide inputs (from useFamilyStats) — pass to rate the WHOLE family. */
+export interface FamilyApyInput {
+  familyId: Hex | null;
+  ratePerMs: number;
+  totalStaked18?: bigint;
+}
+
 /**
  * Estimated APY (percent) for the active instance. These vault-agnostic tokens
  * expose no `vaultAPY()` oracle (unlike crowdstaking-v2's sDAI adaptor), so we
@@ -18,13 +26,23 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
  * stats interval) are needed before a fresh measurement lands, so the last
  * measurement is cached per token for instant display on revisits. Donated
  * yield only: a community keeping part of its yield reads slightly low.
+ *
+ * Pass `family` (from useFamilyStats) to rate a family across ALL its chains —
+ * the single-chain view of a family can be empty (zero supply) on the chain
+ * being browsed while the community earns elsewhere.
  */
-export function useApy(): number | undefined {
-  const { ratePerMs } = useLiveYieldDetails();
+export function useApy(family?: FamilyApyInput): number | undefined {
+  const single = useLiveYieldDetails();
   const { totalSupply } = useTokenStats();
   const a = useInstance();
   const chainId = useActiveChainId();
-  const cacheKey = `${CACHE_PREFIX}:${chainId}:${a.token.toLowerCase()}`;
+
+  const familyMode = Boolean(family?.familyId);
+  const ratePerMs = familyMode ? family!.ratePerMs : single.ratePerMs;
+  const supply = familyMode ? family!.totalStaked18 : totalSupply;
+  const cacheKey = familyMode
+    ? `${CACHE_PREFIX}:family:${family!.familyId}`
+    : `${CACHE_PREFIX}:${chainId}:${a.token.toLowerCase()}`;
 
   // The cache is read in an effect — never during render — so the prerendered
   // HTML and the first client paint agree ("—"), then the cached value pops in
@@ -47,8 +65,8 @@ export function useApy(): number | undefined {
 
   // A live measurement supersedes (and refreshes) the cache.
   const measured =
-    totalSupply && totalSupply > 0n && ratePerMs > 0
-      ? (ratePerMs * MS_PER_YEAR * 100) / Number(totalSupply)
+    supply && supply > 0n && ratePerMs > 0
+      ? (ratePerMs * MS_PER_YEAR * 100) / Number(supply)
       : undefined;
 
   useEffect(() => {

--- a/src/hooks/use-family-stats.ts
+++ b/src/hooks/use-family-stats.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { erc20Abi } from "viem";
+import { erc20Abi, type Address } from "viem";
+import { useAccount } from "wagmi";
 import { tokenAbi } from "@/lib/abis";
 import { publicClientFor } from "@/lib/instance";
 import type { FamilyState } from "@/hooks/use-family";
@@ -12,6 +13,12 @@ export interface FamilyStats {
   totalStaked18?: bigint;
   /** Σ yieldAccrued across siblings, normalized to 18 decimals. */
   yieldAccrued18?: bigint;
+  /**
+   * Measured family-wide accrual rate, 18-dp wei/ms (0 until two polls landed).
+   * Same estimator as the single-chain live-yield ticker, over the summed
+   * accrued value.
+   */
+  ratePerMs: number;
   /** Chains included in the sums. */
   chains: number;
   /** True when at least one sibling was unreachable (sums are a floor). */
@@ -22,6 +29,23 @@ const POLL_MS = 12_000; // match the single-chain token stats cadence
 const scaleTo18 = (value: bigint, decimals: number) =>
   decimals >= 18 ? value : value * 10n ** BigInt(18 - decimals);
 
+/** Serialize the family membership so effects key on content, not identity. */
+function familyMemberKey(family: FamilyState): string {
+  if (!family.isFamily) return "";
+  return family.perChain
+    .filter((c) => c.instance)
+    .map((c) => `${c.chainId}:${c.instance!.token.toLowerCase()}`)
+    .sort()
+    .join(",");
+}
+
+function parseMembers(memberKey: string) {
+  return memberKey.split(",").map((m) => {
+    const [chainId, token] = m.split(":");
+    return { chainId: Number(chainId), token: token as Address };
+  });
+}
+
 /**
  * Family-wide staked/yield totals: fans out `totalSupply()` + `yieldAccrued()`
  * to every sibling chain's token, normalizes to 18 decimals (the L2 tokens
@@ -31,30 +55,30 @@ const scaleTo18 = (value: bigint, decimals: number) =>
  */
 export function useFamilyStats(family: FamilyState): FamilyStats {
   const [stats, setStats] = useState<FamilyStats>({
+    ratePerMs: 0,
     chains: 0,
     partial: false,
   });
   // decimals never change per token — read once per sibling, then reuse.
   const decimalsCache = useRef(new Map<string, number>());
+  // Rate estimation over the summed accrued (only comparable when the same
+  // chain set responded — a chain dropping out would fake a negative delta).
+  const anchor = useRef<{ value: bigint; t: number; chains: number } | null>(
+    null,
+  );
+  const rate = useRef(0);
 
-  // Key the effect on the family's membership, not object identity.
-  const memberKey = family.isFamily
-    ? family.perChain
-        .filter((c) => c.instance)
-        .map((c) => `${c.chainId}:${c.instance!.token.toLowerCase()}`)
-        .sort()
-        .join(",")
-    : "";
+  const memberKey = familyMemberKey(family);
 
   useEffect(() => {
+    // New family (or in-place instance switch) — old anchors are meaningless.
+    anchor.current = null;
+    rate.current = 0;
     if (!memberKey) {
-      setStats({ chains: 0, partial: false });
+      setStats({ ratePerMs: 0, chains: 0, partial: false });
       return;
     }
-    const members = memberKey.split(",").map((m) => {
-      const [chainId, token] = m.split(":");
-      return { chainId: Number(chainId), token: token as `0x${string}` };
-    });
+    const members = parseMembers(memberKey);
 
     let cancelled = false;
     const load = async () => {
@@ -95,13 +119,31 @@ export function useFamilyStats(family: FamilyState): FamilyStats {
       );
       if (cancelled) return;
       const ok = perChain.filter((c) => c !== null);
+      const accruedSum = ok.length
+        ? ok.reduce((s, c) => s + c.accrued, 0n)
+        : undefined;
+
+      if (accruedSum !== undefined) {
+        const now = Date.now();
+        const prev = anchor.current;
+        if (
+          prev &&
+          prev.chains === ok.length && // same coverage — delta is real
+          accruedSum > prev.value &&
+          now > prev.t
+        ) {
+          const r = Number(accruedSum - prev.value) / (now - prev.t);
+          rate.current = rate.current === 0 ? r : rate.current * 0.5 + r * 0.5;
+        }
+        anchor.current = { value: accruedSum, t: now, chains: ok.length };
+      }
+
       setStats({
         totalStaked18: ok.length
           ? ok.reduce((s, c) => s + c.staked, 0n)
           : undefined,
-        yieldAccrued18: ok.length
-          ? ok.reduce((s, c) => s + c.accrued, 0n)
-          : undefined,
+        yieldAccrued18: accruedSum,
+        ratePerMs: rate.current,
         chains: ok.length,
         partial: ok.length < members.length,
       });
@@ -116,4 +158,103 @@ export function useFamilyStats(family: FamilyState): FamilyStats {
   }, [memberKey]);
 
   return stats;
+}
+
+/** The connected wallet's family-wide position. */
+export interface FamilyPosition {
+  /** Σ balanceOf across siblings, normalized to 18 decimals. */
+  balance18?: bigint;
+  /** Σ getVotes across siblings, normalized to 18 decimals. */
+  votes18?: bigint;
+  /** Per-chain balances (18-dp), for the "0.5 on Arbitrum" breakdown. */
+  perChain: { chainId: number; balance18: bigint }[];
+  partial: boolean;
+}
+
+/**
+ * The connected wallet's position summed across every family chain — a family
+ * member usually holds the token on several chains, and the portfolio should
+ * headline the whole holding, not just the chain being viewed.
+ */
+export function useFamilyPosition(family: FamilyState): FamilyPosition {
+  const { address } = useAccount();
+  const [pos, setPos] = useState<FamilyPosition>({
+    perChain: [],
+    partial: false,
+  });
+  const decimalsCache = useRef(new Map<string, number>());
+
+  const memberKey = familyMemberKey(family);
+  const account = address?.toLowerCase() ?? "";
+
+  useEffect(() => {
+    if (!memberKey || !account) {
+      setPos({ perChain: [], partial: false });
+      return;
+    }
+    const members = parseMembers(memberKey);
+
+    let cancelled = false;
+    const load = async () => {
+      const perChain = await Promise.all(
+        members.map(async (m) => {
+          try {
+            const client = publicClientFor(m.chainId);
+            const key = `${m.chainId}:${m.token}`;
+            let decimals = decimalsCache.current.get(key);
+            if (decimals === undefined) {
+              decimals = await client.readContract({
+                address: m.token,
+                abi: erc20Abi,
+                functionName: "decimals",
+              });
+              decimalsCache.current.set(key, decimals);
+            }
+            const [balance, votes] = await Promise.all([
+              client.readContract({
+                address: m.token,
+                abi: erc20Abi,
+                functionName: "balanceOf",
+                args: [account as Address],
+              }),
+              client
+                .readContract({
+                  address: m.token,
+                  abi: tokenAbi,
+                  functionName: "getVotes",
+                  args: [account as Address],
+                })
+                .catch(() => 0n) as Promise<bigint>,
+            ]);
+            return {
+              chainId: m.chainId,
+              balance18: scaleTo18(balance, decimals),
+              votes18: scaleTo18(votes, decimals),
+            };
+          } catch {
+            return null;
+          }
+        }),
+      );
+      if (cancelled) return;
+      const ok = perChain.filter((c) => c !== null);
+      setPos({
+        balance18: ok.length
+          ? ok.reduce((s, c) => s + c.balance18, 0n)
+          : undefined,
+        votes18: ok.length ? ok.reduce((s, c) => s + c.votes18, 0n) : undefined,
+        perChain: ok.map(({ chainId, balance18 }) => ({ chainId, balance18 })),
+        partial: ok.length < members.length,
+      });
+    };
+
+    void load();
+    const id = setInterval(() => void load(), POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [memberKey, account]);
+
+  return pos;
 }


### PR DESCRIPTION
Live report on Convent (`?i=0xC6bC…11E6`, Gnosis view): APY showed `—` forever and "Your CONV: 0" while the wallet held 0.72 CONV across OP+Arbitrum. Both were single-chain reads on a multichain family.

- `useApy(family?)`: rates the whole family — the measured rate now also runs over the family-wide accrued sum (in `useFamilyStats`, guarded so a sibling RPC dropping out can't fabricate a delta) against family-wide staked. Family cache key `crowdstake.apy.v1:family:<id>`.
- `useFamilyPosition()`: the connected wallet's balance + voting power summed across all sibling chains (18-dp normalized), with a per-chain breakdown — portfolio shows "Your CONV · all chains: 0.7196" with "0.54 on Arbitrum · 0.18 on OP Mainnet".
- Family live-yield chip renders 6 fractional digits (young families accrue amounts that round to zero at 4).

Gates: lint / format:check / build green.