### PR TITLE
feat: redesign the dapp nav

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,6 +34,14 @@ body {
   }
 }
 
+/* Hide scrollbars on intentionally-scrollable pill rows (the mobile nav). */
+.scrollbar-none {
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
 /* --- Telegram Mini App (html.tg-app set by the boot script in layout.tsx) ---
    Fullscreen mini apps draw under the device status bar / Telegram controls;
    telegram-web-app.js exposes the insets as CSS vars (0px in the regular

--- a/src/components/dapp/dapp-nav.tsx
+++ b/src/components/dapp/dapp-nav.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { CaretDown } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { WalletButton } from "@/components/dapp/wallet-button";
 import { useRegistryOwner } from "@/hooks/use-recipients";
@@ -16,93 +18,151 @@ function DemoToggle() {
       onClick={() => setDemo(!demo)}
       title="Demo mode: multiply displayed amounts ×1000 (does not change real amounts)"
       className={cn(
-        "hidden shrink-0 rounded-lg border px-2.5 py-1.5 text-xs font-semibold transition-colors sm:block",
+        "hidden h-8 shrink-0 items-center rounded-full border px-3 text-xs font-semibold transition-colors sm:inline-flex",
         demo
           ? "border-core-orange bg-core-orange text-white"
           : "border-paper-2 text-surface-grey-2 hover:text-text-standard",
       )}
     >
-      Demo ×1000{demo ? " ●" : ""}
+      ×1000{demo ? " on" : ""}
     </button>
   );
 }
 
-const LINKS = [
+/** The everyday actions stay visible; everything else lives under More. */
+const PRIMARY = [
   { href: "/app", label: "Portfolio" },
   { href: "/app/deposit", label: "Deposit" },
   { href: "/app/withdraw", label: "Withdraw" },
-  { href: "/app/yield", label: "Yield" },
   { href: "/app/vote", label: "Vote" },
   { href: "/app/distribute", label: "Distribute" },
+];
+
+const SECONDARY = [
+  { href: "/app/yield", label: "Yield split" },
   { href: "/app/history", label: "History" },
   { href: "/app/deploy", label: "Deploy" },
 ];
 
-function useNavLinks() {
+const ADMIN = [
+  { href: "/app/recipients", label: "Recipients" },
+  { href: "/app/admin", label: "Admin" },
+];
+
+function useSecondaryLinks() {
   const { isAdmin } = useRegistryOwner();
-  return isAdmin
-    ? [
-        ...LINKS,
-        { href: "/app/recipients", label: "Recipients" },
-        { href: "/app/admin", label: "Admin" },
-      ]
-    : LINKS;
+  return isAdmin ? [...SECONDARY, ...ADMIN] : SECONDARY;
 }
 
 function isActive(pathname: string, href: string) {
-  return href === "/app" ? pathname === "/app" : pathname.startsWith(href);
+  // trailingSlash builds report "/app/" on hard loads — normalize both forms.
+  const p = pathname.replace(/\/+$/, "") || "/";
+  return href === "/app" ? p === "/app" : p.startsWith(href);
+}
+
+function NavLink({
+  href,
+  label,
+  pathname,
+  className,
+  onClick,
+}: {
+  href: string;
+  label: string;
+  pathname: string;
+  className?: string;
+  onClick?: () => void;
+}) {
+  return (
+    <Link
+      href={href}
+      onClick={onClick}
+      className={cn(
+        "rounded-full px-3.5 py-1.5 text-sm font-medium whitespace-nowrap transition-colors",
+        isActive(pathname, href)
+          ? "bg-core-orange/10 text-core-orange"
+          : "text-surface-grey-2 hover:bg-paper-1 hover:text-text-standard",
+        className,
+      )}
+    >
+      {label}
+    </Link>
+  );
+}
+
+/** Overflow menu for the less-frequent pages (admin entries when relevant). */
+function MoreMenu({ pathname }: { pathname: string }) {
+  const [open, setOpen] = useState(false);
+  const links = useSecondaryLinks();
+  const anyActive = links.some((l) => isActive(pathname, l.href));
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          "flex items-center gap-1 rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors",
+          anyActive
+            ? "bg-core-orange/10 text-core-orange"
+            : "text-surface-grey-2 hover:bg-paper-1 hover:text-text-standard",
+        )}
+      >
+        More
+        <CaretDown
+          size={12}
+          weight="bold"
+          className={cn("transition-transform", open && "rotate-180")}
+        />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="border-paper-2 bg-paper-0 absolute right-0 z-50 mt-2 flex w-44 flex-col gap-0.5 rounded-xl border p-1.5 shadow-xl">
+            {links.map((l) => (
+              <NavLink
+                key={l.href}
+                {...l}
+                pathname={pathname}
+                className="block px-3 py-2"
+                onClick={() => setOpen(false)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
 }
 
 export function DappNav() {
   const pathname = usePathname();
-  const links = useNavLinks();
+  const secondary = useSecondaryLinks();
 
   return (
-    <header className="border-paper-2 bg-paper-main/80 tg-safe-top sticky top-0 z-50 border-b backdrop-blur">
+    <header className="border-paper-2 bg-paper-main/85 tg-safe-top sticky top-0 z-50 border-b backdrop-blur-md">
       <nav className="section-container flex h-16 items-center gap-3">
         {/* Left: the instance IS the brand (white-label) — its badge + name. */}
         <InstanceSwitcher />
 
-        {/* Center: page navigation (lg+) */}
-        <div className="hidden flex-1 items-center justify-center gap-1 lg:flex">
-          {links.map((l) => (
-            <Link
-              key={l.href}
-              href={l.href}
-              className={cn(
-                "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
-                isActive(pathname, l.href)
-                  ? "bg-core-orange/10 text-core-orange"
-                  : "text-surface-grey-2 hover:text-text-standard",
-              )}
-            >
-              {l.label}
-            </Link>
+        {/* Center: everyday pages + an overflow menu (lg+). */}
+        <div className="hidden flex-1 items-center justify-center gap-0.5 lg:flex">
+          {PRIMARY.map((l) => (
+            <NavLink key={l.href} {...l} pathname={pathname} />
           ))}
+          <MoreMenu pathname={pathname} />
         </div>
 
         {/* Right: utilities */}
         <div className="ml-auto flex items-center gap-2 lg:ml-0">
           <DemoToggle />
-          <WalletButton size="sm" />
+          <WalletButton size="sm" nav />
         </div>
       </nav>
 
-      {/* Compact nav row (below lg) */}
-      <div className="border-paper-2 flex gap-1 overflow-x-auto border-t px-4 py-2 lg:hidden">
-        {links.map((l) => (
-          <Link
-            key={l.href}
-            href={l.href}
-            className={cn(
-              "rounded-lg px-3 py-1.5 text-sm font-medium whitespace-nowrap",
-              isActive(pathname, l.href)
-                ? "bg-core-orange/10 text-core-orange"
-                : "text-surface-grey-2",
-            )}
-          >
-            {l.label}
-          </Link>
+      {/* Compact nav row (below lg): everyday pages scroll, the rest follow. */}
+      <div className="-mt-1 flex scrollbar-none gap-0.5 overflow-x-auto px-4 pb-2 lg:hidden">
+        {[...PRIMARY, ...secondary].map((l) => (
+          <NavLink key={l.href} {...l} pathname={pathname} />
         ))}
       </div>
     </header>

--- a/src/components/dapp/wallet-button.tsx
+++ b/src/components/dapp/wallet-button.tsx
@@ -3,6 +3,7 @@
 import { useAccount } from "wagmi";
 import { Button } from "@breadcoop/ui";
 import { SignOut } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
 import { useWalletActions } from "@/components/wallet/wallet-actions";
 
 /** Shortened `0x1234…abcd` address. */
@@ -11,17 +12,24 @@ function shortAddress(address: string): string {
 }
 
 /**
- * Wallet connect / account control for the nav. Backed by Privy (email/social +
- * external wallets, gasless) when configured, else a plain injected wallet.
- * Address + connection come from wagmi, so this one component works in both.
+ * Wallet connect / account control. Backed by Privy (email/social + external
+ * wallets, gasless) when configured, else a plain injected wallet. Address +
+ * connection come from wagmi, so this one component works in both.
+ *
+ * `nav` renders the quiet pill variant: the design system's brutalist offset
+ * shadow reads as clutter inside the slim h-16 bar, so the nav gets a flat
+ * rounded-full treatment instead.
  */
 export function WalletButton({
   full = false,
   size,
+  nav = false,
 }: {
   full?: boolean;
   /** Button size — the nav passes "sm" so it fits the h-16 row. */
   size?: "sm";
+  /** Quiet rounded-pill styling for the nav bar. */
+  nav?: boolean;
 }) {
   const { address, isConnected } = useAccount();
   const { connect, disconnect } = useWalletActions();
@@ -32,7 +40,10 @@ export function WalletButton({
         app="fund"
         variant="primary"
         size={size}
-        className={full ? "w-full" : "whitespace-nowrap"}
+        className={cn(
+          full ? "w-full" : "whitespace-nowrap",
+          nav && "rounded-full shadow-none",
+        )}
         onClick={connect}
       >
         Connect wallet
@@ -41,21 +52,26 @@ export function WalletButton({
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <span className="border-paper-2 text-text-standard rounded-full border px-3 py-1.5 font-mono text-sm">
+    <div className="flex items-center gap-1.5">
+      <span
+        className={cn(
+          "border-paper-2 text-text-standard rounded-full border font-mono",
+          nav ? "bg-paper-0 h-8 px-3 text-xs leading-8" : "px-3 py-1.5 text-sm",
+        )}
+      >
         {shortAddress(address)}
       </span>
-      <Button
-        app="fund"
-        variant="secondary"
-        size={size}
-        className="px-2"
+      <button
         onClick={disconnect}
-        leftIcon={<SignOut weight="bold" />}
         aria-label="Disconnect wallet"
+        title="Disconnect"
+        className={cn(
+          "border-paper-2 text-surface-grey-2 hover:text-core-orange hover:border-core-orange/40 flex items-center justify-center rounded-full border transition-colors",
+          nav ? "h-8 w-8" : "h-9 w-9",
+        )}
       >
-        <span className="sr-only">Disconnect</span>
-      </Button>
+        <SignOut size={16} weight="bold" />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
Report: "navbar still looks ugly as hell" — fair. What changed:

- **Five everyday links + a More ▾ menu** (Yield split / History / Deploy, plus Recipients / Admin for admins) instead of ten crowded links.
- **Pill link treatment** with hover + active states; More highlights when one of its pages is active.
- **Quiet rounded wallet pill** in the nav — the design system's brutalist offset shadow stays on page CTAs, where it reads as intentional rather than cramped. Connected state = address chip + round sign-out icon.
- **×1000 demo chip** instead of the boxy toggle.
- **Mobile**: one tight scrollable pill strip (hidden scrollbar), no double-border stack.

Before/after screenshots verified at 1440/390px; gates green (pipefail).