### PR TITLE
style: responsive polish from a screenshot pass

### DIFF
--- a/src/app/app/history/page.tsx
+++ b/src/app/app/history/page.tsx
@@ -111,7 +111,7 @@ export default function HistoryPage() {
       {hasData && (
         <>
           {/* Summary */}
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
             <StatCard
               label="Total distributed"
               value={`≈ ${fmtNum(history.totalNormalized)}`}
@@ -260,7 +260,7 @@ function RecipientRow({
         href={addressUrl(r.recipient, r.perChain[0]?.chainId)}
         target="_blank"
         rel="noreferrer"
-        className="text-text-standard hover:text-core-orange font-mono text-sm"
+        className="text-text-standard hover:text-core-orange font-mono text-sm whitespace-nowrap"
       >
         {shortenAddress(r.recipient)}
       </a>


### PR DESCRIPTION
Screenshot-driven pass over every `/app` page at 375px and 1440px, classic + 3-chain family. Honest verdict: after the nav redesign, most of the suspected issues weren't real — portfolio chips wrap acceptably, family action rows stack fine, deposit inputs fit. Two real fixes shipped:

- History summary stats: four full-width stacked cards made a tall wall on phones → 2×2 grid (4-up on lg, as before).
- Recipient address chip wrapped mid-string at 375px → nowrap.

Before/after screenshots verified. Gates green (pipefail).