### PR TITLE
fix: repair voting-power reads broken in the recast polish

### DIFF
--- a/src/hooks/use-voting.ts
+++ b/src/hooks/use-voting.ts
@@ -161,8 +161,8 @@ export function useVote() {
         // just-unstaked wallet can't record a 0-power ballot over its old one
         // (the classic entrypoint, unlike cross-chain, doesn't revert on it).
         const livePower = (await client.readContract({
-          address: a.votingModule,
-          abi: votingModuleAbi,
+          address: a.votingPowerStrategy,
+          abi: votingPowerAbi,
           functionName: "getCurrentVotingPower",
           args: [address],
         })) as bigint;


### PR DESCRIPTION
Hotfix for main's broken frontend build (my post-review polish on #178 introduced a wrong function/target pair, and a too-broad rename then broke the legitimate strategy read — the pipe-masked exit code let it slip past my local gate, and the required CI check only runs Foundry). Both power reads now use `votingPowerStrategy.getCurrentVotingPower`, matching the UI guard. Verified with `set -o pipefail` this time: lint/format/build all genuinely green.