### PR TITLE
fix: per-chain decimals + payout waves in family history

### DIFF
--- a/src/app/app/history/page.tsx
+++ b/src/app/app/history/page.tsx
@@ -12,17 +12,24 @@ import { Card, EmptyState, PageHeader, StatCard } from "@/components/dapp/ui";
 import {
   useDistributionHistory,
   type EnrichedRound,
+  type PayoutWave,
   type RecipientSummary,
 } from "@/hooks/use-distribution-history";
 import { addressUrl, shortChainName, txUrl } from "@/lib/chains";
 import { toDecimal } from "@/lib/distribution-history";
-import { formatAmount, formatPercent, shortenAddress } from "@/lib/format";
+import {
+  formatAmountKeepTiny,
+  formatNumberKeepTiny,
+  formatPercent,
+  shortenAddress,
+} from "@/lib/format";
 import { useInstanceToken } from "@/hooks/use-token";
 
-/** ~decimal number → grouped string (family total across stablecoin chains). */
-function fmtNum(n: number, frac = 2): string {
-  return n.toLocaleString("en-US", { maximumFractionDigits: frac });
-}
+/**
+ * ~decimal number → grouped string (family totals across chains). Dust-safe:
+ * small real payouts keep their significant digits instead of showing "0".
+ */
+const fmtNum = formatNumberKeepTiny;
 
 function fmtDate(ts: number): string {
   if (!ts) return "—";
@@ -100,7 +107,19 @@ export default function HistoryPage() {
               }
               accent
             />
-            <StatCard label="Payout rounds" value={history.roundCount} />
+            {history.isFamily ? (
+              // One family payout executes as separate txs per chain — count
+              // the cross-chain waves, not the per-chain legs.
+              <StatCard
+                label="Payout waves"
+                value={history.waves.length}
+                sub={`${history.roundCount} chain payout${
+                  history.roundCount === 1 ? "" : "s"
+                }`}
+              />
+            ) : (
+              <StatCard label="Payout rounds" value={history.roundCount} />
+            )}
             <StatCard label="Recipients paid" value={history.recipientCount} />
             <StatCard
               label="Chains"
@@ -128,7 +147,8 @@ export default function HistoryPage() {
                           {shortChainName(c.chainId)}
                         </span>
                         <span className="text-surface-grey-2">
-                          {formatAmount(c.total, 2, c.decimals)} {c.symbol}
+                          {formatAmountKeepTiny(c.total, 2, c.decimals)}{" "}
+                          {c.symbol}
                           <span className="text-surface-grey ml-2">
                             {c.rounds} round{c.rounds === 1 ? "" : "s"}
                           </span>
@@ -163,19 +183,34 @@ export default function HistoryPage() {
             </ul>
           </Card>
 
-          {/* Timeline */}
+          {/* Timeline — families group each cross-chain wave's per-chain
+              payouts under one header; classic instances keep the flat list. */}
           <Caption className="text-surface-grey-2 mt-8 mb-3 block">
             Payout timeline
+            {history.isFamily &&
+              " — payouts on different chains within ~6 hours are grouped as one wave"}
           </Caption>
-          <div className="space-y-2">
-            {history.rounds.map((round) => (
-              <RoundRow
-                key={`${round.chainId}-${round.txHash}`}
-                round={round}
-                allTimeNormalized={history.totalNormalized}
-              />
-            ))}
-          </div>
+          {history.isFamily ? (
+            <div className="space-y-5">
+              {history.waves.map((wave) => (
+                <WaveGroup
+                  key={wave.key}
+                  wave={wave}
+                  allTimeNormalized={history.totalNormalized}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {history.rounds.map((round) => (
+                <RoundRow
+                  key={`${round.chainId}-${round.txHash}`}
+                  round={round}
+                  allTimeNormalized={history.totalNormalized}
+                />
+              ))}
+            </div>
+          )}
 
           <div className="mt-6 flex items-center gap-3">
             <Button
@@ -223,7 +258,7 @@ function RecipientRow({
             {r.perChain
               .map(
                 (pc) =>
-                  `${formatAmount(pc.amount, 2, pc.decimals)} ${pc.symbol} on ${shortChainName(
+                  `${formatAmountKeepTiny(pc.amount, 2, pc.decimals)} ${pc.symbol} on ${shortChainName(
                     pc.chainId,
                   )}`,
               )
@@ -232,6 +267,47 @@ function RecipientRow({
         )}
       </div>
     </li>
+  );
+}
+
+/**
+ * One cross-chain payout wave: a header (date + ≈ total across its chains)
+ * over the per-chain rounds, which keep their own expandable detail. The
+ * grouping is a display-time heuristic (6h clustering) — hence the ≈.
+ */
+function WaveGroup({
+  wave,
+  allTimeNormalized,
+}: {
+  wave: PayoutWave;
+  allTimeNormalized: number;
+}) {
+  const symbols = new Set(wave.rounds.map((r) => r.symbol));
+  const symbol = symbols.size === 1 ? ` ${[...symbols][0]}` : "";
+  return (
+    <div>
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <span className="text-text-standard text-sm font-semibold">
+          {fmtDate(wave.timestamp)}
+        </span>
+        <span className="text-surface-grey-2 text-sm">
+          ≈ {fmtNum(wave.totalNormalized)}
+          {symbol}
+          <span className="text-surface-grey ml-2 text-xs">
+            {wave.rounds.length} chain{wave.rounds.length === 1 ? "" : "s"}
+          </span>
+        </span>
+      </div>
+      <div className="border-paper-2 space-y-2 border-l-2 pl-3">
+        {wave.rounds.map((round) => (
+          <RoundRow
+            key={`${round.chainId}-${round.txHash}`}
+            round={round}
+            allTimeNormalized={allTimeNormalized}
+          />
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -261,7 +337,8 @@ function RoundRow({
       >
         <div className="min-w-0">
           <div className="text-text-standard text-sm font-semibold">
-            {formatAmount(round.total, 2, round.decimals)} {round.symbol}
+            {formatAmountKeepTiny(round.total, 2, round.decimals)}{" "}
+            {round.symbol}
           </div>
           <div className="text-surface-grey text-xs">
             {fmtDate(round.timestamp)} · {shortChainName(round.chainId)} ·{" "}
@@ -296,7 +373,8 @@ function RoundRow({
                       {shortenAddress(x.recipient)}
                     </a>
                     <span className="text-text-standard">
-                      {formatAmount(x.amount, 4, round.decimals)} {round.symbol}
+                      {formatAmountKeepTiny(x.amount, 4, round.decimals)}{" "}
+                      {round.symbol}
                       <span className="text-surface-grey ml-2 text-xs tabular-nums">
                         {formatPercent(share)}
                       </span>

--- a/src/hooks/use-distribution-history.ts
+++ b/src/hooks/use-distribution-history.ts
@@ -49,9 +49,58 @@ export interface RecipientSummary {
   }[];
 }
 
+/**
+ * One payout "wave": per-chain rounds that belong to the same cross-chain
+ * distribution. Families execute one payout as separate transactions on every
+ * chain, so rounds on DIFFERENT chains landing within a short window are
+ * clustered (heuristically — there's no on-chain link between them). A chain
+ * appears at most once per wave; same-chain rounds are always separate waves.
+ * For classic instances every wave is exactly one round.
+ */
+export interface PayoutWave {
+  /** Stable key for rendering (the newest round's chain+tx). */
+  key: string;
+  /** This wave's rounds, newest first — at most one per chain. */
+  rounds: EnrichedRound[];
+  /** The newest round's timestamp (unix seconds). */
+  timestamp: number;
+  /** Σ over the wave's rounds, normalized (cross-chain comparable). */
+  totalNormalized: number;
+}
+
+/** Rounds on different chains within this window count as one wave. */
+const WAVE_WINDOW_SECONDS = 6 * 3600;
+
+/** Cluster newest-first rounds into contiguous cross-chain waves. */
+function toWaves(rounds: EnrichedRound[]): PayoutWave[] {
+  const waves: PayoutWave[] = [];
+  for (const r of rounds) {
+    const last = waves[waves.length - 1];
+    const joins =
+      last !== undefined &&
+      r.timestamp > 0 && // unknown timestamps never cluster
+      last.timestamp - r.timestamp <= WAVE_WINDOW_SECONDS &&
+      !last.rounds.some((x) => x.chainId === r.chainId);
+    if (joins) {
+      last.rounds.push(r);
+      last.totalNormalized += toDecimal(r.total, r.decimals);
+    } else {
+      waves.push({
+        key: `${r.chainId}-${r.txHash}`,
+        rounds: [r],
+        timestamp: r.timestamp,
+        totalNormalized: toDecimal(r.total, r.decimals),
+      });
+    }
+  }
+  return waves;
+}
+
 export interface DistributionHistory {
   /** Every distribution round across all chains, newest first. */
   rounds: EnrichedRound[];
+  /** Rounds grouped into cross-chain payout waves, newest first. */
+  waves: PayoutWave[];
   /** Per-chain totals. */
   chains: ChainSummary[];
   /** Per-recipient totals across chains, highest first. */
@@ -65,10 +114,18 @@ export interface DistributionHistory {
   failedChains: number[];
 }
 
+// Token display meta never changes — cache successful reads per chain+token
+// (module scope, like use-family-stats' decimals cache) so one flaky RPC read
+// can't fall back to the wrong decimals for a sibling chain's amounts.
+const tokenMetaCache = new Map<string, TokenMeta>();
+
 async function readTokenMeta(
   chainId: number,
   token: Address,
 ): Promise<TokenMeta> {
+  const key = `${chainId}:${token.toLowerCase()}`;
+  const cached = tokenMetaCache.get(key);
+  if (cached) return cached;
   const client = publicClientFor(chainId);
   try {
     const [decimals, symbol] = await Promise.all([
@@ -83,10 +140,18 @@ async function readTokenMeta(
         functionName: "symbol",
       }),
     ]);
-    return { decimals: Number(decimals), symbol: String(symbol) };
+    const meta = { decimals: Number(decimals), symbol: String(symbol) };
+    tokenMetaCache.set(key, meta);
+    return meta;
   } catch {
+    // Guess from the chain's yield model: stable-chain family tokens mirror
+    // USDC's 6 decimals, native chains use 18. NOT cached — a later successful
+    // read must be able to replace the guess.
     const cfg = chainConfig(chainId);
-    return { decimals: 18, symbol: cfg.wrappedSymbol };
+    return {
+      decimals: cfg.yieldKind === "stable" ? 6 : 18,
+      symbol: cfg.wrappedSymbol,
+    };
   }
 }
 
@@ -153,6 +218,7 @@ function aggregate(
 
   return {
     rounds: enriched,
+    waves: toWaves(enriched),
     chains,
     recipients,
     totalNormalized: chains.reduce((s, c) => s + c.normalized, 0),

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -17,6 +17,32 @@ export function formatAmount(
   });
 }
 
+/**
+ * Format a decimal number without flooring dust to zero: values ≥ 1 group with
+ * `maxFrac` decimals (like formatAmount); smaller nonzero values keep their
+ * first two significant digits, so a real-but-tiny payout (e.g. 0.000022)
+ * renders as "0.000022" instead of "0".
+ */
+export function formatNumberKeepTiny(n: number, maxFrac = 2): string {
+  if (!Number.isFinite(n) || n === 0) return "0";
+  if (Math.abs(n) >= 1)
+    return n.toLocaleString("en-US", { maximumFractionDigits: maxFrac });
+  return n.toLocaleString("en-US", { maximumSignificantDigits: 2 });
+}
+
+/** formatAmount, but dust-safe (see formatNumberKeepTiny). */
+export function formatAmountKeepTiny(
+  value: bigint | undefined,
+  maxFrac = 2,
+  decimals = TOKEN_DECIMALS,
+): string {
+  if (value === undefined) return "—";
+  const s = formatUnits(value, decimals);
+  const n = Number(s);
+  if (Number.isNaN(n)) return s;
+  return formatNumberKeepTiny(n, maxFrac);
+}
+
 /** Parse a user-entered decimal string into a bigint base unit. Returns null on bad input. */
 export function parseAmount(
   input: string,


### PR DESCRIPTION
Fixes the two family history-page reports from https://crowdstake.fun/app/history/?i=0xC6bCE9F20d45B5458D35eb5a99a65E30e20511E6 (CONV, Gnosis 18-dp + Arbitrum/Optimism 6-dp).

## 1. "Total distributed ≈ 0" / every By-chain row "0 CONV"

**Root cause — not the suspected cross-chain decimals mixup.** `useDistributionHistory` already reads each sibling token's `decimals()`/`symbol()` per chain and normalizes each round with its own chain's decimals. The real payouts are just tiny — on-chain `Distributed` logs for this family are:

| chain | tx | base units | real value |
|---|---|---|---|
| Gnosis (18-dp) | `0xd216e9c1…` | 148565911007 | 0.00000014856… CONV |
| Arbitrum (6-dp) | `0x4ec87f82…` | 22 | 0.000022 CONV |
| Optimism (6-dp) | `0x693ece09…` | 10 | 0.00001 CONV |

Every formatter on the page used `maximumFractionDigits: 2`, so all of them floored to "0" and the total (0.0000321…) rendered "≈ 0". (The ~0.009/~0.017 figures from the report match the *Demo ×1000* display multiplier on the yield views — history shows real, unscaled values.)

Fix: dust-safe formatters (`formatNumberKeepTiny` / `formatAmountKeepTiny`) — values ≥ 1 keep the old 2-decimal grouping, smaller nonzero values keep their first two significant digits. The page now shows **≈ 0.000032** total, and 0.000022 / 0.00001 / 0.00000015 CONV per chain.

Two decimals hardening fixes on the way (the suspected bug *was* a real hazard):
- token meta is now cached per chain+token at module scope (like `use-family-stats`' decimals cache), so a flaky RPC read can't re-apply a fallback to a sibling's amounts;
- the meta-read fallback now guesses 6 decimals on stable-yield chains (USDC mirrors) instead of always 18 — the old fallback would have produced exactly the 9000-units → 9e-15 → 0 failure whenever an L2 RPC read failed.

## 2. "Payout rounds: 3" for one cross-chain payout

Families execute one payout as separate txs per chain (this one landed on all 3 chains within 16 seconds). Rounds on **different** chains within a 6-hour window are now clustered into one payout **wave** (a chain appears at most once per wave; same-chain rounds always stay separate waves; unknown timestamps never cluster).

- Summary stat becomes **Payout waves: 1** with sub "3 chain payouts".
- The timeline groups each wave under a header (date + ≈ total across its chains) with the per-chain rounds nested inside, keeping their expandable recipient detail.
- Labeled honestly: the timeline caption says payouts within ~6 hours are grouped, and wave totals carry ≈ (the clustering is heuristic — there is no on-chain link between the legs).
- Classic (non-family) instances are unchanged: "Payout rounds" stat and the flat timeline, verified against the default CSTAKE instance.

Waves are computed at display/aggregate time — the localStorage scan cache schema is untouched (no version bump needed).

Verified: `pnpm lint && pnpm format:check && pnpm build`, plus Playwright screenshots of the static export against live RPCs for both the family page (real nonzero totals, one wave) and the default instance (classic rendering unchanged).