### PR TITLE
feat: withdraw-all and distribute-all for families

### DIFF
--- a/src/app/app/distribute/_components/family-distribute-card.tsx
+++ b/src/app/app/distribute/_components/family-distribute-card.tsx
@@ -3,6 +3,7 @@
 import { ArrowSquareOut, CheckCircle } from "@phosphor-icons/react";
 import { Button, Caption } from "@breadcoop/ui";
 import { Card } from "@/components/dapp/ui";
+import { ActionButton } from "@/components/dapp/action-button";
 import { shortChainName, txUrl } from "@/lib/chains";
 import { useActiveChainId } from "@/components/instance-provider";
 import { useAmountFormatter18 } from "@/components/demo-mode-provider";
@@ -21,7 +22,10 @@ import type { FamilyState } from "@/hooks/use-family";
  */
 export function FamilyDistributeCard({ family }: { family: FamilyState }) {
   const activeChainId = useActiveChainId();
-  const { rows, distributeOn } = useFamilyDistribute(family);
+  const { rows, distributeOn, distributeAll, anyBusy } =
+    useFamilyDistribute(family);
+  // Only rows the contract itself reports ready — the walk re-checks each one.
+  const readyCount = rows.filter((r) => r.isReady === true).length;
 
   if (rows.length === 0) return null;
 
@@ -30,6 +34,18 @@ export function FamilyDistributeCard({ family }: { family: FamilyState }) {
       <Caption className="text-surface-grey-2 block">
         Your community across chains — yield accrues and distributes per chain
       </Caption>
+      <div className="mt-3">
+        {/* chainless: the walk targets each chain itself, so no
+            switch-to-active-chain gating — only connect gating. */}
+        <ActionButton
+          chainless
+          isLoading={anyBusy}
+          disabled={readyCount === 0 || anyBusy}
+          onClick={() => void distributeAll()}
+        >
+          Distribute on all ready chains
+        </ActionButton>
+      </div>
       <div className="mt-1">
         <GasModeNote />
       </div>

--- a/src/app/app/withdraw/_components/family-withdraw.tsx
+++ b/src/app/app/withdraw/_components/family-withdraw.tsx
@@ -11,11 +11,11 @@ import {
 } from "@phosphor-icons/react";
 import { Body, Button, Caption } from "@breadcoop/ui";
 import { Card } from "@/components/dapp/ui";
+import { ActionButton } from "@/components/dapp/action-button";
 import { GasModeNote } from "@/components/dapp/gas-mode-note";
 import { formatAmount, parseAmount } from "@/lib/format";
 import { shortChainName, txUrl } from "@/lib/chains";
 import { useActiveChainId } from "@/components/instance-provider";
-import { useWalletActions } from "@/components/wallet/wallet-actions";
 import { useInstanceToken } from "@/hooks/use-token";
 import {
   useFamilyWithdraw,
@@ -31,12 +31,14 @@ import type { FamilyState } from "@/hooks/use-family";
  */
 export function FamilyWithdraw({ family }: { family: FamilyState }) {
   const activeChainId = useActiveChainId();
-  const { isConnected } = useAccount();
-  const { connect } = useWalletActions();
   const { symbol } = useInstanceToken();
-  const { rows, withdrawOn } = useFamilyWithdraw(family);
+  const { rows, withdrawOn, withdrawAll, anyBusy } = useFamilyWithdraw(family);
   // Per-chain amount inputs, parsed with THAT chain's token decimals.
   const [amounts, setAmounts] = useState<Record<number, string>>({});
+  // "Withdraw everything" only makes sense with something to burn somewhere.
+  const hasBalances = rows.some(
+    (r) => r.balance !== undefined && r.balance > 0n,
+  );
 
   // Clear a row's input once its withdrawal lands (the state machine passes
   // through "withdrawing" between runs, so each completion clears once).
@@ -70,6 +72,23 @@ export function FamilyWithdraw({ family }: { family: FamilyState }) {
         <Globe size={14} weight="fill" className="text-core-orange" />
         Withdraw {symbol} across your chains
       </Caption>
+
+      <div className="mt-3">
+        {/* chainless: the walk targets each chain itself, so no
+            switch-to-active-chain gating — only connect gating. */}
+        <ActionButton
+          chainless
+          isLoading={anyBusy}
+          disabled={!hasBalances || anyBusy}
+          onClick={() => void withdrawAll()}
+        >
+          Withdraw everything
+        </ActionButton>
+      </div>
+      <Caption className="text-surface-grey mt-1.5 block">
+        burns your full balance on every chain — you receive the local asset on
+        each
+      </Caption>
       <div className="mt-1">
         <GasModeNote />
       </div>
@@ -89,19 +108,6 @@ export function FamilyWithdraw({ family }: { family: FamilyState }) {
           />
         ))}
       </ul>
-
-      {!isConnected && (
-        <div className="mt-5">
-          <Button
-            app="fund"
-            variant="primary"
-            className="w-full"
-            onClick={connect}
-          >
-            Connect wallet
-          </Button>
-        </div>
-      )}
 
       <Body className="text-surface-grey mt-6 text-sm">
         Each withdrawal burns {symbol} on that chain and sends you its base

--- a/src/hooks/use-family-distribute.ts
+++ b/src/hooks/use-family-distribute.ts
@@ -140,6 +140,10 @@ export function useFamilyDistribute(family: FamilyState) {
   const membersRef = useRef<Member[]>([]);
   // decimals never change per token — read once per sibling, then reuse.
   const decimalsCache = useRef(new Map<number, number>());
+  // "Distribute all" walk in progress — ref guards re-entry (the walk has
+  // idle gaps between chains while re-checking readiness), state drives the UI.
+  const allRunningRef = useRef(false);
+  const [allRunning, setAllRunning] = useState(false);
 
   const setRows = useCallback(
     (updater: (prev: FamilyDistributeRow[]) => FamilyDistributeRow[]) => {
@@ -253,11 +257,50 @@ export function useFamilyDistribute(family: FamilyState) {
     [patchRow, sendSponsored],
   );
 
+  /**
+   * Distribute on every READY chain, sequentially — a self-paid wallet must
+   * switch networks between writes, so parallel submits would race the switch
+   * (embedded wallets just sign each silently). Each chain's readiness is
+   * RE-CHECKED right before its tx: the row's copy can be up to 12s stale and
+   * distribute is a public keeper race, so a chain someone else just
+   * distributed is skipped instead of submitting a doomed tx. Fail-soft per
+   * chain: not-ready/unreachable rows are skipped without breaking the walk.
+   */
+  const distributeAll = useCallback(async () => {
+    if (allRunningRef.current) return; // one walk at a time
+    allRunningRef.current = true;
+    setAllRunning(true);
+    try {
+      for (const m of membersRef.current) {
+        const row = rowsRef.current.find((r) => r.chainId === m.chainId);
+        if (!row) continue;
+        if (row.unreachable) continue; // can't confirm anything there
+        if (!row.isReady) continue; // only chains shown ready
+        if (row.state === "distributing" || row.state === "confirming")
+          continue;
+        let fresh: ChainReads;
+        try {
+          fresh = await readChain(m, decimalsCache.current);
+        } catch {
+          patchRow(m.chainId, { unreachable: true });
+          continue; // dead RPC — skip this chain, keep walking
+        }
+        patchRow(m.chainId, fresh);
+        if (!fresh.isReady) continue; // raced — already distributed elsewhere
+        await distributeOn(m.chainId);
+      }
+    } finally {
+      allRunningRef.current = false;
+      setAllRunning(false);
+    }
+  }, [distributeOn, patchRow]);
+
   return {
     rows,
     distributeOn,
-    anyBusy: rows.some(
-      (r) => r.state === "distributing" || r.state === "confirming",
-    ),
+    distributeAll,
+    anyBusy:
+      allRunning ||
+      rows.some((r) => r.state === "distributing" || r.state === "confirming"),
   };
 }

--- a/src/hooks/use-family-withdraw.ts
+++ b/src/hooks/use-family-withdraw.ts
@@ -125,6 +125,10 @@ export function useFamilyWithdraw(family: FamilyState) {
   const membersRef = useRef<Member[]>([]);
   // decimals never change per token — read once per sibling, then reuse.
   const decimalsCache = useRef(new Map<number, number>());
+  // "Withdraw everything" walk in progress — ref guards re-entry (the walk has
+  // idle gaps between chains while re-reading balances), state drives the UI.
+  const allRunningRef = useRef(false);
+  const [allRunning, setAllRunning] = useState(false);
 
   const setRows = useCallback(
     (updater: (prev: FamilyWithdrawRow[]) => FamilyWithdrawRow[]) => {
@@ -239,11 +243,49 @@ export function useFamilyWithdraw(family: FamilyState) {
     [address, patchRow, sendSponsored],
   );
 
+  /**
+   * Burn the FULL balance on every chain that has one, sequentially — a
+   * self-paid wallet must switch networks between writes, so parallel submits
+   * would race the switch (embedded wallets just sign each silently). Each
+   * chain's balance is RE-READ right before its burn: the row's copy can be
+   * up to 12s stale, and burning a stale-high amount REVERTS — so the burn
+   * uses the exact fresh amount. Fail-soft per chain: zero/unreachable rows
+   * are skipped without breaking the walk.
+   */
+  const withdrawAll = useCallback(async () => {
+    if (allRunningRef.current || !address) return; // one walk at a time
+    allRunningRef.current = true;
+    setAllRunning(true);
+    try {
+      for (const m of membersRef.current) {
+        const row = rowsRef.current.find((r) => r.chainId === m.chainId);
+        if (!row) continue;
+        if (row.unreachable) continue; // can't confirm anything there
+        if (row.balance === undefined || row.balance === 0n) continue;
+        if (row.state === "withdrawing" || row.state === "confirming") continue;
+        let fresh: ChainReads;
+        try {
+          fresh = await readChain(m, address, decimalsCache.current);
+        } catch {
+          patchRow(m.chainId, { unreachable: true });
+          continue; // dead RPC — skip this chain, keep walking
+        }
+        patchRow(m.chainId, fresh);
+        if (fresh.balance === undefined || fresh.balance === 0n) continue;
+        await withdrawOn(m.chainId, fresh.balance);
+      }
+    } finally {
+      allRunningRef.current = false;
+      setAllRunning(false);
+    }
+  }, [address, patchRow, withdrawOn]);
+
   return {
     rows,
     withdrawOn,
-    anyBusy: rows.some(
-      (r) => r.state === "withdrawing" || r.state === "confirming",
-    ),
+    withdrawAll,
+    anyBusy:
+      allRunning ||
+      rows.some((r) => r.state === "withdrawing" || r.state === "confirming"),
   };
 }


### PR DESCRIPTION
## What

Adds one-click **"Withdraw everything"** and **"Distribute on all ready chains"** actions to the family panels, following the sequential fan-out precedent set by `setSplitEverywhere` (self-paid wallets must switch networks between writes, so the walk is sequential; per-row guards make re-entry safe).

### `withdrawAll()` — `src/hooks/use-family-withdraw.ts`
- Walks family chains sequentially; skips zero-balance, unreachable, and in-flight rows.
- **Re-reads the live balance right before each burn** via the existing `readChain` — the row's copy can be up to 12s stale, and burning a stale-high amount reverts — then burns that exact fresh amount through the existing `withdrawOn` (same `sendSponsored` + own-chain receipt-status path, no new write code).
- A dead RPC during the fresh read marks that row unreachable and skips it without breaking the walk.

### `distributeAll()` — `src/hooks/use-family-distribute.ts`
- Walks rows currently shown ready, sequentially; **re-checks `isDistributionReady` right before each tx** via the existing `readChain` (distribute is a public keeper race — a chain someone else just distributed is skipped instead of submitting a doomed tx), then calls the existing `distributeOn`.

### UI
- Both buttons are `ActionButton chainless` above the rows, matching the yield page's "Update split on N chains" style, with `GasModeNote` below.
- Withdraw: "Withdraw everything" + sub-caption "burns your full balance on every chain — you receive the local asset on each"; disabled when no balances anywhere or anything is busy. The card's old bottom "Connect wallet" button is removed — `ActionButton` already renders the connect CTA, so keeping both would show two connect buttons.
- Distribute: "Distribute on all ready chains"; disabled when no chain is ready or anything is busy.
- Per-row statuses (withdrawing/confirming/done/failed + tx links) show progress as the walk moves chain to chain.
- Each hook guards the walk with a ref (`allRunningRef`) and folds an `allRunning` state into `anyBusy`, so the button stays busy through the idle gaps between chains (fresh reads) instead of flickering enabled mid-walk.

## Verification
- `pnpm lint`, `pnpm format:check`, `pnpm build` all pass (with `set -o pipefail`).
- Playwright screenshots of the exported site at `/app/withdraw/?i=0xC6bC…11E6` and `/app/distribute/?i=0xC6bC…11E6`: both family cards render the new full-width action above Optimism/Gnosis/Arbitrum rows (showing the connect CTA while disconnected), with per-row inputs/buttons intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)