### PR TITLE
feat: family-aware distribute + auto-synced recipients

### DIFF
--- a/src/app/app/distribute/_components/family-distribute-card.tsx
+++ b/src/app/app/distribute/_components/family-distribute-card.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { ArrowSquareOut, CheckCircle } from "@phosphor-icons/react";
+import { Button, Caption } from "@breadcoop/ui";
+import { Card } from "@/components/dapp/ui";
+import { shortChainName, txUrl } from "@/lib/chains";
+import { useActiveChainId } from "@/components/instance-provider";
+import { useAmountFormatter18 } from "@/components/demo-mode-provider";
+import { GasModeNote } from "@/components/dapp/gas-mode-note";
+import { useInstanceToken } from "@/hooks/use-token";
+import {
+  useFamilyDistribute,
+  type FamilyDistributeRow,
+} from "@/hooks/use-family-distribute";
+import type { FamilyState } from "@/hooks/use-family";
+
+/**
+ * The family's per-chain distribution checklist — yield accrues and distributes
+ * independently on every chain, so each row shows that chain's pot, cycle, and
+ * readiness with its own Distribute button (a public keeper action).
+ */
+export function FamilyDistributeCard({ family }: { family: FamilyState }) {
+  const activeChainId = useActiveChainId();
+  const { rows, distributeOn } = useFamilyDistribute(family);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <Card className="mb-6">
+      <Caption className="text-surface-grey-2 block">
+        Your community across chains — yield accrues and distributes per chain
+      </Caption>
+      <div className="mt-1">
+        <GasModeNote />
+      </div>
+      <ul className="mt-3 space-y-3">
+        {rows.map((r) => (
+          <ChainRow
+            key={r.chainId}
+            row={r}
+            isActive={r.chainId === activeChainId}
+            onDistribute={() => void distributeOn(r.chainId)}
+          />
+        ))}
+      </ul>
+    </Card>
+  );
+}
+
+function ChainRow({
+  row,
+  isActive,
+  onDistribute,
+}: {
+  row: FamilyDistributeRow;
+  isActive: boolean;
+  onDistribute: () => void;
+}) {
+  const fmt18 = useAmountFormatter18();
+  const { symbol } = useInstanceToken();
+  const busy = row.state === "distributing" || row.state === "confirming";
+
+  return (
+    <li className="border-paper-2 flex items-start justify-between gap-3 border-t pt-3 first:border-t-0 first:pt-0">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-breadDisplay text-text-standard font-bold">
+            {shortChainName(row.chainId)}
+          </span>
+          {isActive && (
+            <Caption className="text-surface-grey">this chain</Caption>
+          )}
+          {row.isReady && (
+            <span className="bg-system-green/10 text-system-green rounded-full px-2 py-0.5 text-xs font-semibold">
+              ready
+            </span>
+          )}
+        </div>
+
+        {row.unreachable ? (
+          <Caption className="text-system-warning mt-0.5 block">
+            couldn&apos;t reach chain
+          </Caption>
+        ) : (
+          <Caption className="text-surface-grey-2 mt-0.5 block">
+            {fmt18(row.accrued18)} {symbol} accrued · cycle #
+            {row.cycleNumber?.toString() ?? "—"}
+            {row.isReady === false &&
+              (row.isComplete ? " · complete, not ready" : " · in progress")}
+          </Caption>
+        )}
+
+        {row.state === "done" && (
+          <Caption className="text-system-green mt-1 flex items-center gap-1">
+            <CheckCircle size={13} weight="fill" /> distributed — cycle advanced
+            {row.txHash && (
+              <a
+                href={txUrl(row.txHash, row.chainId)}
+                target="_blank"
+                rel="noreferrer"
+                className="text-core-orange inline-flex items-center gap-0.5 hover:underline"
+              >
+                View <ArrowSquareOut size={11} />
+              </a>
+            )}
+          </Caption>
+        )}
+        {row.state === "failed" && row.error && (
+          <Caption className="text-system-red mt-1 block">{row.error}</Caption>
+        )}
+      </div>
+
+      <Button
+        app="fund"
+        variant="secondary"
+        size="sm"
+        className="flex-none"
+        isLoading={busy}
+        onClick={onDistribute}
+        {...(!row.isReady && !busy ? { disabled: true } : {})}
+      >
+        {row.state === "failed" ? "Retry" : "Distribute"}
+      </Button>
+    </li>
+  );
+}

--- a/src/app/app/distribute/page.tsx
+++ b/src/app/app/distribute/page.tsx
@@ -14,9 +14,13 @@ import { useInstanceToken, useTokenStats } from "@/hooks/use-token";
 import { useLiveYieldDetails } from "@/hooks/use-live-yield";
 import { useApy } from "@/hooks/use-apy";
 import { useActiveChain } from "@/hooks/use-chain";
+import { useFamily } from "@/hooks/use-family";
 import { useAmountFormatter } from "@/components/demo-mode-provider";
 import { ProgressBar } from "@/components/dapp/ui";
 import { LiveYield } from "@/components/dapp/live-yield";
+import { shortChainName } from "@/lib/chains";
+import { useActiveChainId } from "@/components/instance-provider";
+import { FamilyDistributeCard } from "./_components/family-distribute-card";
 
 export default function DistributePage() {
   return (
@@ -42,6 +46,8 @@ function Distribute() {
   const { live, ratePerMs } = useLiveYieldDetails();
   const apy = useApy();
   const { blockTimeSeconds } = useActiveChain();
+  const family = useFamily();
+  const chainId = useActiveChainId();
   const fmt = useAmountFormatter();
 
   const totalVotes = useMemo(
@@ -129,8 +135,16 @@ function Distribute() {
         />
       </div>
 
+      {/* Family instances: every sibling chain's pot + its own Distribute.
+          The single-chain readiness card below stays as this chain's detail. */}
+      {family.isFamily && <FamilyDistributeCard family={family} />}
+
       <Card>
-        <Caption className="text-surface-grey-2">Readiness</Caption>
+        <Caption className="text-surface-grey-2">
+          {family.isFamily
+            ? `Readiness on ${shortChainName(chainId)} — this chain`
+            : "Readiness"}
+        </Caption>
         <ul className="mt-3 space-y-2">
           {checks.map((c) => (
             <li key={c.label} className="flex items-center gap-2">

--- a/src/app/app/recipients/page.tsx
+++ b/src/app/app/recipients/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { isAddress, zeroAddress, type Address } from "viem";
 import { useAccount } from "wagmi";
 import { Body, Button, Caption } from "@breadcoop/ui";
@@ -10,6 +10,7 @@ import {
   ArrowsClockwise,
   X,
   CheckCircle,
+  Globe,
 } from "@phosphor-icons/react";
 import {
   Card,
@@ -41,8 +42,11 @@ import {
 } from "@/hooks/use-recipient-voting";
 import { shortenAddress } from "@/lib/format";
 import { addressUrl, shortChainName } from "@/lib/chains";
-import { useActiveChainId } from "@/components/instance-provider";
-import { useFamily } from "@/hooks/use-family";
+import { useActiveChainId, useInstance } from "@/components/instance-provider";
+import { publicClientFor } from "@/lib/instance";
+import { recipientRegistryAbi } from "@/lib/abis";
+import { useFamily, type FamilyState } from "@/hooks/use-family";
+import { useCrossChainRegistryUpdate } from "@/hooks/use-cross-chain-registry-update";
 import {
   useCrossChainProposals,
   useSiblingProposalExpiry,
@@ -87,7 +91,7 @@ function RecipientsRouter() {
       <DemocraticRecipients />
     );
   }
-  return <AdminRecipients />;
+  return <AdminRecipients family={family} />;
 }
 
 const lc = (a: string) => a.toLowerCase();
@@ -98,8 +102,33 @@ const sortAsc = (arr: Address[]) =>
     BigInt(a) < BigInt(b) ? -1 : BigInt(a) > BigInt(b) ? 1 : 0,
   );
 
-function AdminRecipients() {
+/** Per-chain copy for the family auto-sync (same grammar as the Admin page). */
+function syncStateLabel(row: ChainActionRow): string {
+  switch (row.state) {
+    case "confirmed":
+      return "Synced";
+    case "superseded":
+      return "Superseded by a newer sync";
+    case "recipient_mismatch":
+      return "Recipient list out of sync";
+    case "unreachable":
+      return "Couldn't reach chain";
+    case "failed":
+      return row.error ?? "Delivery failed";
+    case "submitted":
+      return "Submitted — confirming…";
+    case "relaying":
+      return "Submitting…";
+    case "signing":
+      return "Waiting for your signature…";
+    default:
+      return "Waiting…";
+  }
+}
+
+function AdminRecipients({ family }: { family: FamilyState }) {
   const chainId = useActiveChainId();
+  const instance = useInstance();
   const { isConnected } = useAccount();
   const { isAdmin } = useRegistryOwner();
   const { recipients, queuedAdditions, queuedRemovals, refetch } =
@@ -114,6 +143,39 @@ function AdminRecipients() {
   const processTx = useProcessQueue();
   const clearTx = useClearQueue();
   const transferTx = useTransferAdmin();
+
+  // Family auto-sync (admin registries — this component only renders for that
+  // kind): after a local membership change lands, push the new set to every
+  // sibling with the same sign-once flow as the Admin page's manual button.
+  const sync = useCrossChainRegistryUpdate(family);
+  const siblingCount = family.perChain.filter(
+    (c) => c.status === "found" && c.chainId !== chainId,
+  ).length;
+  // Queuing adds/removes doesn't change getRecipients — membership only moves
+  // on processQueue, so that's the sync trigger. Keyed on the tx hash so one
+  // completed change fires exactly one sync.
+  const lastSyncedHashRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!processTx.isSuccess || !processTx.hash) return;
+    if (!family.isFamily || siblingCount === 0 || !isAdmin) return;
+    if (lastSyncedHashRef.current === processTx.hash) return;
+    lastSyncedHashRef.current = processTx.hash;
+    void (async () => {
+      try {
+        // Read the just-processed membership straight from the chain — the
+        // wagmi cache may still hold the pre-process list.
+        const fresh = await publicClientFor(chainId).readContract({
+          address: instance.recipientRegistry,
+          abi: recipientRegistryAbi,
+          functionName: "getRecipients",
+        });
+        await sync.sign(fresh);
+      } catch {
+        /* best-effort — the Admin page's manual sync remains available */
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [processTx.isSuccess, processTx.hash]);
 
   const knownAdds = new Set(
     [...recipients, ...queuedAdditions, ...pendingAdds].map(lc),
@@ -397,6 +459,49 @@ function AdminRecipients() {
               />
             </>
           )}
+        </Card>
+      )}
+
+      {/* Family auto-sync delivery status. Local success stands on its own —
+          a failed sibling delivery is shown (and retryable) without blocking. */}
+      {(sync.phase !== "idle" || sync.error) && (
+        <Card>
+          <Caption className="text-text-standard flex items-center gap-1.5 font-semibold">
+            <Globe size={16} weight="fill" className="text-core-orange" />
+            Syncing recipients everywhere
+          </Caption>
+          {sync.isBusy && (
+            <Caption className="text-surface-grey-2 mt-1 block">
+              Syncing membership to {siblingCount} sibling chain
+              {siblingCount === 1 ? "" : "s"}…
+            </Caption>
+          )}
+          {sync.error && (
+            <Caption className="text-system-red mt-2 block">
+              {sync.error}
+            </Caption>
+          )}
+          <MultiChainActionStatus
+            rows={sync.rows}
+            phase={sync.phase}
+            submitting={sync.submitting}
+            payload={sync.payload}
+            onSubmitOnChain={sync.submitOnChain}
+            onRetryFailed={sync.retryFailed}
+            copy={{
+              stateLabel: syncStateLabel,
+              aggregate: ({ counted, total, phase }) =>
+                phase === "signing"
+                  ? "Confirm in your wallet…"
+                  : phase === "done"
+                    ? `Synced on ${counted} of ${total} chain${
+                        total === 1 ? "" : "s"
+                      }`
+                    : `Syncing ${total} chain${total === 1 ? "" : "s"}…`,
+              copyLabel: "Copy signed sync",
+              copyHint: "Anyone can deliver this — paste it to your community.",
+            }}
+          />
         </Card>
       )}
 

--- a/src/app/app/recipients/page.tsx
+++ b/src/app/app/recipients/page.tsx
@@ -157,6 +157,10 @@ function AdminRecipients({ family }: { family: FamilyState }) {
   const lastSyncedHashRef = useRef<string | null>(null);
   useEffect(() => {
     if (!processTx.isSuccess || !processTx.hash) return;
+    // A sign() already fanning out must finish first — re-entering swaps the
+    // shared payload under its loop. isBusy is in the deps, so the skipped
+    // sync fires as soon as the running one settles.
+    if (sync.isBusy) return;
     if (!family.isFamily || siblingCount === 0 || !isAdmin) return;
     if (lastSyncedHashRef.current === processTx.hash) return;
     lastSyncedHashRef.current = processTx.hash;
@@ -175,7 +179,7 @@ function AdminRecipients({ family }: { family: FamilyState }) {
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [processTx.isSuccess, processTx.hash]);
+  }, [processTx.isSuccess, processTx.hash, sync.isBusy]);
 
   const knownAdds = new Set(
     [...recipients, ...queuedAdditions, ...pendingAdds].map(lc),

--- a/src/app/app/withdraw/page.tsx
+++ b/src/app/app/withdraw/page.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Caption } from "@breadcoop/ui";
+import { Body, Caption } from "@breadcoop/ui";
 import { Card, PageHeader } from "@/components/dapp/ui";
 import { AmountField } from "@/components/dapp/amount-field";
 import { ActionButton } from "@/components/dapp/action-button";
 import { TxStatus } from "@/components/dapp/tx-status";
 import { formatAmount, parseAmount } from "@/lib/format";
+import { shortChainName } from "@/lib/chains";
+import { useActiveChainId } from "@/components/instance-provider";
+import { useAmountFormatter18 } from "@/components/demo-mode-provider";
 import { useActiveChain, useNativeSymbol } from "@/hooks/use-chain";
+import { useFamily } from "@/hooks/use-family";
+import { useFamilyPosition } from "@/hooks/use-family-stats";
 import {
   useInstanceToken,
   useTokenBalance,
@@ -30,8 +35,50 @@ export default function WithdrawPage() {
         title="Withdraw"
         subtitle={`Burn ${symbol} to redeem your ${redeemSym} principal 1:1. Your stake is always fully withdrawable.`}
       />
+      <FamilyWithdrawNote />
       <WithdrawForm />
     </div>
+  );
+}
+
+/**
+ * Family mode: withdrawals burn the LOCAL chain's token, so show where the
+ * rest of the holding lives (18-dp normalized across the family).
+ */
+function FamilyWithdrawNote() {
+  const family = useFamily();
+  const chainId = useActiveChainId();
+  const pos = useFamilyPosition(family);
+  const fmt18 = useAmountFormatter18();
+  const { symbol } = useInstanceToken();
+  if (!family.isFamily) return null;
+  const here = pos.perChain.find((c) => c.chainId === chainId);
+  const elsewhere = pos.perChain.filter(
+    (c) => c.chainId !== chainId && c.balance18 > 0n,
+  );
+  return (
+    <Card className="mb-6">
+      <Body className="text-surface-grey-2 text-sm">
+        Withdrawals act per chain. You&apos;re withdrawing on{" "}
+        <span className="text-text-standard font-semibold">
+          {shortChainName(chainId)}
+        </span>
+        {here && ` (balance there: ${fmt18(here.balance18)} ${symbol})`}.
+        {elsewhere.length > 0 && (
+          <>
+            {" "}
+            You also hold{" "}
+            {elsewhere
+              .map(
+                (c) =>
+                  `${fmt18(c.balance18)} ${symbol} on ${shortChainName(c.chainId)}`,
+              )
+              .join(" · ")}
+            .
+          </>
+        )}
+      </Body>
+    </Card>
   );
 }
 

--- a/src/app/app/yield/page.tsx
+++ b/src/app/app/yield/page.tsx
@@ -6,8 +6,11 @@ import { Card, PageHeader } from "@/components/dapp/ui";
 import { ActionButton } from "@/components/dapp/action-button";
 import { TxStatus } from "@/components/dapp/tx-status";
 import { cn } from "@/lib/utils";
+import { shortChainName } from "@/lib/chains";
+import { useActiveChainId } from "@/components/instance-provider";
 import { useAmountFormatter } from "@/components/demo-mode-provider";
 import { useBaseAssetSymbol } from "@/hooks/use-chain";
+import { useFamily } from "@/hooks/use-family";
 import {
   useClaimKeptYield,
   useInstanceToken,
@@ -26,9 +29,28 @@ export default function YieldPage() {
         title="Yield split"
         subtitle="Choose how much of the yield your stake earns goes to the community's recipients and how much you keep for yourself."
       />
+      <FamilySplitNote />
       <SplitForm />
       <KeptYieldCard />
     </div>
+  );
+}
+
+/** Family mode: the split is a per-chain token setting — say so honestly. */
+function FamilySplitNote() {
+  const family = useFamily();
+  const chainId = useActiveChainId();
+  if (!family.isFamily) return null;
+  return (
+    <Card className="mb-6">
+      <Body className="text-surface-grey-2 text-sm">
+        Your yield split applies per chain. You&apos;re setting it for{" "}
+        <span className="text-text-standard font-semibold">
+          {shortChainName(chainId)}
+        </span>
+        ; switch chains in the instance picker to set it elsewhere.
+      </Body>
+    </Card>
   );
 }
 

--- a/src/hooks/use-family-distribute.ts
+++ b/src/hooks/use-family-distribute.ts
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { erc20Abi, type Address, type Hex } from "viem";
+import { cycleModuleAbi, distributionManagerAbi, tokenAbi } from "@/lib/abis";
+import { publicClientFor } from "@/lib/instance";
+import { parseTxError } from "@/hooks/use-tx";
+import { useWalletActions } from "@/components/wallet/wallet-actions";
+import type { FamilyState } from "@/hooks/use-family";
+
+/** Per-chain action state for one family chain's distribution. */
+export type FamilyDistributeState =
+  "idle" | "distributing" | "confirming" | "done" | "failed";
+
+export interface FamilyDistributeRow {
+  chainId: number;
+  distributionManager: Address;
+  cycleNumber?: bigint;
+  isComplete?: boolean;
+  /** The contract's own gate — the only thing that enables the button. */
+  isReady?: boolean;
+  /** yieldAccrued normalized to 18 decimals (the L2 mirrors are 6-dp USDC). */
+  accrued18?: bigint;
+  /** Reads failed on this chain — readiness unknown. */
+  unreachable?: boolean;
+  state: FamilyDistributeState;
+  txHash?: Hex;
+  error?: string;
+}
+
+const POLL_MS = 12_000; // match the single-chain isDistributionReady cadence
+const scaleTo18 = (value: bigint, decimals: number) =>
+  decimals >= 18 ? value : value * 10n ** BigInt(18 - decimals);
+
+interface Member {
+  chainId: number;
+  distributionManager: Address;
+  cycleModule: Address;
+  token: Address;
+}
+
+/** Serialize the family membership so effects key on content, not identity. */
+function memberKeyOf(family: FamilyState): string {
+  if (!family.isFamily) return "";
+  return family.perChain
+    .filter((c) => c.status === "found" && c.instance)
+    .map((c) =>
+      [
+        c.chainId,
+        c.instance!.distributionManager.toLowerCase(),
+        c.instance!.cycleModule.toLowerCase(),
+        c.instance!.token.toLowerCase(),
+      ].join(":"),
+    )
+    .sort()
+    .join(",");
+}
+
+function parseMembers(memberKey: string): Member[] {
+  return memberKey
+    .split(",")
+    .map((m) => {
+      const [chainId, distributionManager, cycleModule, token] = m.split(":");
+      return {
+        chainId: Number(chainId),
+        distributionManager: distributionManager as Address,
+        cycleModule: cycleModule as Address,
+        token: token as Address,
+      };
+    })
+    .sort((a, b) => a.chainId - b.chainId);
+}
+
+/** The refreshable read fields — patched by polls without touching tx state. */
+type ChainReads = Pick<
+  FamilyDistributeRow,
+  "cycleNumber" | "isComplete" | "isReady" | "accrued18" | "unreachable"
+>;
+
+async function readChain(
+  m: Member,
+  decimalsCache: Map<number, number>,
+): Promise<ChainReads> {
+  const client = publicClientFor(m.chainId);
+  let decimals = decimalsCache.get(m.chainId);
+  if (decimals === undefined) {
+    decimals = await client.readContract({
+      address: m.token,
+      abi: erc20Abi,
+      functionName: "decimals",
+    });
+    decimalsCache.set(m.chainId, decimals);
+  }
+  const [cycleNumber, isComplete, isReady, accrued] = await Promise.all([
+    client.readContract({
+      address: m.cycleModule,
+      abi: cycleModuleAbi,
+      functionName: "getCurrentCycle",
+    }),
+    client.readContract({
+      address: m.cycleModule,
+      abi: cycleModuleAbi,
+      functionName: "isCycleComplete",
+    }),
+    client.readContract({
+      address: m.distributionManager,
+      abi: distributionManagerAbi,
+      functionName: "isDistributionReady",
+    }),
+    client.readContract({
+      address: m.token,
+      abi: tokenAbi,
+      functionName: "yieldAccrued",
+    }) as Promise<bigint>,
+  ]);
+  return {
+    cycleNumber,
+    isComplete,
+    isReady,
+    accrued18: scaleTo18(accrued, decimals),
+    unreachable: false,
+  };
+}
+
+/**
+ * Family-wide distribution checklist: one row per sibling chain with its cycle
+ * number, readiness, and accrued pot (18-dp normalized), each independently
+ * distributable. `claimAndDistribute` is a public keeper call, so any visitor
+ * can run it on every chain from one page — writes go through the sponsored
+ * wallet layer (gasless on embedded wallets, chain-switching self-paid
+ * otherwise) and each receipt is awaited on that chain's OWN client, never the
+ * wallet-chain wait. Fail-soft per chain: a dead RPC marks the row unreachable
+ * without breaking the rest.
+ */
+export function useFamilyDistribute(family: FamilyState) {
+  const { sendSponsored } = useWalletActions();
+
+  const [rows, setRowsState] = useState<FamilyDistributeRow[]>([]);
+  const rowsRef = useRef<FamilyDistributeRow[]>([]);
+  const membersRef = useRef<Member[]>([]);
+  // decimals never change per token — read once per sibling, then reuse.
+  const decimalsCache = useRef(new Map<number, number>());
+
+  const setRows = useCallback(
+    (updater: (prev: FamilyDistributeRow[]) => FamilyDistributeRow[]) => {
+      rowsRef.current = updater(rowsRef.current);
+      setRowsState(rowsRef.current);
+    },
+    [],
+  );
+
+  const patchRow = useCallback(
+    (chainId: number, patch: Partial<FamilyDistributeRow>) => {
+      setRows((prev) =>
+        prev.map((r) => (r.chainId === chainId ? { ...r, ...patch } : r)),
+      );
+    },
+    [setRows],
+  );
+
+  const memberKey = memberKeyOf(family);
+
+  useEffect(() => {
+    if (!memberKey) {
+      membersRef.current = [];
+      setRows(() => []);
+      return;
+    }
+    const members = parseMembers(memberKey);
+    membersRef.current = members;
+    // Seed idle rows, keeping any in-flight/terminal state for surviving chains.
+    setRows((prev) =>
+      members.map(
+        (m) =>
+          prev.find(
+            (r) =>
+              r.chainId === m.chainId &&
+              r.distributionManager === m.distributionManager,
+          ) ?? {
+            chainId: m.chainId,
+            distributionManager: m.distributionManager,
+            state: "idle" as FamilyDistributeState,
+          },
+      ),
+    );
+
+    let cancelled = false;
+    const load = async () => {
+      await Promise.all(
+        members.map(async (m) => {
+          try {
+            const data = await readChain(m, decimalsCache.current);
+            if (!cancelled) patchRow(m.chainId, data);
+          } catch {
+            if (!cancelled) patchRow(m.chainId, { unreachable: true });
+          }
+        }),
+      );
+    };
+    void load();
+    const id = setInterval(() => void load(), POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [memberKey, patchRow, setRows]);
+
+  /** Run claimAndDistribute on ONE chain — independent, per-row retryable. */
+  const distributeOn = useCallback(
+    async (chainId: number) => {
+      const m = membersRef.current.find((x) => x.chainId === chainId);
+      const row = rowsRef.current.find((r) => r.chainId === chainId);
+      if (!m || !row) return;
+      if (row.state === "distributing" || row.state === "confirming") return;
+      patchRow(chainId, {
+        state: "distributing",
+        error: undefined,
+        txHash: undefined,
+      });
+      try {
+        const hash = await sendSponsored({
+          chainId,
+          address: m.distributionManager,
+          abi: distributionManagerAbi,
+          functionName: "claimAndDistribute",
+          args: [],
+        });
+        patchRow(chainId, { state: "confirming", txHash: hash });
+        // Wait on THIS chain's client — the wallet may be pointed elsewhere.
+        await publicClientFor(chainId).waitForTransactionReceipt({ hash });
+        patchRow(chainId, { state: "done" });
+        // Re-read so the advanced cycle / drained pot shows immediately.
+        try {
+          patchRow(chainId, await readChain(m, decimalsCache.current));
+        } catch {
+          /* transient — the next poll refreshes it */
+        }
+      } catch (e) {
+        patchRow(chainId, { state: "failed", error: parseTxError(e) });
+      }
+    },
+    [patchRow, sendSponsored],
+  );
+
+  return {
+    rows,
+    distributeOn,
+    anyBusy: rows.some(
+      (r) => r.state === "distributing" || r.state === "confirming",
+    ),
+  };
+}

--- a/src/hooks/use-family-distribute.ts
+++ b/src/hooks/use-family-distribute.ts
@@ -227,7 +227,18 @@ export function useFamilyDistribute(family: FamilyState) {
         });
         patchRow(chainId, { state: "confirming", txHash: hash });
         // Wait on THIS chain's client — the wallet may be pointed elsewhere.
-        await publicClientFor(chainId).waitForTransactionReceipt({ hash });
+        // viem's raw wait RETURNS reverted receipts (wagmi's throws); distribute
+        // is a public keeper race, so a lost race must read as failed, not done.
+        const receipt = await publicClientFor(
+          chainId,
+        ).waitForTransactionReceipt({ hash });
+        if (receipt.status === "reverted") {
+          patchRow(chainId, {
+            state: "failed",
+            error: "Transaction reverted — likely already distributed",
+          });
+          return;
+        }
         patchRow(chainId, { state: "done" });
         // Re-read so the advanced cycle / drained pot shows immediately.
         try {


### PR DESCRIPTION
## What changed

**1. Family-mode Distribute page** — when the active instance is a multi-chain family, the Distribute page now surfaces every sibling chain (like the vote page does):

- New `src/hooks/use-family-distribute.ts`: fans out to each family chain via `publicClientFor` reading `getCurrentCycle` + `isCycleComplete` (cycle module), `isDistributionReady` (distribution manager) and `yieldAccrued` (token, normalized to 18 dp — the L2 mirrors are 6-dp USDC), fail-soft per chain, polled at the same 12s cadence as the single-chain gate. `distributeOn(chainId)` submits `claimAndDistribute` through the sponsored wallet layer (gasless on Privy embedded wallets, chain-switching self-paid otherwise) and awaits the receipt on THAT chain's own client, then re-reads the row. Each row is an independent idle/distributing/confirming/done/failed state machine with `parseTxError` errors and per-row retry.
- New `family-distribute-card.tsx`: per-chain checklist (chain name, accrued pot, cycle #, "ready" badge, Distribute button enabled only when that chain's contract reports ready; spinner in flight, error caption on failure, green check + tx link on success).
- The classic single-chain readiness card remains — labeled "Readiness on <chain> — this chain" in family mode — and is unchanged for classic instances.

**2. Recipients auto-sync (admin registries)** — membership only actually changes on "Process queue", so a successful `processQueue` on a family admin registry now automatically kicks off the same sign-once "sync recipients everywhere" flow as the Admin page (`useCrossChainRegistryUpdate`, reused not forked). The fresh membership is read straight from the chain before signing (the wagmi cache may still hold the pre-process list). Debounced on the process tx hash so one completed local change fires exactly one sync. Per-chain delivery status renders inline via `MultiChainActionStatus` with a "Syncing membership to N sibling chains…" note; a failed sibling shows its error and stays retryable without blocking the local success.

**3. Yield + Withdraw family notes** — small honest per-chain cards in family mode: the yield split is set for the active chain only (switch chains in the instance picker to set it elsewhere), and the withdraw note shows the active-chain balance plus the per-chain breakdown of the rest of the holding (`useFamilyPosition`, 18-dp formatter). No new write flows.

## How verified

- `pnpm lint`, `pnpm format:check`, `pnpm build` all pass.
- Served `out/` and screenshotted against the live 3-chain Gnosis family (`/app/distribute/?i=0xC6bCE9F20d45B5458D35eb5a99a65E30e20511E6`) at 1280px with Playwright:
  - Distribute: the family card renders three rows with real data — Optimism (ready badge, 0 CONV accrued, cycle #1, enabled Distribute), Gnosis ("this chain", "complete, not ready", disabled button), Arbitrum (ready badge, enabled Distribute) — with the "Readiness on Gnosis — this chain" checklist below (3 of 4 gates green, yield-accrued grey).
  - Recipients: admin flow renders normally (public view; the sync status only appears after an admin processes a queue).
  - Yield: "Your yield split applies per chain. You're setting it for **Gnosis**; switch chains in the instance picker to set it elsewhere."
  - Withdraw: "Withdrawals act per chain. You're withdrawing on **Gnosis**." (balance breakdown appears once a wallet is connected).

Not exercised end-to-end (needs the family admin wallet): an actual cross-chain auto-sync delivery and an actual per-chain distribution tx — both reuse the already-shipped `useCrossChainRegistryUpdate` / `sendSponsored` + per-chain-receipt paths verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)