### PR TITLE
feat: classic vote recasting via signature path

### DIFF
--- a/e2e/verify-classic-recast.ts
+++ b/e2e/verify-classic-recast.ts
@@ -1,0 +1,560 @@
+/*
+ * On-chain verification for CLASSIC vote recasting via the EIP-712 signature
+ * path (castVoteWithSignature). EIP-712 parity is the delicate part, so this
+ * script imports the EXACT frontend signing helpers (classicVoteDomain,
+ * CLASSIC_VOTE_TYPES, classicPointsHash from src/lib/vote-signature) and the
+ * app's generated ABIs — any drift between the dapp and the contracts fails
+ * here first.
+ *
+ * Run against an anvil fork of Gnosis (publicnode: rpc.gnosischain.com
+ * rate-limits forks):
+ *   anvil --fork-url https://gnosis-rpc.publicnode.com --chain-id 100 --port 8547
+ *   RPC_URL=http://localhost:8547 npx tsx e2e/verify-classic-recast.ts
+ *
+ * What it proves:
+ *   1. deploy a fresh classic instance via the LIVE v2 deployer (forked state)
+ *   2. mint stake, accrue time-weighted power, vote 70/30 via voteWithData
+ *   3. a direct re-vote reverts AlreadyVotedInCurrentCycle (why the UI
+ *      needs the signature path at all)
+ *   4. validateSignature() returns true for the frontend-built signature —
+ *      byte-for-byte EIP-712 parity with the contract's assembly hash
+ *   5. castVoteWithSignature succeeds and getCurrentVotingDistribution now
+ *      shows ONLY the new 10/90 ballot (old 70/30 fully reverted)
+ *   6. reusing the nonce reverts NonceAlreadyUsed
+ *   7. feature-detect + the OLD live v1 default instance: its module turns
+ *      out to EXPOSE the same VOTE_TYPEHASH/castVoteWithSignature (so the
+ *      UI's probe enables recast there too) — this section proves the v1
+ *      recast also REPLACES the ballot instead of double-counting it
+ */
+import {
+  BaseError,
+  ContractFunctionRevertedError,
+  createPublicClient,
+  createWalletClient,
+  decodeEventLog,
+  encodePacked,
+  http,
+  keccak256,
+  parseEther,
+  type Address,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { gnosis } from "viem/chains";
+import { votingModuleAbi } from "../src/lib/abis/voting-module";
+import { tokenAbi } from "../src/lib/abis/token";
+import { votingPowerAbi } from "../src/lib/abis/voting-power";
+import { recipientRegistryAbi } from "../src/lib/abis/recipient-registry";
+import { cycleModuleAbi } from "../src/lib/abis/cycle-module";
+import { deployerAbi } from "../src/lib/abis/crowdstake-deployer";
+import {
+  CLASSIC_VOTE_TYPES,
+  classicPointsHash,
+  classicVoteDomain,
+} from "../src/lib/vote-signature";
+
+const RPC = process.env.RPC_URL ?? "http://localhost:8547";
+// Live v2 (family-aware) deployer on Gnosis — present in the forked state.
+const DEPLOYER: Address = "0xD9dbc941C5e66D1cC67C6612d221263eD1A27C55";
+// The OLD live default instance (v1 modules) — mirrors src/lib/constants.ts.
+const V1_VOTING_MODULE: Address = "0xf921AF0C0fCd4A9dE0F6C58b34b05DBCCf0aAc42";
+const V1_TOKEN: Address = "0x7E94a840143E3D5C78f367bBe45e6fB6e55098ec";
+const V1_POWER: Address = "0x3F477A1FD83F56537BEE5cC05406fF4628e7A399";
+// anvil dev account #0 — publicly known, auto-funded on the fork. NEVER a real key.
+const account = privateKeyToAccount(
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+);
+const R1: Address = "0x1111111111111111111111111111111111111111";
+const R2: Address = "0x2222222222222222222222222222222222222222";
+
+const pub = createPublicClient({ chain: gnosis, transport: http(RPC) });
+const wallet = createWalletClient({
+  account,
+  chain: gnosis,
+  transport: http(RPC),
+});
+
+let failures = 0;
+function ok(cond: boolean, label: string): void {
+  console.log(`${cond ? "  ✔" : "  ✘ FAIL"} ${label}`);
+  if (!cond) failures += 1;
+}
+
+async function mine(blocks: number): Promise<void> {
+  await fetch(RPC, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "anvil_mine",
+      params: ["0x" + blocks.toString(16)],
+    }),
+  });
+}
+
+/**
+ * Ratio equality up to integer flooring: each allocation is
+ * floor(power * points_i / totalPoints), so cross-multiplied sides can differ
+ * by a few wei on ~1e18-1e20 magnitudes. 1e6 wei of slack is invisible at
+ * that scale but catches any real residue from an unreverted ballot.
+ */
+function ratioIs(a: bigint, b: bigint, num: bigint, den: bigint): boolean {
+  const lhs = a * den;
+  const rhs = b * num;
+  const diff = lhs > rhs ? lhs - rhs : rhs - lhs;
+  return diff <= 1_000_000n;
+}
+
+/** Deepest custom-error name out of a viem revert, or "". */
+function revertName(e: unknown): string {
+  if (e instanceof BaseError) {
+    const r = e.walk((err) => err instanceof ContractFunctionRevertedError);
+    if (r instanceof ContractFunctionRevertedError)
+      return r.data?.errorName ?? "";
+  }
+  return "";
+}
+
+async function main(): Promise<void> {
+  console.log(`voter: ${account.address}`);
+
+  /* 1 — deploy a fresh classic instance via the live v2 deployer. */
+  const salt = keccak256(
+    encodePacked(["string"], [`classic-recast-${Date.now()}`]),
+  );
+  const deployHash = await wallet.writeContract({
+    address: DEPLOYER,
+    abi: deployerAbi,
+    functionName: "deploy",
+    args: [
+      {
+        owner: account.address,
+        cycleLength: 200_000n, // long cycle: the ballot stays open throughout
+        tokenName: "RecastTest",
+        tokenSymbol: "RCT",
+        maxVotingPoints: 10_000n,
+        salt,
+        registryKind: 0, // admin registry
+        initialRecipients: [R1, R2],
+        proposalExpiry: 0n,
+        distributionKind: 0, // proportional
+        tokenImageURI: "",
+        bannerImageURI: "",
+        crossChain: false, // CLASSIC — familyId stays 0, onlyClassic paths open
+      },
+    ],
+  });
+  const deployReceipt = await pub.waitForTransactionReceipt({
+    hash: deployHash,
+  });
+  ok(deployReceipt.status === "success", `deploy() succeeded (${deployHash})`);
+
+  let votingModule: Address | undefined;
+  let token: Address | undefined;
+  let votingPowerStrategy: Address | undefined;
+  let registry: Address | undefined;
+  for (const log of deployReceipt.logs) {
+    try {
+      const ev = decodeEventLog({
+        abi: deployerAbi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (ev.eventName === "SystemDeployed") {
+        votingModule = ev.args.instance.votingModule;
+        token = ev.args.instance.token;
+        votingPowerStrategy = ev.args.instance.votingPowerStrategy;
+        registry = ev.args.instance.registry;
+      }
+    } catch {
+      /* not our event */
+    }
+  }
+  if (!votingModule || !token || !votingPowerStrategy || !registry) {
+    throw new Error("SystemDeployed not found in deploy receipt");
+  }
+  console.log(`  instance votingModule: ${votingModule}`);
+
+  /* Params.initialRecipients is democratic-only — an admin registry starts
+   * empty, so add recipients the way the app's admin page does: queue then
+   * processQueue (both onlyOwner is fine, we deployed as owner). */
+  const queueHash = await wallet.writeContract({
+    address: registry,
+    abi: recipientRegistryAbi,
+    functionName: "queueRecipientsAddition",
+    args: [[R1, R2]],
+  });
+  await pub.waitForTransactionReceipt({ hash: queueHash });
+  const processHash = await wallet.writeContract({
+    address: registry,
+    abi: recipientRegistryAbi,
+    functionName: "processQueue",
+  });
+  await pub.waitForTransactionReceipt({ hash: processHash });
+  const activeRecipients = await pub.readContract({
+    address: registry,
+    abi: recipientRegistryAbi,
+    functionName: "getRecipients",
+  });
+  ok(
+    activeRecipients.length === 2,
+    `recipients active: [${activeRecipients.join(", ")}]`,
+  );
+
+  /* 2 — mint stake (native xDAI) and let time-weighted power accrue. */
+  const mintHash = await wallet.writeContract({
+    address: token,
+    abi: tokenAbi,
+    functionName: "mint",
+    args: [account.address],
+    value: parseEther("500"),
+  });
+  await pub.waitForTransactionReceipt({ hash: mintHash });
+  let power = 0n;
+  for (let i = 0; i < 20 && power === 0n; i++) {
+    await mine(500);
+    power = await pub.readContract({
+      address: votingPowerStrategy,
+      abi: votingPowerAbi,
+      functionName: "getCurrentVotingPower",
+      args: [account.address],
+    });
+  }
+  ok(power > 0n, `voting power accrued: ${power}`);
+
+  /* 3 — first vote 70/30 via the direct path (unchanged in the UI). */
+  const firstPoints = [7000n, 3000n];
+  const voteHash = await wallet.writeContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "voteWithData",
+    args: [firstPoints, "0x"],
+  });
+  const voteReceipt = await pub.waitForTransactionReceipt({ hash: voteHash });
+  ok(voteReceipt.status === "success", "voteWithData(70/30) succeeded");
+  const before = await pub.readContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "getCurrentVotingDistribution",
+  });
+  console.log(`  distribution BEFORE recast: [${before.join(", ")}]`);
+  ok(
+    ratioIs(before[0], before[1], 7n, 3n),
+    "before ratio is 70/30 (d0*3 == d1*7, flooring slack)",
+  );
+  const hasVoted = await pub.readContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "hasVotedInCurrentCycle",
+    args: [account.address],
+  });
+  ok(hasVoted, "hasVotedInCurrentCycle == true");
+
+  /* Direct re-vote is gated — this is WHY the UI needs the signature path. */
+  try {
+    await pub.simulateContract({
+      account: account.address,
+      address: votingModule,
+      abi: votingModuleAbi,
+      functionName: "voteWithData",
+      args: [[1000n, 9000n], "0x"],
+    });
+    ok(false, "direct re-vote unexpectedly allowed");
+  } catch (e) {
+    ok(
+      revertName(e) === "AlreadyVotedInCurrentCycle",
+      `direct re-vote reverts AlreadyVotedInCurrentCycle (got: ${revertName(e)})`,
+    );
+  }
+
+  /* 4+5 — RECAST 10/90 via the frontend signing code path.
+   * This block mirrors useVote().recast in src/hooks/use-voting.ts
+   * step-for-step: Date.now() nonce bumped past isNonceUsed, then EIP-712
+   * signTypedData over classicVoteDomain/CLASSIC_VOTE_TYPES/classicPointsHash
+   * (the wallet-side equivalent of wagmi's signTypedDataAsync). */
+  const newPoints = [1000n, 9000n];
+  let nonce = BigInt(Date.now());
+  while (
+    await pub.readContract({
+      address: votingModule,
+      abi: votingModuleAbi,
+      functionName: "isNonceUsed",
+      args: [account.address, nonce],
+    })
+  ) {
+    nonce += 1n;
+  }
+  const signature = await account.signTypedData({
+    domain: classicVoteDomain(gnosis.id, votingModule),
+    types: CLASSIC_VOTE_TYPES,
+    primaryType: "Vote",
+    message: {
+      voter: account.address,
+      pointsHash: classicPointsHash(newPoints),
+      nonce,
+    },
+  });
+
+  // Parity proof BEFORE submitting: the contract's own assembly-built digest
+  // must accept the frontend-built signature.
+  const valid = await pub.readContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "validateSignature",
+    args: [account.address, newPoints, nonce, signature],
+  });
+  ok(valid, "validateSignature() accepts the frontend-built signature");
+
+  const recastHash = await wallet.writeContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "castVoteWithSignature",
+    args: [account.address, newPoints, nonce, signature],
+  });
+  const recastReceipt = await pub.waitForTransactionReceipt({
+    hash: recastHash,
+  });
+  ok(
+    recastReceipt.status === "success",
+    `castVoteWithSignature(10/90, nonce=${nonce}) succeeded (${recastHash})`,
+  );
+
+  const after = await pub.readContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "getCurrentVotingDistribution",
+  });
+  console.log(`  distribution AFTER recast:  [${after.join(", ")}]`);
+  // The voter is the ONLY voter, so a clean 10/90 ratio proves the 70/30
+  // ballot was fully reverted — any residue would skew the ratio.
+  ok(
+    ratioIs(after[0], after[1], 1n, 9n),
+    "after ratio is 10/90 (d0*9 == d1) — old ballot fully reverted",
+  );
+  ok(after[0] < before[0], "recipient 1 allocation dropped (70% -> 10%)");
+  ok(after[1] > before[1], "recipient 2 allocation rose (30% -> 90%)");
+  // Single-count proof: the cycle's total tracked power equals ONE ballot's
+  // worth (the recast subtracted the previous power before re-adding).
+  const cycleModule = await pub.readContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "cycleModule",
+  });
+  const cycle = await pub.readContract({
+    address: cycleModule,
+    abi: cycleModuleAbi,
+    functionName: "getCurrentCycle",
+  });
+  const totalCyclePower = await pub.readContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "totalCycleVotingPower",
+    args: [cycle],
+  });
+  const afterSum = after[0] + after[1];
+  console.log(
+    `  totalCycleVotingPower: ${totalCyclePower} vs sum(after): ${afterSum}`,
+  );
+  ok(
+    totalCyclePower - afterSum >= 0n && totalCyclePower - afterSum <= 10n,
+    "cycle power counted ONCE (sum(after) == totalCycleVotingPower, flooring slack)",
+  );
+  const stillVoted = await pub.readContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "hasVotedInCurrentCycle",
+    args: [account.address],
+  });
+  ok(stillVoted, "hasVotedInCurrentCycle still true after recast");
+
+  /* 6 — replaying a used nonce must revert NonceAlreadyUsed. */
+  const replayPoints = [5000n, 5000n];
+  const replaySig = await account.signTypedData({
+    domain: classicVoteDomain(gnosis.id, votingModule),
+    types: CLASSIC_VOTE_TYPES,
+    primaryType: "Vote",
+    message: {
+      voter: account.address,
+      pointsHash: classicPointsHash(replayPoints),
+      nonce, // reused on purpose
+    },
+  });
+  try {
+    await pub.simulateContract({
+      account: account.address,
+      address: votingModule,
+      abi: votingModuleAbi,
+      functionName: "castVoteWithSignature",
+      args: [account.address, replayPoints, nonce, replaySig],
+    });
+    ok(false, "nonce reuse unexpectedly allowed");
+  } catch (e) {
+    ok(
+      revertName(e) === "NonceAlreadyUsed",
+      `reused nonce reverts NonceAlreadyUsed (got: ${revertName(e)})`,
+    );
+  }
+
+  /* 7 — feature-detect + the OLD live v1 default instance. */
+  const typehash = await pub.readContract({
+    address: votingModule,
+    abi: votingModuleAbi,
+    functionName: "VOTE_TYPEHASH",
+  });
+  const expectedTypehash = keccak256(
+    encodePacked(
+      ["string"],
+      ["Vote(address voter,bytes32 pointsHash,uint256 nonce)"],
+    ),
+  );
+  ok(
+    typehash === expectedTypehash,
+    `v2 VOTE_TYPEHASH matches pinned type string (${typehash})`,
+  );
+
+  // Empirical finding: the old live v1 module EXPOSES the same
+  // VOTE_TYPEHASH + castVoteWithSignature (the feature-detect probe enables
+  // recast there), so prove its recast also REPLACES the ballot. All checks
+  // are DELTA-based against the pre-test distribution, since the live
+  // instance forks in with other voters' state.
+  console.log("\nOLD live v1 default instance:");
+  let v1Typehash: Hex | null = null;
+  try {
+    v1Typehash = await pub.readContract({
+      address: V1_VOTING_MODULE,
+      abi: votingModuleAbi,
+      functionName: "VOTE_TYPEHASH",
+    });
+  } catch {
+    /* would mean the UI probe keeps recast disabled there — also fine */
+  }
+  if (v1Typehash === null) {
+    console.log(
+      "  (VOTE_TYPEHASH reverted — UI probe keeps recast disabled; skipping)",
+    );
+  } else {
+    ok(
+      v1Typehash === expectedTypehash,
+      "v1 VOTE_TYPEHASH present and identical — UI probe ENABLES recast",
+    );
+    const n = Number(
+      await pub.readContract({
+        address: V1_VOTING_MODULE,
+        abi: votingModuleAbi,
+        functionName: "getExpectedPointsLength",
+      }),
+    );
+    if (n < 2) throw new Error("live instance has <2 recipients");
+    const at = (d: readonly bigint[], i: number): bigint => d[i] ?? 0n;
+    const zeros = (): bigint[] => Array.from({ length: n }, () => 0n);
+    const d0 = await pub.readContract({
+      address: V1_VOTING_MODULE,
+      abi: votingModuleAbi,
+      functionName: "getCurrentVotingDistribution",
+    });
+    const mintV1 = await wallet.writeContract({
+      address: V1_TOKEN,
+      abi: tokenAbi,
+      functionName: "mint",
+      args: [account.address],
+      value: parseEther("100"),
+    });
+    await pub.waitForTransactionReceipt({ hash: mintV1 });
+    let v1Power = 0n;
+    for (let i = 0; i < 30 && v1Power === 0n; i++) {
+      await mine(1000);
+      v1Power = await pub.readContract({
+        address: V1_POWER,
+        abi: votingPowerAbi,
+        functionName: "getCurrentVotingPower",
+        args: [account.address],
+      });
+    }
+    ok(v1Power > 0n, `v1 voting power accrued: ${v1Power}`);
+    const p1 = zeros();
+    p1[0] = 7000n;
+    p1[1] = 3000n;
+    const v1Vote = await wallet.writeContract({
+      address: V1_VOTING_MODULE,
+      abi: votingModuleAbi,
+      functionName: "voteWithData",
+      args: [p1, "0x"],
+    });
+    await pub.waitForTransactionReceipt({ hash: v1Vote });
+    const d1 = await pub.readContract({
+      address: V1_VOTING_MODULE,
+      abi: votingModuleAbi,
+      functionName: "getCurrentVotingDistribution",
+    });
+    console.log(`  v1 delta after voteWithData(70/30): [${d1.join(", ")}]`);
+    const p2 = zeros();
+    p2[0] = 1000n;
+    p2[1] = 9000n;
+    let v1Nonce = BigInt(Date.now());
+    while (
+      await pub.readContract({
+        address: V1_VOTING_MODULE,
+        abi: votingModuleAbi,
+        functionName: "isNonceUsed",
+        args: [account.address, v1Nonce],
+      })
+    ) {
+      v1Nonce += 1n;
+    }
+    // Same frontend signing helpers, pointed at the v1 module's domain.
+    const v1Sig = await account.signTypedData({
+      domain: classicVoteDomain(gnosis.id, V1_VOTING_MODULE),
+      types: CLASSIC_VOTE_TYPES,
+      primaryType: "Vote",
+      message: {
+        voter: account.address,
+        pointsHash: classicPointsHash(p2),
+        nonce: v1Nonce,
+      },
+    });
+    const v1Valid = await pub.readContract({
+      address: V1_VOTING_MODULE,
+      abi: votingModuleAbi,
+      functionName: "validateSignature",
+      args: [account.address, p2, v1Nonce, v1Sig],
+    });
+    ok(v1Valid, "v1 validateSignature() accepts the frontend-built signature");
+    const v1Recast = await wallet.writeContract({
+      address: V1_VOTING_MODULE,
+      abi: votingModuleAbi,
+      functionName: "castVoteWithSignature",
+      args: [account.address, p2, v1Nonce, v1Sig],
+    });
+    const v1RecastReceipt = await pub.waitForTransactionReceipt({
+      hash: v1Recast,
+    });
+    ok(
+      v1RecastReceipt.status === "success",
+      "v1 castVoteWithSignature(10/90) succeeded on a re-vote",
+    );
+    const d2 = await pub.readContract({
+      address: V1_VOTING_MODULE,
+      abi: votingModuleAbi,
+      functionName: "getCurrentVotingDistribution",
+    });
+    console.log(`  v1 distribution after recast:       [${d2.join(", ")}]`);
+    ok(
+      ratioIs(at(d2, 0) - at(d0, 0), at(d2, 1) - at(d0, 1), 1n, 9n),
+      "v1 delta ratio is 10/90 — old ballot replaced, not double-counted",
+    );
+    const deltaSum = d2.reduce((s, v, i) => s + v - at(d0, i), 0n);
+    ok(
+      deltaSum < (v1Power * 3n) / 2n,
+      `v1 delta sum ${deltaSum} ≈ one ballot's power (not 2x)`,
+    );
+  }
+
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/app/vote/page.tsx
+++ b/src/app/app/vote/page.tsx
@@ -150,7 +150,7 @@ function VoteForm() {
   const { recipients } = useRecipients();
   const voting = useVotingState();
   const cycle = useCycle();
-  const { vote, recast, supportsRecast, ...tx } = useVote();
+  const { vote, recast, supportsRecast, recastProbePending, ...tx } = useVote();
 
   // Per-recipient weight in *percent* (0..100); converted to basis points on submit.
   const [weights, setWeights] = useState<Record<string, number>>({});
@@ -191,6 +191,7 @@ function VoteForm() {
   // Recasting rides the EIP-712 signature path (castVoteWithSignature). On a
   // module that doesn't expose it (VOTE_TYPEHASH() reverts), the ballot stays
   // locked for the cycle, exactly like before.
+  const probing = voting.hasVoted && recastProbePending;
   const locked = voting.hasVoted && !supportsRecast;
 
   const distributeEqually = () => {
@@ -213,9 +214,11 @@ function VoteForm() {
         {voting.hasVoted && (
           <p className="text-system-green mt-3 flex items-center gap-2 text-sm font-medium">
             <CheckCircle size={18} weight="fill" />
-            {supportsRecast
-              ? "You voted this cycle — you can update your ballot until it ends."
-              : "You've already voted this cycle. New votes are accepted next cycle."}
+            {probing
+              ? "You voted this cycle."
+              : supportsRecast
+                ? "You voted this cycle — you can update your ballot until it ends."
+                : "You've already voted this cycle. New votes are accepted next cycle."}
           </p>
         )}
       </Card>
@@ -245,10 +248,12 @@ function VoteForm() {
       <div className="mt-6">
         <ActionButton
           isLoading={tx.isBusy}
-          disabled={!anyAllocated || locked || noPower || lengthMismatch}
+          disabled={
+            !anyAllocated || locked || probing || noPower || lengthMismatch
+          }
           onClick={() => (voting.hasVoted ? recast(points) : vote(points))}
         >
-          {locked
+          {probing || locked
             ? "Already voted this cycle"
             : voting.hasVoted
               ? "Update vote"
@@ -276,7 +281,7 @@ function VoteForm() {
         status={tx.status}
         hash={tx.hash}
         error={tx.error}
-        successLabel="Vote cast"
+        successLabel={voting.hasVoted ? "Vote updated" : "Vote cast"}
       />
 
       <Body className="text-surface-grey mt-6 text-sm">

--- a/src/app/app/vote/page.tsx
+++ b/src/app/app/vote/page.tsx
@@ -150,7 +150,7 @@ function VoteForm() {
   const { recipients } = useRecipients();
   const voting = useVotingState();
   const cycle = useCycle();
-  const { vote, ...tx } = useVote();
+  const { vote, recast, supportsRecast, ...tx } = useVote();
 
   // Per-recipient weight in *percent* (0..100); converted to basis points on submit.
   const [weights, setWeights] = useState<Record<string, number>>({});
@@ -188,6 +188,11 @@ function VoteForm() {
     voting.expectedPointsLength !== undefined &&
     points.length !== Number(voting.expectedPointsLength);
 
+  // Recasting rides the EIP-712 signature path (castVoteWithSignature). On a
+  // module that doesn't expose it (VOTE_TYPEHASH() reverts), the ballot stays
+  // locked for the cycle, exactly like before.
+  const locked = voting.hasVoted && !supportsRecast;
+
   const distributeEqually = () => {
     const w: Record<string, number> = {};
     recipients.forEach((r) => (w[r] = 1));
@@ -208,8 +213,9 @@ function VoteForm() {
         {voting.hasVoted && (
           <p className="text-system-green mt-3 flex items-center gap-2 text-sm font-medium">
             <CheckCircle size={18} weight="fill" />
-            You&apos;ve already voted this cycle. New votes are accepted next
-            cycle.
+            {supportsRecast
+              ? "You voted this cycle — you can update your ballot until it ends."
+              : "You've already voted this cycle. New votes are accepted next cycle."}
           </p>
         )}
       </Card>
@@ -220,7 +226,7 @@ function VoteForm() {
         </Caption>
         <button
           onClick={distributeEqually}
-          disabled={voting.hasVoted}
+          disabled={locked}
           className="text-core-orange text-sm font-semibold hover:underline disabled:opacity-50"
         >
           Distribute equally
@@ -233,32 +239,34 @@ function VoteForm() {
         weights={weights}
         setWeight={setWeight}
         maxStep={maxStep}
-        disabled={voting.hasVoted}
+        disabled={locked}
       />
 
       <div className="mt-6">
         <ActionButton
           isLoading={tx.isBusy}
-          disabled={
-            !anyAllocated || voting.hasVoted || noPower || lengthMismatch
-          }
-          onClick={() => vote(points)}
+          disabled={!anyAllocated || locked || noPower || lengthMismatch}
+          onClick={() => (voting.hasVoted ? recast(points) : vote(points))}
         >
-          {voting.hasVoted ? "Already voted this cycle" : "Cast vote"}
+          {locked
+            ? "Already voted this cycle"
+            : voting.hasVoted
+              ? "Update vote"
+              : "Cast vote"}
         </ActionButton>
       </div>
 
-      {!voting.hasVoted && noPower && (
+      {!locked && noPower && (
         <Caption className="text-system-warning mt-2 block text-center">
           Your voting power is still accruing this cycle — try again shortly.
         </Caption>
       )}
-      {!voting.hasVoted && !noPower && lengthMismatch && (
+      {!locked && !noPower && lengthMismatch && (
         <Caption className="text-system-warning mt-2 block text-center">
           The recipient list just changed — refresh before voting.
         </Caption>
       )}
-      {!anyAllocated && !voting.hasVoted && !noPower && !lengthMismatch && (
+      {!anyAllocated && !locked && !noPower && !lengthMismatch && (
         <Caption className="text-surface-grey mt-2 block text-center">
           Allocate weight to at least one recipient.
         </Caption>

--- a/src/hooks/use-voting.ts
+++ b/src/hooks/use-voting.ts
@@ -1,9 +1,16 @@
 "use client";
 
-import { useAccount, useReadContract } from "wagmi";
+import { useCallback, useState } from "react";
+import { useAccount, useReadContract, useSignTypedData } from "wagmi";
 import { votingModuleAbi, votingPowerAbi } from "@/lib/abis";
 import { useActiveChainId, useInstance } from "@/components/instance-provider";
-import { useTx } from "@/hooks/use-tx";
+import { publicClientFor } from "@/lib/instance";
+import { parseTxError, useTx } from "@/hooks/use-tx";
+import {
+  CLASSIC_VOTE_TYPES,
+  classicPointsHash,
+  classicVoteDomain,
+} from "@/lib/vote-signature";
 
 const LIVE = { refetchInterval: 12_000 } as const;
 
@@ -69,16 +76,114 @@ export function useVotingState() {
   };
 }
 
-/** Cast a direct vote: `points[]` (one per recipient, basis points). */
+/**
+ * Cast a direct vote (`vote`) or update an existing one (`recast`).
+ *
+ * First-time votes go through voteWithData; that path reverts
+ * AlreadyVotedInCurrentCycle on a re-vote, so updating a ballot uses the
+ * EIP-712 signature path instead: castVoteWithSignature only gates on nonce
+ * uniqueness, and _processVote fully reverts the previous ballot's stored
+ * allocations before applying the new one — recasting is designed in.
+ */
 export function useVote() {
   const a = useInstance();
+  const chainId = useActiveChainId();
+  const { address } = useAccount();
+  const { signTypedDataAsync } = useSignTypedData();
   const tx = useTx();
-  const vote = (points: bigint[]) =>
-    tx.run({
+  // Destructured so recast's useCallback can depend on the stable `run`
+  // instead of the per-render `tx` object.
+  const { run } = tx;
+
+  // Feature-detect the signature path before enabling recast: a module that
+  // doesn't expose VOTE_TYPEHASH won't have castVoteWithSignature either. A
+  // reverting read IS the answer (no retry) — recast stays unavailable there
+  // and the UI keeps the locked "already voted" behavior. The old live
+  // default instance's v1 module passes this probe and verifiably recasts
+  // (replaces, not double-counts) — see e2e/verify-classic-recast.ts.
+  const typehash = useReadContract({
+    address: a.votingModule,
+    abi: votingModuleAbi,
+    functionName: "VOTE_TYPEHASH",
+    chainId,
+    query: { retry: false, staleTime: Infinity },
+  });
+  const supportsRecast = typehash.isSuccess;
+
+  // The EIP-712 prompt (or the pre-sign nonce read) can fail before any tx
+  // exists — surface that through the same status/error the page already
+  // renders, since useTx only tracks errors from its own submission.
+  const [signError, setSignError] = useState<string | null>(null);
+  const [isSigningBallot, setIsSigningBallot] = useState(false);
+
+  const vote = (points: bigint[]) => {
+    setSignError(null);
+    return run({
       address: a.votingModule,
       abi: votingModuleAbi,
       functionName: "voteWithData",
       args: [points, "0x"],
     });
-  return { vote, ...tx };
+  };
+
+  const recast = useCallback(
+    async (points: bigint[]) => {
+      if (!address) return undefined;
+      setSignError(null);
+      setIsSigningBallot(true);
+      let nonce: bigint;
+      let signature: `0x${string}`;
+      try {
+        // Fresh nonce: wall-clock ms (same scheme as the cross-chain
+        // chooseNonce). Classic nonces are per-voter set-membership, not
+        // monotonic — only a same-millisecond reuse collides, so bump past
+        // any already-used value.
+        nonce = BigInt(Date.now());
+        const client = publicClientFor(chainId);
+        while (
+          await client.readContract({
+            address: a.votingModule,
+            abi: votingModuleAbi,
+            functionName: "isNonceUsed",
+            args: [address, nonce],
+          })
+        ) {
+          nonce += 1n;
+        }
+        signature = await signTypedDataAsync({
+          domain: classicVoteDomain(chainId, a.votingModule),
+          types: CLASSIC_VOTE_TYPES,
+          primaryType: "Vote",
+          message: {
+            voter: address,
+            pointsHash: classicPointsHash(points),
+            nonce,
+          },
+        });
+      } catch (e) {
+        setSignError(parseTxError(e));
+        return undefined;
+      } finally {
+        setIsSigningBallot(false);
+      }
+      return run({
+        address: a.votingModule,
+        abi: votingModuleAbi,
+        functionName: "castVoteWithSignature",
+        args: [address, points, nonce, signature],
+      });
+    },
+    [address, a.votingModule, chainId, signTypedDataAsync, run],
+  );
+
+  return {
+    vote,
+    recast,
+    /** False on v1 modules (no castVoteWithSignature) — recast unavailable. */
+    supportsRecast,
+    ...tx,
+    isBusy: tx.isBusy || isSigningBallot,
+    status: signError ? ("error" as const) : tx.status,
+    error: signError ?? tx.error,
+  };
 }

--- a/src/hooks/use-voting.ts
+++ b/src/hooks/use-voting.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { BaseError, ContractFunctionRevertedError } from "viem";
 import { useAccount, useReadContract, useSignTypedData } from "wagmi";
 import { votingModuleAbi, votingPowerAbi } from "@/lib/abis";
 import { useActiveChainId, useInstance } from "@/components/instance-provider";
@@ -85,6 +86,15 @@ export function useVotingState() {
  * uniqueness, and _processVote fully reverts the previous ballot's stored
  * allocations before applying the new one — recasting is designed in.
  */
+
+/** True when a read failed because the contract REVERTED (vs a flaky RPC). */
+function isRevert(error: unknown): boolean {
+  return (
+    error instanceof BaseError &&
+    error.walk((e) => e instanceof ContractFunctionRevertedError) !== null
+  );
+}
+
 export function useVote() {
   const a = useInstance();
   const chainId = useActiveChainId();
@@ -106,9 +116,16 @@ export function useVote() {
     abi: votingModuleAbi,
     functionName: "VOTE_TYPEHASH",
     chainId,
-    query: { retry: false, staleTime: Infinity },
+    query: {
+      // A REVERT is the answer (unsupported — don't retry it), but a transient
+      // RPC failure isn't: without retry it would silently lock recast for the
+      // whole mount on a capable chain.
+      retry: (failureCount, error) => !isRevert(error) && failureCount < 2,
+      staleTime: Infinity,
+    },
   });
   const supportsRecast = typehash.isSuccess;
+  const probePending = typehash.isPending;
 
   // The EIP-712 prompt (or the pre-sign nonce read) can fail before any tx
   // exists — surface that through the same status/error the page already
@@ -140,6 +157,19 @@ export function useVote() {
         // any already-used value.
         nonce = BigInt(Date.now());
         const client = publicClientFor(chainId);
+        // The page's power guard polls at 12s — re-read at sign time so a
+        // just-unstaked wallet can't record a 0-power ballot over its old one
+        // (the classic entrypoint, unlike cross-chain, doesn't revert on it).
+        const livePower = (await client.readContract({
+          address: a.votingModule,
+          abi: votingModuleAbi,
+          functionName: "getCurrentVotingPower",
+          args: [address],
+        })) as bigint;
+        if (livePower === 0n) {
+          setSignError("No voting power — deposit before updating your vote");
+          return undefined;
+        }
         while (
           await client.readContract({
             address: a.votingModule,
@@ -181,6 +211,8 @@ export function useVote() {
     recast,
     /** False on v1 modules (no castVoteWithSignature) — recast unavailable. */
     supportsRecast,
+    /** VOTE_TYPEHASH probe still in flight — recast availability unknown. */
+    recastProbePending: probePending,
     ...tx,
     isBusy: tx.isBusy || isSigningBallot,
     status: signError ? ("error" as const) : tx.status,

--- a/src/lib/vote-signature.ts
+++ b/src/lib/vote-signature.ts
@@ -15,9 +15,11 @@ import {
  *
  * The same chainless domain carries the three registry-governance kinds too
  * (registry-update, proposal, proposal-vote): distinct EIP-712 primary types
- * are the firewall between action kinds. Every TYPES const + payload builder
+ * are the firewall between action kinds. Every cross-chain TYPES const +
+ * payload builder
  * below mirrors relay/src/typed-data.ts and the contracts byte-for-byte —
- * pinned by the tracked relay/test/crosschain-vector.json parity assertion.
+ * pinned by the tracked relay/test/crosschain-vector.json;
+ * the classic Vote types are pinned by e2e/verify-classic-recast.ts parity assertion.
  */
 
 /** Domain per family: EIP712Domain(string name,string version,bytes32 salt). */

--- a/src/lib/vote-signature.ts
+++ b/src/lib/vote-signature.ts
@@ -89,6 +89,47 @@ export function buildVotePayload(
   };
 }
 
+/* ─────────────────────── classic (single-chain) vote ─────────────────── */
+
+/**
+ * Classic single-chain vote signature — the recast path for non-family
+ * instances. Unlike the chainless family domain above, this is the STANDARD
+ * EIP712Upgradeable domain (name "CrowdstakingVoting", version "1", chainId,
+ * verifyingContract = the voting module), so the signature is bound to one
+ * module on one chain. Mirrors AbstractVotingModule.VOTE_TYPEHASH and its
+ * validateSignature assembly byte-for-byte — the direct voteWithData path
+ * reverts AlreadyVotedInCurrentCycle, but castVoteWithSignature only gates on
+ * nonce uniqueness and _processVote reverts the previous ballot, so recasting
+ * is designed in via this signature path.
+ */
+export function classicVoteDomain(chainId: number, votingModule: Address) {
+  return {
+    name: "CrowdstakingVoting",
+    version: "1",
+    chainId,
+    verifyingContract: votingModule,
+  } as const;
+}
+
+/** Mirrors VOTE_TYPEHASH = keccak256("Vote(address voter,bytes32 pointsHash,uint256 nonce)"). */
+export const CLASSIC_VOTE_TYPES = {
+  Vote: [
+    { name: "voter", type: "address" },
+    { name: "pointsHash", type: "bytes32" },
+    { name: "nonce", type: "uint256" },
+  ],
+} as const;
+
+/**
+ * pointsHash = keccak256 of the tightly-packed 32-byte words of the points
+ * array — the contract's validateSignature calldatacopies points.offset for
+ * points.length * 0x20 bytes and hashes that (no length prefix, no ABI head),
+ * which is exactly encodePacked over uint256[].
+ */
+export function classicPointsHash(points: readonly bigint[]): Hex {
+  return keccak256(encodePacked(["uint256[]"], [[...points]]));
+}
+
 /* ─────────────────────────── registry-update ─────────────────────────── */
 
 /**


### PR DESCRIPTION
## What

Classic (non-family) instances can now UPDATE their ballot mid-cycle. The direct `voteWithData` path reverts `AlreadyVotedInCurrentCycle`, but `castVoteWithSignature` only gates on nonce uniqueness — and `_processVote` fully reverts the previous ballot's stored allocations before applying the new one. Recasting was designed in; the UI just never used it.

- **`src/lib/vote-signature.ts`** — new "classic (single-chain) vote" section: `classicVoteDomain` (standard EIP712Upgradeable domain: `"CrowdstakingVoting"` / `"1"` / chainId / verifyingContract), `CLASSIC_VOTE_TYPES` (`Vote(address voter,bytes32 pointsHash,uint256 nonce)`), and `classicPointsHash` (keccak256 of the tightly-packed uint256 words — mirrors the contract's `validateSignature` assembly byte-for-byte).
- **`src/hooks/use-voting.ts`** — `useVote()` gains `recast(points)`: fresh `Date.now()` nonce bumped past `isNonceUsed`, EIP-712 sign via wagmi `signTypedDataAsync` (Privy embedded signs silently), submit `castVoteWithSignature` through the wallet-actions `sendSponsored` layer (gasless on embedded wallets). First-time votes keep using `voteWithData` unchanged. `supportsRecast` feature-detects via a no-retry `VOTE_TYPEHASH()` read — a revert keeps today's locked behavior.
- **`src/app/app/vote/page.tsx`** — when `hasVoted` and the module supports it: steppers stay enabled, button reads **"Update vote"** (matching family mode's language), badge reads "You voted this cycle — you can update your ballot until it ends." Modules without the signature path keep the old disabled state.
- **`e2e/verify-classic-recast.ts`** — fork-verification script that imports the EXACT frontend signing helpers + generated ABIs, so any EIP-712 drift fails there first.

## On-chain verification (anvil fork of Gnosis, publicnode)

Fresh classic instance deployed via the live v2 deployer `0xD9dbc941C5e66D1cC67C6612d221263eD1A27C55` (registryKind 0, crossChain false), 500 xDAI minted, power accrued:

```
voting power accrued: 497017892644135188866
voteWithData(70/30) succeeded
distribution BEFORE recast: [347916666666666666666, 149107142857142857142]   (70/30)
direct re-vote reverts AlreadyVotedInCurrentCycle
validateSignature() accepts the frontend-built signature   ← EIP-712 parity, checked on-chain pre-submit
castVoteWithSignature(10/90, nonce=1783802296491) succeeded
distribution AFTER recast:  [49702970297029702970, 447326732673267326731]    (exactly 10/90)
totalCycleVotingPower: 497029702970297029702 vs sum(after): 497029702970297029701  ← counted ONCE
reused nonce reverts NonceAlreadyUsed
v2 VOTE_TYPEHASH matches pinned type string (0x75bc59ee506a0b0e949fb3a7df4ed9c67afe07055fed85f523f130ba4f0bfaea)
```

**Empirical finding — the OLD live v1 default instance supports this too.** Contrary to the working assumption that v1 modules lack `castVoteWithSignature`/`VOTE_TYPEHASH`, the live module `0xf921AF0C…` exposes both with the identical typehash and domain, and its recast REPLACES the ballot (delta-verified on the fork):

```
v1 delta after voteWithData(70/30): [348511601303126009, 149362114844196861]
v1 castVoteWithSignature(10/90) succeeded on a re-vote
v1 delta ratio is 10/90 — old ballot replaced, not double-counted
v1 delta sum 498368613719560718 ≈ one ballot's power (not 2x)
```

So the `VOTE_TYPEHASH()` probe is the right gate both ways: it enables recast on every known live module (verified safe) and disables it on anything that reverts.

Repro: `anvil --fork-url https://gnosis-rpc.publicnode.com --chain-id 100 --port 8547` then `RPC_URL=http://localhost:8547 npx tsx e2e/verify-classic-recast.ts` → ALL CHECKS PASSED.

## Design decisions

- Recast submission reuses `useTx` (wallet-actions `sendSponsored` underneath) so the existing `TxStatus` plumbing renders signing/confirming/success identically; pre-tx failures (sign rejection, nonce read) surface through the same `status`/`error` surface.
- Classic nonces are per-voter set-membership (not monotonic like cross-chain), so `Date.now()` with an `isNonceUsed` bump loop is collision-proof.
- While the `VOTE_TYPEHASH` probe is in flight the form shows the safe locked state, then unlocks — never the reverse.

`pnpm lint` / `pnpm format:check` / `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)