### PR TITLE
fix: skeleton-gate family pages until the mode is known

### DIFF
--- a/src/app/app/deposit/page.tsx
+++ b/src/app/app/deposit/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useAccount } from "wagmi";
 import { Body, Caption } from "@breadcoop/ui";
-import { Card, PageHeader } from "@/components/dapp/ui";
+import { Card, GateSkeleton, PageHeader } from "@/components/dapp/ui";
 import { AmountField } from "@/components/dapp/amount-field";
 import { ActionButton } from "@/components/dapp/action-button";
 import { TxStatus } from "@/components/dapp/tx-status";
@@ -32,18 +32,24 @@ export default function DepositPage() {
   const family = useFamily();
   const depositSym = yieldKind === "stable" ? wrappedSymbol : native;
   const isFamily = family.isFamily && !family.isLoading;
+  // familyId not yet known — don't render (and then swap) the wrong mode.
+  const resolving = family.familyId === null && family.isLoading;
 
   return (
     <div className="mx-auto max-w-lg">
       <PageHeader
         title="Deposit"
         subtitle={
-          isFamily
-            ? `Mint ${symbol} across the chains this community lives on — deposit whatever you hold on each. Your principal stays withdrawable; only the interest is distributed.`
-            : `Stake ${depositSym} to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
+          resolving
+            ? `Deposit to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
+            : isFamily
+              ? `Mint ${symbol} across the chains this community lives on — deposit whatever you hold on each. Your principal stays withdrawable; only the interest is distributed.`
+              : `Stake ${depositSym} to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
         }
       />
-      {isFamily ? (
+      {resolving ? (
+        <GateSkeleton />
+      ) : isFamily ? (
         <>
           <FamilyDeposit family={family} tokenSymbol={symbol} />
           <details className="mt-4">

--- a/src/app/app/withdraw/page.tsx
+++ b/src/app/app/withdraw/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Caption } from "@breadcoop/ui";
-import { Card, PageHeader } from "@/components/dapp/ui";
+import { Card, GateSkeleton, PageHeader } from "@/components/dapp/ui";
 import { AmountField } from "@/components/dapp/amount-field";
 import { ActionButton } from "@/components/dapp/action-button";
 import { TxStatus } from "@/components/dapp/tx-status";
@@ -28,6 +28,8 @@ export default function WithdrawPage() {
   const redeemSym = useRedeemSymbol();
   const family = useFamily();
   const isFamily = family.isFamily && !family.isLoading;
+  // familyId not yet known — don't render (and then swap) the wrong mode.
+  const resolving = family.familyId === null && family.isLoading;
   return (
     <div className="mx-auto max-w-lg">
       <PageHeader
@@ -41,7 +43,13 @@ export default function WithdrawPage() {
       {/* Family mode: the token lives on several chains, so withdrawing the
           whole position is a per-chain burn fan-out — one panel, per-chain
           rows. Classic instances keep the single-chain form. */}
-      {isFamily ? <FamilyWithdraw family={family} /> : <WithdrawForm />}
+      {resolving ? (
+        <GateSkeleton />
+      ) : isFamily ? (
+        <FamilyWithdraw family={family} />
+      ) : (
+        <WithdrawForm />
+      )}
     </div>
   );
 }

--- a/src/app/app/yield/page.tsx
+++ b/src/app/app/yield/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Body, Caption } from "@breadcoop/ui";
-import { Card, PageHeader } from "@/components/dapp/ui";
+import { Card, GateSkeleton, PageHeader } from "@/components/dapp/ui";
 import { ActionButton } from "@/components/dapp/action-button";
 import { TxStatus } from "@/components/dapp/tx-status";
 import { cn } from "@/lib/utils";
@@ -41,6 +41,8 @@ function SplitForm({ family }: { family: FamilyState }) {
   // fans setYieldSplit out to every sibling chain (per-chain status rows
   // below); classic instances keep the single-chain write.
   const isFamily = family.isFamily && !family.isLoading;
+  // familyId not yet known — don't render (and then swap) the wrong mode.
+  const resolving = family.familyId === null && family.isLoading;
   const { keepBps, supported, refetch } = useYieldSplit();
   const { setSplit, ...tx } = useSetYieldSplit();
   const fam = useFamilyYieldSplit(family); // inert ([] rows) when not a family
@@ -72,6 +74,9 @@ function SplitForm({ family }: { family: FamilyState }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tx.isSuccess]);
 
+  if (resolving) {
+    return <GateSkeleton />;
+  }
   if (isFamily ? famAllUnsupported : supported === false) {
     return (
       <Card>

--- a/src/components/dapp/ui.tsx
+++ b/src/components/dapp/ui.tsx
@@ -81,3 +81,14 @@ export function EmptyState({ children }: { children: ReactNode }) {
     </Card>
   );
 }
+
+/** Pulse placeholder while the instance's family mode is being resolved —
+ * rendering either mode's real form first would flash the wrong one. */
+export function GateSkeleton() {
+  return (
+    <div className="animate-pulse space-y-4">
+      <div className="bg-paper-1 h-24 rounded-2xl" />
+      <div className="bg-paper-1 h-40 rounded-2xl" />
+    </div>
+  );
+}


### PR DESCRIPTION
Report: "when I load the deposit page the single chain deposit still flashes". The deposit/withdraw/yield pages gated on `isFamily = family.isFamily && !family.isLoading`, which renders the CLASSIC form during resolution and swaps in the family panel after — a visible flash on family instances. All three now use the vote page's skeleton-until-resolved pattern (shared `GateSkeleton` in dapp/ui). Deposit's subtitle also stays mode-neutral while resolving instead of swapping text. Gates green (pipefail-verified).