### PR TITLE
feat: history round breakdowns + backers count + funding hero

### DIFF
--- a/src/app/app/history/page.tsx
+++ b/src/app/app/history/page.tsx
@@ -15,7 +15,8 @@ import {
   type RecipientSummary,
 } from "@/hooks/use-distribution-history";
 import { addressUrl, shortChainName, txUrl } from "@/lib/chains";
-import { formatAmount, shortenAddress } from "@/lib/format";
+import { toDecimal } from "@/lib/distribution-history";
+import { formatAmount, formatPercent, shortenAddress } from "@/lib/format";
 import { useInstanceToken } from "@/hooks/use-token";
 
 /** ~decimal number → grouped string (family total across stablecoin chains). */
@@ -171,6 +172,7 @@ export default function HistoryPage() {
               <RoundRow
                 key={`${round.chainId}-${round.txHash}`}
                 round={round}
+                allTimeNormalized={history.totalNormalized}
               />
             ))}
           </div>
@@ -233,9 +235,21 @@ function RecipientRow({
   );
 }
 
-function RoundRow({ round }: { round: EnrichedRound }) {
+function RoundRow({
+  round,
+  allTimeNormalized,
+}: {
+  round: EnrichedRound;
+  allTimeNormalized: number;
+}) {
   const [open, setOpen] = useState(false);
   const panelId = `round-${round.chainId}-${round.txHash}`;
+  // This round's weight in everything ever distributed (normalized — rounds on
+  // 6-dp chains compare fairly against 18-dp ones).
+  const shareOfAllTime =
+    allTimeNormalized > 0
+      ? toDecimal(round.total, round.decimals) / allTimeNormalized
+      : 0;
   return (
     <Card className="!p-0">
       <button
@@ -252,7 +266,8 @@ function RoundRow({ round }: { round: EnrichedRound }) {
           <div className="text-surface-grey text-xs">
             {fmtDate(round.timestamp)} · {shortChainName(round.chainId)} ·{" "}
             {round.recipients.length} recipient
-            {round.recipients.length === 1 ? "" : "s"}
+            {round.recipients.length === 1 ? "" : "s"} ·{" "}
+            {formatPercent(shareOfAllTime)} of everything distributed
           </div>
         </div>
         <CaretDown
@@ -262,25 +277,41 @@ function RoundRow({ round }: { round: EnrichedRound }) {
       </button>
       {open && (
         <div id={panelId} className="border-paper-2 border-t px-5 py-3">
-          <ul className="space-y-1.5">
-            {round.recipients.map((x) => (
-              <li
-                key={x.recipient}
-                className="flex items-center justify-between text-sm"
-              >
-                <a
-                  href={addressUrl(x.recipient, round.chainId)}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-surface-grey-2 hover:text-core-orange font-mono text-xs"
-                >
-                  {shortenAddress(x.recipient)}
-                </a>
-                <span className="text-text-standard">
-                  {formatAmount(x.amount, 4, round.decimals)} {round.symbol}
-                </span>
-              </li>
-            ))}
+          <ul className="space-y-2.5">
+            {round.recipients.map((x) => {
+              // Exact bigint ratio (4-dp) — Number() on raw wei loses precision.
+              const share =
+                round.total > 0n
+                  ? Number((x.amount * 10_000n) / round.total) / 10_000
+                  : 0;
+              return (
+                <li key={x.recipient} className="text-sm">
+                  <div className="flex items-center justify-between gap-3">
+                    <a
+                      href={addressUrl(x.recipient, round.chainId)}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-surface-grey-2 hover:text-core-orange font-mono text-xs"
+                    >
+                      {shortenAddress(x.recipient)}
+                    </a>
+                    <span className="text-text-standard">
+                      {formatAmount(x.amount, 4, round.decimals)} {round.symbol}
+                      <span className="text-surface-grey ml-2 text-xs tabular-nums">
+                        {formatPercent(share)}
+                      </span>
+                    </span>
+                  </div>
+                  {/* Share of this round — same hand-rolled bar as "By chain". */}
+                  <div className="bg-paper-2 mt-1 h-1.5 w-full overflow-hidden rounded-full">
+                    <div
+                      className="bg-core-orange h-full rounded-full"
+                      style={{ width: `${Math.max(1, share * 100)}%` }}
+                    />
+                  </div>
+                </li>
+              );
+            })}
           </ul>
           <a
             href={txUrl(round.txHash, round.chainId)}

--- a/src/components/dapp/instance-header.tsx
+++ b/src/components/dapp/instance-header.tsx
@@ -109,9 +109,7 @@ export function InstanceHeader() {
   // 6-dp and 18-dp); re-quantize to 18 dp so it sums with the accruing bigints
   // and demo-scales through the same formatter.
   const distributed18 =
-    history !== null
-      ? parseUnits(history.totalNormalized.toFixed(18), 18)
-      : undefined;
+    history !== null ? safeParse18(history.totalNormalized) : undefined;
   const accruing18 = family.isFamily
     ? fstats.yieldAccrued18
     : singleLiveYield !== undefined
@@ -229,4 +227,14 @@ export function InstanceHeader() {
       </div>
     </div>
   );
+}
+
+/** parseUnits-safe 18-dp quantization: Number.toFixed goes exponential at
+ * >= 1e21 (parseUnits throws on it), so fall back to a whole-unit BigInt. */
+function safeParse18(n: number): bigint {
+  try {
+    return parseUnits(n.toFixed(18), 18);
+  } catch {
+    return BigInt(Math.round(n)) * 10n ** 18n;
+  }
 }

--- a/src/components/dapp/instance-header.tsx
+++ b/src/components/dapp/instance-header.tsx
@@ -9,8 +9,10 @@ import {
   Percent,
   ShieldCheck,
   TrendUp,
+  UsersFour,
   UsersThree,
 } from "@phosphor-icons/react";
+import { parseUnits } from "viem";
 import { InstanceTokenBadge } from "@/components/dapp/instance-branding";
 import { LiveYield } from "@/components/dapp/live-yield";
 import { useInstanceToken, useTokenStats } from "@/hooks/use-token";
@@ -18,8 +20,11 @@ import { useRecipients } from "@/hooks/use-recipients";
 import { useCycle } from "@/hooks/use-cycle";
 import { useRegistryKind } from "@/hooks/use-recipient-voting";
 import { useApy } from "@/hooks/use-apy";
+import { useBackers } from "@/hooks/use-backers";
 import { useFamily } from "@/hooks/use-family";
-import { useFamilyStats } from "@/hooks/use-family-stats";
+import { scaleTo18, useFamilyStats } from "@/hooks/use-family-stats";
+import { useDistributionHistoryForFamily } from "@/hooks/use-distribution-history";
+import { useLiveYield } from "@/hooks/use-live-yield";
 import {
   useAmountFormatter,
   useAmountFormatter18,
@@ -31,13 +36,18 @@ function Chip({
   icon,
   label,
   children,
+  title,
 }: {
   icon: ReactNode;
   label: string;
   children: ReactNode;
+  title?: string;
 }) {
   return (
-    <div className="border-core-orange/40 bg-paper-0 flex items-center gap-2.5 rounded-full border px-4 py-2">
+    <div
+      title={title}
+      className="border-core-orange/40 bg-paper-0 flex items-center gap-2.5 rounded-full border px-4 py-2"
+    >
       <span className="text-core-orange flex-none">{icon}</span>
       <span className="flex flex-col leading-tight">
         <span className="text-surface-grey text-[11px] font-semibold tracking-wide uppercase">
@@ -57,7 +67,7 @@ function Chip({
  * community's own page.
  */
 export function InstanceHeader() {
-  const { name, symbol } = useInstanceToken();
+  const { name, symbol, decimals } = useInstanceToken();
   const { totalSupply } = useTokenStats();
   const { recipients } = useRecipients();
   const cycle = useCycle();
@@ -66,6 +76,17 @@ export function InstanceHeader() {
   const fmt18 = useAmountFormatter18();
   const family = useFamily();
   const fstats = useFamilyStats(family);
+  // Unique holders across every family chain (union — one person on two
+  // chains is one backer). Counted from a bounded Transfer-log window, so
+  // communities older than the lookback undercount until backfill exists.
+  const backers = useBackers(family);
+  // Total funding generated — v2's flagship number: everything EVER distributed
+  // (all chains) + what's accruing right now. Mounting the header kicks off the
+  // history event scan, but it shares the history page's localStorage cache, so
+  // repeat visits only top up the gap since the last scan.
+  const { history, isLoading: historyLoading } =
+    useDistributionHistoryForFamily(family);
+  const singleLiveYield = useLiveYield();
   // Families are rated across ALL their chains — the browsed chain alone can
   // be empty while the community earns elsewhere.
   const apy = useApy(
@@ -83,6 +104,26 @@ export function InstanceHeader() {
   // normalized), not just the chain being viewed.
   const familyMode = family.isFamily && fstats.totalStaked18 !== undefined;
   const chainsNote = familyMode ? ` · ${fstats.chains} chains` : "";
+
+  // All-time distributed is a decimals-normalized decimal number (chains mix
+  // 6-dp and 18-dp); re-quantize to 18 dp so it sums with the accruing bigints
+  // and demo-scales through the same formatter.
+  const distributed18 =
+    history !== null
+      ? parseUnits(history.totalNormalized.toFixed(18), 18)
+      : undefined;
+  const accruing18 = family.isFamily
+    ? fstats.yieldAccrued18
+    : singleLiveYield !== undefined
+      ? scaleTo18(singleLiveYield, decimals)
+      : undefined;
+  // While the history scan runs, show the accruing part alone (with a note)
+  // rather than nothing.
+  const generated18 =
+    distributed18 !== undefined || accruing18 !== undefined
+      ? (distributed18 ?? 0n) + (accruing18 ?? 0n)
+      : undefined;
+  const scanningHistory = historyLoading && history === null;
 
   return (
     <div className="border-paper-2 bg-paper-0 mb-8 rounded-2xl border p-5 sm:p-6">
@@ -142,6 +183,15 @@ export function InstanceHeader() {
         <Chip icon={<UsersThree size={18} weight="fill" />} label="Recipients">
           {recipients.length}
         </Chip>
+        <Chip
+          icon={<UsersFour size={18} weight="fill" />}
+          label="Backers"
+          title="Unique holders, counted from recent on-chain transfers. Communities older than the scanned window may show fewer backers than they really have."
+        >
+          {backers.count !== undefined
+            ? `${backers.partial || backers.capped ? "≈ " : ""}${backers.count}`
+            : "—"}
+        </Chip>
         <Chip icon={<ArrowsClockwise size={18} weight="fill" />} label="Cycle">
           <span className="flex items-center gap-1.5">
             #{cycle.cycleNumber?.toString() ?? "—"}
@@ -155,6 +205,27 @@ export function InstanceHeader() {
             </Caption>
           </span>
         </Chip>
+      </div>
+
+      {/* Total funding generated — distributed all-time + currently accruing. */}
+      <div className="border-core-orange/40 bg-core-orange/5 mt-5 rounded-xl border px-5 py-4">
+        <span className="font-breadDisplay text-text-standard block text-3xl font-bold tabular-nums">
+          {generated18 !== undefined ? (
+            <>
+              {/* 6 frac digits like the live-yield chip — young communities
+                  have generated amounts a 4-dp display rounds to zero. */}
+              {fmt18(generated18, 6)}{" "}
+              <span className="text-surface-grey-2 text-xl">{symbol}</span>
+            </>
+          ) : (
+            "—"
+          )}
+        </span>
+        <Caption className="text-surface-grey mt-1">
+          Total funding generated — distributed + accruing
+          {chainsNote}
+          {scanningHistory && " · scanning history…"}
+        </Caption>
       </div>
     </div>
   );

--- a/src/hooks/use-backers.ts
+++ b/src/hooks/use-backers.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useActiveChainId, useInstance } from "@/components/instance-provider";
+import { loadChainHolders, type HolderTarget } from "@/lib/holder-count";
+import type { FamilyState } from "@/hooks/use-family";
+
+export interface BackersState {
+  /** Unique holders across all scanned chains (undefined until a scan lands). */
+  count?: number;
+  isLoading: boolean;
+  /** A chain failed or was only partially scanned — the count is a floor. */
+  partial: boolean;
+  /** A chain exceeded the tracked-address cap, so its holders couldn't be
+   *  deduped against the other chains (that chain's count is added as-is). */
+  capped: boolean;
+}
+
+/**
+ * "Backers" = unique token holders, reconstructed from Transfer logs (see
+ * holder-count.ts). Classic instances scan the active token; families scan
+ * every sibling token and count the UNION of holder addresses across chains —
+ * one person holding on two chains is one backer.
+ *
+ * Takes the caller's already-loaded family (the header calls useFamily for its
+ * other stats — don't fan the family resolution out twice).
+ *
+ * CAVEAT: counts reflect the scanned block window; tokens older than the
+ * lookback undercount until a "load older"-style extension exists.
+ */
+export function useBackers(family: FamilyState): BackersState {
+  const instance = useInstance();
+  const activeChainId = useActiveChainId();
+  const [state, setState] = useState<BackersState>({
+    isLoading: true,
+    partial: false,
+    capped: false,
+  });
+
+  // The chains + tokens to scan: family siblings, or the active instance.
+  const targets: HolderTarget[] = useMemo(() => {
+    if (family.isFamily) {
+      return family.perChain
+        .filter((c) => c.status === "found" && c.instance)
+        .map((c) => ({ chainId: c.chainId, token: c.instance!.token }));
+    }
+    return [{ chainId: activeChainId, token: instance.token }];
+  }, [family.isFamily, family.perChain, activeChainId, instance.token]);
+
+  // Key the effect on serialized content, not array identity — perChain is a
+  // fresh array on every family reload.
+  const targetKey = targets
+    .map((t) => `${t.chainId}:${t.token.toLowerCase()}`)
+    .join("|");
+
+  useEffect(() => {
+    if (family.isLoading || targets.length === 0) return;
+    let cancelled = false;
+    setState((s) => ({ ...s, isLoading: true }));
+    void (async () => {
+      // Per-chain allSettled: one dead RPC surfaces as a partial count, not a
+      // failure of the whole stat.
+      const settled = await Promise.allSettled(
+        targets.map((t) => loadChainHolders(t)),
+      );
+      if (cancelled) return;
+      const union = new Set<string>();
+      let cappedCount = 0;
+      let capped = false;
+      let failed = 0;
+      let incomplete = false;
+      for (const res of settled) {
+        if (res.status !== "fulfilled") {
+          failed += 1;
+          continue;
+        }
+        if (!res.value.complete) incomplete = true;
+        if (res.value.holders) {
+          for (const addr of res.value.holders) union.add(addr);
+        } else {
+          cappedCount += res.value.count;
+          capped = true;
+        }
+      }
+      if (failed === targets.length) {
+        // Nothing scanned — keep count undefined so the UI shows "—".
+        setState({ isLoading: false, partial: true, capped: false });
+        return;
+      }
+      setState({
+        count: union.size + cappedCount,
+        isLoading: false,
+        partial: failed > 0 || incomplete,
+        capped,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetKey, family.isLoading]);
+
+  return state;
+}

--- a/src/hooks/use-distribution-history.ts
+++ b/src/hooks/use-distribution-history.ts
@@ -12,7 +12,7 @@ import {
   type DistributionRound,
   type DistributionTarget,
 } from "@/lib/distribution-history";
-import { useFamily } from "@/hooks/use-family";
+import { useFamily, type FamilyState } from "@/hooks/use-family";
 
 /** Yield-token display metadata for one chain. */
 interface TokenMeta {
@@ -170,7 +170,15 @@ function aggregate(
  * the scanned window further into the past.
  */
 export function useDistributionHistory() {
-  const family = useFamily();
+  return useDistributionHistoryForFamily(useFamily());
+}
+
+/**
+ * Same, but reusing an already-loaded family — components that call useFamily
+ * for other stats (e.g. the instance header) pass it in instead of fanning the
+ * sibling resolution out a second time.
+ */
+export function useDistributionHistoryForFamily(family: FamilyState) {
   const instance = useInstance();
   const activeChainId = useActiveChainId();
 

--- a/src/hooks/use-family-stats.ts
+++ b/src/hooks/use-family-stats.ts
@@ -26,7 +26,8 @@ export interface FamilyStats {
 }
 
 const POLL_MS = 12_000; // match the single-chain token stats cadence
-const scaleTo18 = (value: bigint, decimals: number) =>
+/** Normalize a base-unit amount to 18 decimals (6-dp USDC mirrors ↔ 18-dp native). */
+export const scaleTo18 = (value: bigint, decimals: number) =>
   decimals >= 18 ? value : value * 10n ** BigInt(18 - decimals);
 
 /** Serialize the family membership so effects key on content, not identity. */

--- a/src/lib/holder-count.ts
+++ b/src/lib/holder-count.ts
@@ -241,10 +241,15 @@ export async function loadChainHolders(
   // pass's logs when the range is re-scanned. So on an incomplete scan the old
   // cache is left untouched and only the best-effort merge is RETURNED.
   if (complete) {
+    // A lagging RPC replica can report latest < cached.toBlock; the cursor
+    // must never regress — deltas aren't idempotent, and a regressed range
+    // would be re-scanned and double-applied (same guard as
+    // distribution-history's bigMax).
+    const newTo = cached ? bigMax(BigInt(cached.toBlock), latest) : latest;
     if (capped) {
       writeCache(chainId, token, {
         fromBlock: coveredFrom.toString(),
-        toBlock: latest.toString(),
+        toBlock: newTo.toString(),
         capped: true,
         count: holders.size,
       });
@@ -253,7 +258,7 @@ export async function loadChainHolders(
       for (const [addr, v] of balances) record[addr] = v.toString();
       writeCache(chainId, token, {
         fromBlock: coveredFrom.toString(),
-        toBlock: latest.toString(),
+        toBlock: newTo.toString(),
         capped: false,
         balances: record,
       });
@@ -266,4 +271,8 @@ export async function loadChainHolders(
     capped,
     complete,
   };
+}
+
+function bigMax(a: bigint, b: bigint): bigint {
+  return a > b ? a : b;
 }

--- a/src/lib/holder-count.ts
+++ b/src/lib/holder-count.ts
@@ -1,0 +1,269 @@
+import { parseAbiItem, type Address, type Log } from "viem";
+import { publicClientFor } from "@/lib/instance";
+
+/**
+ * Client-side, serverless holder counter ("backers").
+ *
+ * There is no on-chain holder count, so we reconstruct one from the token's
+ * ERC-20 `Transfer` logs: net balance deltas per address over a bounded block
+ * window (mint = from 0x0, burn = to 0x0); a holder is any address whose net
+ * balance is positive. Same architecture as distribution-history.ts: chunked
+ * `getLogs` with bisection on range-limit errors, incremental localStorage
+ * cache, fail-soft per chain.
+ *
+ * CAVEAT: the count reflects the scanned window only. A token older than the
+ * initial lookback undercounts — holders whose last transfer predates the
+ * window are invisible, and an address that only *sold* inside the window nets
+ * negative (treated as not holding). A "load older"-style backfill would fix
+ * this; deliberately not built yet.
+ */
+
+export const TRANSFER_EVENT = parseAbiItem(
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+);
+
+/** Above this many tracked addresses we stop keeping the balance map and only
+ *  persist the count — a localStorage/memory safety valve for huge tokens. */
+export const HOLDER_MAP_CAP = 20_000;
+
+/** A chain + the ERC-20 token whose `Transfer` events we index. */
+export interface HolderTarget {
+  chainId: number;
+  token: Address;
+}
+
+export interface HolderScanResult {
+  /** Lowercase addresses with a positive net balance — null once capped. */
+  holders: Set<string> | null;
+  count: number;
+  capped: boolean;
+  /** False when part of the window couldn't be scanned (count is a floor). */
+  complete: boolean;
+}
+
+type TransferLog = Log<bigint, number, false, typeof TRANSFER_EVENT, true>;
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/** Split [from, to] into ≤maxRange windows. */
+function windows(
+  from: bigint,
+  to: bigint,
+  maxRange: bigint,
+): [bigint, bigint][] {
+  const out: [bigint, bigint][] = [];
+  for (let lo = from; lo <= to; lo += maxRange) {
+    const hi = lo + maxRange - 1n;
+    out.push([lo, hi > to ? to : hi]);
+  }
+  return out;
+}
+
+/**
+ * Fetch `Transfer` logs for one token over [fromBlock, toBlock], chunked by
+ * `maxRange` and bisecting any window the RPC rejects (range too large).
+ * `complete` is false if a single-block window still failed after bisection —
+ * the caller must then NOT advance its cache cursor past this range, so the
+ * dropped block is re-scanned next time instead of becoming a permanent gap.
+ */
+async function fetchTransferLogs(
+  chainId: number,
+  token: Address,
+  fromBlock: bigint,
+  toBlock: bigint,
+  maxRange: bigint,
+): Promise<{ logs: TransferLog[]; complete: boolean }> {
+  const client = publicClientFor(chainId);
+  const stack = windows(fromBlock, toBlock, maxRange).reverse();
+  const logs: TransferLog[] = [];
+  let complete = true;
+  while (stack.length > 0) {
+    const [lo, hi] = stack.pop()!;
+    if (lo > hi) continue;
+    try {
+      const got = await client.getLogs({
+        address: token,
+        event: TRANSFER_EVENT,
+        fromBlock: lo,
+        toBlock: hi,
+      });
+      logs.push(...(got as TransferLog[]));
+    } catch {
+      // Range too large / rate limited → split and retry, unless single block.
+      if (hi > lo) {
+        const mid = lo + (hi - lo) / 2n;
+        stack.push([mid + 1n, hi], [lo, mid]);
+      } else {
+        // A single block still failed — the scan is incomplete for this range.
+        complete = false;
+      }
+    }
+  }
+  return { logs, complete };
+}
+
+function applyDelta(
+  balances: Map<string, bigint>,
+  address: string,
+  delta: bigint,
+): void {
+  const next = (balances.get(address) ?? 0n) + delta;
+  // Zero entries carry no information — drop them so the cap counts real ones.
+  if (next === 0n) balances.delete(address);
+  else balances.set(address, next);
+}
+
+/** Fold transfer logs into per-address net deltas (0x0 = mint/burn, untracked). */
+function applyDeltas(balances: Map<string, bigint>, logs: TransferLog[]): void {
+  for (const log of logs) {
+    const from = (log.args.from as Address).toLowerCase();
+    const to = (log.args.to as Address).toLowerCase();
+    const value = log.args.value as bigint;
+    if (value === 0n || from === to) continue;
+    if (from !== ZERO_ADDRESS) applyDelta(balances, from, -value);
+    if (to !== ZERO_ADDRESS) applyDelta(balances, to, value);
+  }
+}
+
+/* --------------------------- localStorage cache ---------------------------- */
+
+interface HolderCacheEntry {
+  /** Lowest block scanned so far (inclusive). */
+  fromBlock: string;
+  /** Highest block scanned so far (inclusive). */
+  toBlock: string;
+  capped: boolean;
+  /** Net per-address balance deltas over [fromBlock, toBlock]; negative means
+   *  the address also held tokens from before the window. Absent once capped. */
+  balances?: Record<string, string>;
+  /** Holder count frozen at cap time (the map itself is discarded). */
+  count?: number;
+}
+
+const cacheKey = (chainId: number, token: Address) =>
+  `crowdstake.holders.v1:${chainId}:${token.toLowerCase()}`;
+
+function readCache(chainId: number, token: Address): HolderCacheEntry | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(cacheKey(chainId, token));
+    return raw ? (JSON.parse(raw) as HolderCacheEntry) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(
+  chainId: number,
+  token: Address,
+  entry: HolderCacheEntry,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      cacheKey(chainId, token),
+      JSON.stringify(entry),
+    );
+  } catch {
+    /* quota — skip caching */
+  }
+}
+
+/* ------------------------------ public API -------------------------------- */
+
+/**
+ * Load one chain's holder set. Uses the localStorage cache and only scans the
+ * gap up to the latest block (cheap on repeat visits). On the first scan it
+ * looks back `initialLookback` blocks.
+ */
+export async function loadChainHolders(
+  target: HolderTarget,
+  opts: { initialLookback: bigint; maxRange: bigint } = {
+    initialLookback: 400_000n,
+    maxRange: 9_000n,
+  },
+): Promise<HolderScanResult> {
+  const { chainId, token } = target;
+  const cached = readCache(chainId, token);
+
+  // Once capped the per-address map is gone, so the count can't be updated
+  // incrementally — serve the frozen snapshot (a rescan affordance can reset
+  // the cache later).
+  if (cached?.capped) {
+    return {
+      holders: null,
+      count: cached.count ?? 0,
+      capped: true,
+      complete: true,
+    };
+  }
+
+  const client = publicClientFor(chainId);
+  const latest = await client.getBlockNumber();
+
+  const balances = new Map<string, bigint>();
+  if (cached?.balances) {
+    for (const [addr, v] of Object.entries(cached.balances))
+      balances.set(addr, BigInt(v));
+  }
+
+  let scanFrom: bigint;
+  let coveredFrom: bigint;
+  if (cached) {
+    // Top up forward to the latest block.
+    scanFrom = BigInt(cached.toBlock) + 1n;
+    coveredFrom = BigInt(cached.fromBlock);
+  } else {
+    scanFrom =
+      latest < opts.initialLookback ? 0n : latest - opts.initialLookback + 1n;
+    coveredFrom = scanFrom;
+  }
+
+  let complete = true;
+  if (scanFrom <= latest) {
+    const res = await fetchTransferLogs(
+      chainId,
+      token,
+      scanFrom,
+      latest,
+      opts.maxRange,
+    );
+    complete = res.complete;
+    applyDeltas(balances, res.logs);
+  }
+
+  const holders = new Set<string>();
+  for (const [addr, v] of balances) if (v > 0n) holders.add(addr);
+  const capped = balances.size > HOLDER_MAP_CAP;
+
+  // Unlike distribution rounds (deduped by txHash), balance deltas are NOT
+  // idempotent — persisting a partially-scanned range would double-apply this
+  // pass's logs when the range is re-scanned. So on an incomplete scan the old
+  // cache is left untouched and only the best-effort merge is RETURNED.
+  if (complete) {
+    if (capped) {
+      writeCache(chainId, token, {
+        fromBlock: coveredFrom.toString(),
+        toBlock: latest.toString(),
+        capped: true,
+        count: holders.size,
+      });
+    } else {
+      const record: Record<string, string> = {};
+      for (const [addr, v] of balances) record[addr] = v.toString();
+      writeCache(chainId, token, {
+        fromBlock: coveredFrom.toString(),
+        toBlock: latest.toString(),
+        capped: false,
+        balances: record,
+      });
+    }
+  }
+
+  return {
+    holders: capped ? null : holders,
+    count: holders.size,
+    capped,
+    complete,
+  };
+}


### PR DESCRIPTION
Ports the remaining crowdstaking-v2 dashboard surfaces, multichain-aware and fully serverless (no Dune/subgraph — everything is read client-side from each chain's RPC).

## 1. Richer history rounds
- Expanding a payout round now shows each recipient's **% share of that round** with a per-recipient progress bar (same hand-rolled bar as the "By chain" breakdown). Shares use an exact bigint ratio, not lossy float division on raw wei.
- The round header shows the round's **share of everything ever distributed** ("N% of everything distributed"), normalized so 6-dp USDC-mirror chains compare fairly against 18-dp ones.

## 2. Backers count (family-aware holder count)
- `src/lib/holder-count.ts`: reconstructs unique holders from ERC-20 `Transfer` logs — same architecture as `distribution-history.ts` (chunked `getLogs` with bisection on range-limit errors, incremental localStorage cache at `crowdstake.holders.v1:<chainId>:<token>`, fail-soft per chain). Net balance deltas per address (mint = from 0x0, burn = to 0x0); holders = addresses with balance > 0. Initial lookback 400k blocks, maxRange 9k. Past 20k tracked addresses the map is dropped and only a frozen count + `capped` flag persists.
- Unlike rounds (deduped by txHash), balance deltas aren't idempotent — an incomplete scan never advances the cache cursor, so a dropped block can't double-apply on rescan.
- `src/hooks/use-backers.ts`: classic instances scan the active token; families scan every sibling token and count the **union** of holder addresses across chains (one person on two chains = one backer). Takes the header's already-loaded family instead of calling `useFamily` again.
- Shown as a **Backers** chip in the instance header (UsersFour icon, `≈` prefix when partial/capped, native tooltip). Caveat: counts reflect the scanned window; tokens older than the lookback undercount until a "load older"-style extension exists (deliberately not built yet).

## 3. "Total funding generated" hero
- v2's flagship number, rendered as a wide banner inside the instance-header card: **all-time distributed** (from the shared distribution-history scan — the header reuses the history page's localStorage cache, so repeat visits only top up the gap) **+ currently accruing** (family: `yieldAccrued18` summed across chains; classic: the ticking live yield, scaled to 18 dp). Demo-scaled via `useAmountFormatter18`, 6 fractional digits so young communities don't round to zero.
- While the first history scan runs, the accruing part shows alone with a "scanning history…" note.
- Added `useDistributionHistoryForFamily(family)` so the header reuses its already-loaded family (no second sibling fan-out); the history page's `useDistributionHistory()` is unchanged.

## Verified
`pnpm lint` / `pnpm format:check` / `pnpm build` green. Static export served locally and Playwright-screenshotted at 1280px for both the default Gnosis instance and the `?i=0xC6bC…11E6` family:
- Default `/app/`: Backers **3**, hero **0.000479 CSTAKE** (≈0.0000111 distributed + 0.000468 accruing).
- Default `/app/history/`: 1 round (Jun 29, 2026, Gnosis, "100% of everything distributed"), recipient bars at **60% / 40%** — matches the on-chain logs exactly (6649770811216 / 4433180540812 wei).
- Family `/app/`: Backers **1** (union across 3 chains), hero **0.000023 CONV · 3 chains** (accruing only; no distributions yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)