### PR TITLE
ci: pin etherform ref to the blockscout verification fix

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -90,7 +90,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: BreadchainCoop/etherform
-          ref: main
+          # Pinned to the verify-blockscout.sh fix (RPC-free constructor args +
+          # bounded polling). Repoint to main once BreadchainCoop/etherform#55
+          # merges.
+          ref: fix/blockscout-verify-hang
           sparse-checkout: scripts
           path: .etherform
 
@@ -168,12 +171,16 @@ jobs:
 
       - name: Verify on Blockscout
         continue-on-error: true
-        # Bounded: L2 Blockscout verification can hang the etherform script.
-        # The deploy already succeeded by here — verification is best-effort.
+        # Best-effort: the deploy already succeeded by here. The script derives
+        # constructor args from the broadcast file (no RPC needed) and its
+        # polling is tuned below to a hard bound of INITIAL_WAIT +
+        # MAX_CHECKS × CHECK_DELAY = 150s, well inside the step timeout.
         timeout-minutes: 5
         env:
-          RPC_URL: ${{ steps.chain.outputs.rpc }}
           BLOCKSCOUT_URL: ${{ steps.chain.outputs.blockscout }}
+          INITIAL_WAIT: "30"
+          CHECK_DELAY: "20"
+          MAX_CHECKS: "6"
         run: |
           BROADCAST_FILE=$(ls "broadcast/${{ inputs.target }}.s.sol/${{ steps.chain.outputs.id }}/run-latest.json" 2>/dev/null || true)
           if [ -n "$BROADCAST_FILE" ]; then

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -90,10 +90,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: BreadchainCoop/etherform
-          # Pinned to the verify-blockscout.sh fix (RPC-free constructor args +
-          # bounded polling). Repoint to main once BreadchainCoop/etherform#55
-          # merges.
-          ref: fix/blockscout-verify-hang
+          # Pinned to the etherform commit with the verify-blockscout.sh fix
+          # (RPC-free constructor args + bounded polling; etherform#55). A SHA
+          # pin keeps deploys reproducible — bump deliberately.
+          ref: 180aa91926a02ce2045f9a7e3ed08be9395ecfab
           sparse-checkout: scripts
           path: .etherform
 


### PR DESCRIPTION
## Why

The **Verify on Blockscout** step has timed out after 5 minutes on every deploy run (e.g. runs 29133058331 / 29133083853 / 29133084514 on 2026-07-11) and has **never verified a single contract**. Root cause, from the run logs:

1. etherform's `verify-blockscout.sh` calls `forge verify-contract --guess-constructor-args`, which hard-fails with `You have to provide a valid RPC URL to use --guess-constructor-args feature` — this workflow exports `RPC_URL`, a variable forge doesn't read (forge wants `--rpc-url`/`ETH_RPC_URL`). So every submission silently failed.
2. The script's retry loop then burns up to `MAX_CHECKS × CHECK_DELAY` = 300 s **per contract** (~100 min worst case for our 20-contract deploys), so the step is guaranteed to hit the 5-minute timeout before a single check can pass.

## What

- Pin the etherform sparse-checkout to `fix/blockscout-verify-hang` — BreadchainCoop/etherform#55 — which derives constructor args offline from the broadcast file (no RPC dependency at all), passes the compiler version from the build artifacts, resolves Blockscout host redirects (optimism.blockscout.com → explorer.optimism.io), and polls in bounded rounds. **Repoint to `main` once that PR merges** (comment left in the workflow).
- Drop the now-unused `RPC_URL` env from the verify step.
- Tune polling (`INITIAL_WAIT=30`, `CHECK_DELAY=20`, `MAX_CHECKS=6`) to a 150 s hard bound, well inside the kept `timeout-minutes: 5` + `continue-on-error: true`.

## Validation

Ran the pinned script locally against today's three real deploy broadcasts (artifacts from the runs above, built at the deploy commit with solc 0.8.30): **all 20 broadcast contracts verified with exit 0 on each of Gnosis, Arbitrum, and Optimism Blockscout**, including `CrowdStakeDeployer` and `CrowdStakeFactory` on all three chains (confirmed `is_verified: true` via `/api/v2/smart-contracts/<addr>`).

Today's deployers are already verified as part of that validation:
- Gnosis: [`0xD9db…7C55`](https://gnosis.blockscout.com/address/0xD9dbc941C5e66D1cC67C6612d221263eD1A27C55) + factory [`0xE283…811A`](https://gnosis.blockscout.com/address/0xE283f07dFB0A462940198882ae69aDF0b7B5811A)
- Arbitrum: [`0x4480…8A30`](https://arbitrum.blockscout.com/address/0x4480909dD3fC3ADE8586Dd3758F628A7c9B38A30) + factory [`0xAbC9…6134`](https://arbitrum.blockscout.com/address/0xAbC995e02a22AE7134fdAd95bEF0A28505976134)
- Optimism: [`0xCf1F…c361`](https://optimism.blockscout.com/address/0xCf1Fe91A1946E56D12c2B685a18Cc3d7c1F0c361) + factory [`0xbD01…E908`](https://optimism.blockscout.com/address/0xbD01a0F13d06227cF0c1752E685d1ee3281FE908)

🤖 Generated with [Claude Code](https://claude.com/claude-code)