### PR TITLE
feat: pool-mode frontend (default no-token deploys)

### DIFF
--- a/e2e/verify-classic-recast.ts
+++ b/e2e/verify-classic-recast.ts
@@ -142,6 +142,7 @@ async function main(): Promise<void> {
         tokenImageURI: "",
         bannerImageURI: "",
         crossChain: false, // CLASSIC — familyId stays 0, onlyClassic paths open
+        issueToken: true, // transferable ERC-20 — recasting exercises the token path
       },
     ],
   });

--- a/e2e/verify-pool-mode.ts
+++ b/e2e/verify-pool-mode.ts
@@ -3,10 +3,11 @@
  * frontend's OWN ABIs — any drift between the dapp and the contracts fails
  * here first. It proves the ABI-compatibility contract the UI leans on: every
  * read/write the app does on `instance.token` (balanceOf/totalSupply/decimals/
- * name/symbol, yieldAccrued/yieldSplitOf/keptYieldOf/setYieldSplit, and the
- * same mint/burn deposit-withdraw signatures) works against a StakePool, the
- * `isPool()` probe feature-detects the kind exactly like useInstanceKind, and
- * the pool exposes NO transfer/approve/allowance surface.
+ * name/symbol, getVotes/delegates, yieldAccrued/yieldSplitOf/keptYieldOf/
+ * setYieldSplit, and the same mint/burn deposit-withdraw signatures) works
+ * against a StakePool, the `isPool()` probe feature-detects the kind exactly
+ * like useInstanceKind, and the pool exposes NO transfer/approve/allowance
+ * surface.
  *
  * Needs a deployer that supports the appended `issueToken` param (the sibling
  * pool-mode contracts branch) — pass its address via DEPLOYER. Run against an
@@ -22,7 +23,9 @@
  *      success+true → "pool" / revert → "token" probe is sound both ways
  *   3. name() is the instance name; symbol() is the UNDERLYING asset's (the
  *      deploy passed "", as the wizard does in pool mode); decimals() readable
- *   4. mint(receiver){value} deposits: balanceOf/totalSupply == the deposit
+ *   4. mint(receiver){value} deposits: balanceOf/totalSupply == the deposit;
+ *      getVotes(depositor) == the balance and delegates(depositor) == self
+ *      (the pool self-delegates on deposit, like the token)
  *   5. yieldAccrued/totalYieldAccrued/yieldSplitOf/keptYieldOf all read;
  *      setYieldSplit(2500) round-trips through yieldSplitOf
  *   6. burn(amount, receiver) withdraws: balance drops, native comes back
@@ -203,6 +206,26 @@ async function main(): Promise<void> {
     functionName: "totalSupply",
   });
   ok(supply === depositWei, `totalSupply == deposit (${supply})`);
+  // Voting-power surface: a pool self-delegates on deposit (no transfer
+  // surface, so votes can't be moved), exactly like the token instance — the
+  // app reads getVotes/delegates on instance.token to show voting power.
+  const votes = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "getVotes",
+    args: [account.address],
+  });
+  ok(votes === depositWei, `getVotes() == deposited balance (${votes})`);
+  const delegatee = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "delegates",
+    args: [account.address],
+  });
+  ok(
+    delegatee.toLowerCase() === account.address.toLowerCase(),
+    `delegates() == self (${delegatee})`,
+  );
 
   /* 5 — yield surface reads + split round-trip. */
   const yieldAccrued = await pub.readContract({

--- a/e2e/verify-pool-mode.ts
+++ b/e2e/verify-pool-mode.ts
@@ -1,0 +1,331 @@
+/*
+ * On-chain verification for POOL MODE (issueToken=false deploys) through the
+ * frontend's OWN ABIs — any drift between the dapp and the contracts fails
+ * here first. It proves the ABI-compatibility contract the UI leans on: every
+ * read/write the app does on `instance.token` (balanceOf/totalSupply/decimals/
+ * name/symbol, yieldAccrued/yieldSplitOf/keptYieldOf/setYieldSplit, and the
+ * same mint/burn deposit-withdraw signatures) works against a StakePool, the
+ * `isPool()` probe feature-detects the kind exactly like useInstanceKind, and
+ * the pool exposes NO transfer/approve/allowance surface.
+ *
+ * Needs a deployer that supports the appended `issueToken` param (the sibling
+ * pool-mode contracts branch) — pass its address via DEPLOYER. Run against an
+ * anvil fork of Gnosis:
+ *   anvil --fork-url https://gnosis-rpc.publicnode.com --chain-id 100 --port 8547
+ *   DEPLOYER=0x… RPC_URL=http://localhost:8547 npx tsx e2e/verify-pool-mode.ts
+ *
+ * What it proves:
+ *   1. deploy() with issueToken=false succeeds; SystemDeployed carries the
+ *      pool address in the Instance tuple's `token` slot
+ *   2. isPool() returns true on the pool — and REVERTS on a classic token
+ *      instance (deployed with issueToken=true in the same run), so the UI's
+ *      success+true → "pool" / revert → "token" probe is sound both ways
+ *   3. name() is the instance name; symbol() is the UNDERLYING asset's (the
+ *      deploy passed "", as the wizard does in pool mode); decimals() readable
+ *   4. mint(receiver){value} deposits: balanceOf/totalSupply == the deposit
+ *   5. yieldAccrued/totalYieldAccrued/yieldSplitOf/keptYieldOf all read;
+ *      setYieldSplit(2500) round-trips through yieldSplitOf
+ *   6. burn(amount, receiver) withdraws: balance drops, native comes back
+ *   7. transfer/approve/allowance (ERC-20 selectors) all revert on the pool —
+ *      no transfer surface exists
+ */
+import {
+  createPublicClient,
+  createWalletClient,
+  decodeEventLog,
+  encodePacked,
+  erc20Abi,
+  http,
+  keccak256,
+  parseEther,
+  type Address,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { gnosis } from "viem/chains";
+import { deployerAbi } from "../src/lib/abis/crowdstake-deployer";
+import { tokenAbi } from "../src/lib/abis/token";
+import { poolAbi } from "../src/lib/abis/pool";
+
+const RPC = process.env.RPC_URL ?? "http://localhost:8547";
+// The pool-mode-capable deployer (from the sibling contracts branch) — there
+// is no live one yet, so it MUST be provided.
+const DEPLOYER = process.env.DEPLOYER as Address | undefined;
+if (!DEPLOYER) {
+  console.error(
+    "Set DEPLOYER to a pool-mode-capable CrowdStakeDeployer address (deploy the contracts branch onto the fork first).",
+  );
+  process.exit(2);
+}
+// anvil dev account #0 — publicly known, auto-funded on the fork. NEVER a real key.
+const account = privateKeyToAccount(
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+);
+const R1: Address = "0x1111111111111111111111111111111111111111";
+const R2: Address = "0x2222222222222222222222222222222222222222";
+
+const pub = createPublicClient({ chain: gnosis, transport: http(RPC) });
+const wallet = createWalletClient({
+  account,
+  chain: gnosis,
+  transport: http(RPC),
+});
+
+let failures = 0;
+function ok(cond: boolean, label: string): void {
+  console.log(`${cond ? "  ✔" : "  ✘ FAIL"} ${label}`);
+  if (!cond) failures += 1;
+}
+
+/** Deploy one instance via the frontend deployer ABI; returns the token slot. */
+async function deployInstance(issueToken: boolean): Promise<Address> {
+  const salt = keccak256(
+    encodePacked(["string"], [`pool-mode-${issueToken}-${Date.now()}`]),
+  );
+  const hash = await wallet.writeContract({
+    address: DEPLOYER!,
+    abi: deployerAbi,
+    functionName: "deploy",
+    args: [
+      {
+        owner: account.address,
+        cycleLength: 200_000n,
+        tokenName: issueToken ? "PoolModeToken" : "Pool Mode Community",
+        // The wizard passes "" for pools (the pool's symbol() is the
+        // UNDERLYING's) and a real ticker for token instances.
+        tokenSymbol: issueToken ? "PMT" : "",
+        maxVotingPoints: 10_000n,
+        salt,
+        registryKind: 0,
+        initialRecipients: [R1, R2],
+        proposalExpiry: 0n,
+        distributionKind: 0,
+        tokenImageURI: "",
+        bannerImageURI: "",
+        crossChain: false,
+        issueToken,
+      },
+    ],
+  });
+  const receipt = await pub.waitForTransactionReceipt({ hash });
+  ok(
+    receipt.status === "success",
+    `deploy(issueToken=${issueToken}) succeeded (${hash})`,
+  );
+  for (const log of receipt.logs) {
+    try {
+      const ev = decodeEventLog({
+        abi: deployerAbi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (ev.eventName === "SystemDeployed") return ev.args.instance.token;
+    } catch {
+      /* not our event */
+    }
+  }
+  throw new Error("SystemDeployed not found in deploy receipt");
+}
+
+/** Mirrors useInstanceKind: success+true → pool, revert → token. */
+async function probeKind(addr: Address): Promise<"pool" | "token"> {
+  try {
+    const val = await pub.readContract({
+      address: addr,
+      abi: poolAbi,
+      functionName: "isPool",
+    });
+    return val ? "pool" : "token";
+  } catch {
+    return "token";
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(`depositor: ${account.address}`);
+  console.log(`deployer:  ${DEPLOYER}`);
+
+  /* 1 — pool deploy (issueToken=false, the app default). */
+  const pool = await deployInstance(false);
+  console.log(`  pool (Instance.token slot): ${pool}`);
+
+  /* 2 — kind probe, both ways. */
+  ok((await probeKind(pool)) === "pool", "isPool() → true: kind = pool");
+  const token = await deployInstance(true);
+  console.log(`  classic token instance:     ${token}`);
+  ok(
+    (await probeKind(token)) === "token",
+    "classic instance: isPool() reverts (or false) — kind = token",
+  );
+
+  /* 3 — identity reads through the compat surface (tokenAbi). */
+  const name = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "name",
+  });
+  ok(name === "Pool Mode Community", `name() is the instance name ("${name}")`);
+  const symbol = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "symbol",
+  });
+  ok(
+    symbol.length > 0 && symbol !== "PMT",
+    `symbol() is the UNDERLYING asset's ("${symbol}"), not the deploy param ("")`,
+  );
+  const decimals = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "decimals",
+  });
+  ok(decimals === 18, `decimals() == 18 on the Gnosis fork (got ${decimals})`);
+
+  /* 4 — deposit via the SAME mint signature the app uses (native path). */
+  const depositWei = parseEther("10");
+  const mintHash = await wallet.writeContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "mint",
+    args: [account.address],
+    value: depositWei,
+  });
+  await pub.waitForTransactionReceipt({ hash: mintHash });
+  const bal = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "balanceOf",
+    args: [account.address],
+  });
+  ok(bal === depositWei, `balanceOf == deposit (${bal})`);
+  const supply = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "totalSupply",
+  });
+  ok(supply === depositWei, `totalSupply == deposit (${supply})`);
+
+  /* 5 — yield surface reads + split round-trip. */
+  const yieldAccrued = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "yieldAccrued",
+  });
+  ok(yieldAccrued >= 0n, `yieldAccrued() readable (${yieldAccrued})`);
+  const totalYield = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "totalYieldAccrued",
+  });
+  ok(totalYield >= 0n, `totalYieldAccrued() readable (${totalYield})`);
+  const splitBefore = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "yieldSplitOf",
+    args: [account.address],
+  });
+  ok(splitBefore === 0, `yieldSplitOf() starts at 0 keepBps (${splitBefore})`);
+  const setSplitHash = await wallet.writeContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "setYieldSplit",
+    args: [2500],
+  });
+  await pub.waitForTransactionReceipt({ hash: setSplitHash });
+  const splitAfter = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "yieldSplitOf",
+    args: [account.address],
+  });
+  ok(splitAfter === 2500, `setYieldSplit(2500) round-trips (${splitAfter})`);
+  const kept = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "keptYieldOf",
+    args: [account.address],
+  });
+  ok(kept >= 0n, `keptYieldOf() readable (${kept})`);
+
+  /* 6 — withdraw via the SAME burn signature the app uses. */
+  const nativeBefore = await pub.getBalance({ address: account.address });
+  const withdrawWei = parseEther("4");
+  const burnHash = await wallet.writeContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "burn",
+    args: [withdrawWei, account.address],
+  });
+  await pub.waitForTransactionReceipt({ hash: burnHash });
+  const balAfter = await pub.readContract({
+    address: pool,
+    abi: tokenAbi,
+    functionName: "balanceOf",
+    args: [account.address],
+  });
+  ok(
+    balAfter === depositWei - withdrawWei,
+    `balanceOf dropped by the withdrawal (${balAfter})`,
+  );
+  const nativeAfter = await pub.getBalance({ address: account.address });
+  // Withdrew 4 native minus gas — anything > 3.9 proves the payout landed.
+  ok(
+    nativeAfter - nativeBefore > parseEther("3.9"),
+    `native balance rose by ≈ the withdrawal (+${nativeAfter - nativeBefore})`,
+  );
+
+  /* 7 — NO transfer surface: every ERC-20 transfer selector must revert. */
+  const noSelector = async (
+    label: string,
+    fn: () => Promise<unknown>,
+  ): Promise<void> => {
+    try {
+      await fn();
+      ok(false, `${label} unexpectedly succeeded — pool has a ${label}!`);
+    } catch {
+      ok(true, `${label} reverts — selector absent`);
+    }
+  };
+  await noSelector("transfer", () =>
+    pub.simulateContract({
+      account: account.address,
+      address: pool,
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [R1, 1n],
+    }),
+  );
+  await noSelector("approve", () =>
+    pub.simulateContract({
+      account: account.address,
+      address: pool,
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [R1, 1n],
+    }),
+  );
+  await noSelector("allowance", () =>
+    pub.readContract({
+      address: pool,
+      abi: erc20Abi,
+      functionName: "allowance",
+      args: [account.address, R1],
+    }),
+  );
+  await noSelector("transferFrom", () =>
+    pub.simulateContract({
+      account: account.address,
+      address: pool,
+      abi: erc20Abi,
+      functionName: "transferFrom",
+      args: [account.address, R1, 1n],
+    }),
+  );
+
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/app/deploy/page.tsx
+++ b/src/app/app/deploy/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   keccak256,
@@ -23,7 +23,7 @@ import { ActionButton } from "@/components/dapp/action-button";
 import { TxStatus } from "@/components/dapp/tx-status";
 import { InstanceShareCard } from "@/components/dapp/instance-share-card";
 import { DurationInput } from "@/components/dapp/duration-input";
-import { useDeployInstance } from "@/hooks/use-deploy";
+import { useDeployInstance, useDeployerPoolSupport } from "@/hooks/use-deploy";
 import {
   useDeployFamily,
   usePendingFamily,
@@ -40,7 +40,12 @@ import {
   isSupportedChain,
   shortChainName,
 } from "@/lib/chains";
-import { familyIdForConfig, loadFamilyDeployParams } from "@/lib/families";
+import {
+  familyIdForConfig,
+  loadFamilyDeployParams,
+  type PendingFamilyParams,
+  type PendingFamilyRecord,
+} from "@/lib/families";
 import { MAX_POINTS } from "@/lib/constants";
 import { isValidImageUri } from "@/lib/metadata";
 import { SafeImage } from "@/components/dapp/safe-image";
@@ -113,6 +118,49 @@ function DeployForm() {
     setSelectedChains([preferred]);
   }, [walletChainId]);
 
+  // Rehydrate the WHOLE form from a stored family record (params + salt +
+  // familyId) and lock the config as an extend. Shared by the ?family= "add a
+  // chain" path and the pending-family Resume: both must repopulate every field
+  // (issueToken included) and pin the salt/creator, or the deploy would derive
+  // a DIFFERENT familyId and orphan the family.
+  const hydrateFamilyForm = useCallback(
+    (record: { familyId: Hex; salt: Hex; params: PendingFamilyParams }) => {
+      const p = record.params;
+      setName(p.tokenName);
+      setSymbol(p.tokenSymbol);
+      // Records saved before pool mode existed were all token deploys — a
+      // missing flag means TRUE here (new deploys default to pool = false).
+      setIssueToken(p.issueToken ?? true);
+      setOwner(p.owner);
+      setMaxPoints(p.maxVotingPoints);
+      setCycleSeconds(p.cycleSeconds);
+      setTokenImg(p.tokenImageURI);
+      setBannerImg(p.bannerImageURI);
+      setRegistryKind(p.registryKind === 1 ? "voting" : "admin");
+      // Democratic families: founders + expiry are committed into the familyId
+      // (votingFamilyIdOf) — dropping them here would mint an orphan family.
+      if (p.registryKind === 1) {
+        setFoundersText(p.initialRecipients.join(", "));
+        setExpiryDays(String(Number(p.proposalExpiry) / 86400));
+      }
+      setDistributionKind(
+        p.distributionKind === 1
+          ? "equal"
+          : p.distributionKind === 2
+            ? "split"
+            : "proportional",
+      );
+      setAdvanced(true);
+      setMultiReady(true);
+      setExtend({
+        familyId: record.familyId,
+        salt: record.salt,
+        creator: p.creator,
+      });
+    },
+    [],
+  );
+
   // "Add a chain": prefill from ?family=<id>. Client-only (static export) — read
   // the query the same way instance.ts does. Missing/unknown ids just no-op.
   useEffect(() => {
@@ -121,39 +169,28 @@ function DeployForm() {
     if (!raw) return;
     const record = loadFamilyDeployParams(raw as Hex);
     if (!record) return;
-    const p = record.params;
-    setName(p.tokenName);
-    setSymbol(p.tokenSymbol);
-    // Records saved before pool mode existed were all token deploys — a
-    // missing flag means TRUE here (new deploys default to pool = false).
-    setIssueToken(p.issueToken ?? true);
-    setOwner(p.owner);
-    setMaxPoints(p.maxVotingPoints);
-    setCycleSeconds(p.cycleSeconds);
-    setTokenImg(p.tokenImageURI);
-    setBannerImg(p.bannerImageURI);
-    setRegistryKind(p.registryKind === 1 ? "voting" : "admin");
-    // Democratic families: founders + expiry are committed into the familyId
-    // (votingFamilyIdOf) — dropping them here would mint an orphan family.
-    if (p.registryKind === 1) {
-      setFoundersText(p.initialRecipients.join(", "));
-      setExpiryDays(String(Number(p.proposalExpiry) / 86400));
-    }
-    setDistributionKind(
-      p.distributionKind === 1
-        ? "equal"
-        : p.distributionKind === 2
-          ? "split"
-          : "proportional",
-    );
-    setAdvanced(true);
-    setMultiReady(true);
-    setExtend({
-      familyId: record.familyId,
-      salt: record.salt,
-      creator: p.creator,
-    });
-  }, []);
+    hydrateFamilyForm(record);
+  }, [hydrateFamilyForm]);
+
+  // Capability gate: the appended `issueToken` param changed deploy()'s
+  // selector, so the 14-field call REVERTS on deployers that predate pool mode.
+  // Probe the primary selected chain's deployer — until pool-capable deployers
+  // ship, an unsupported chain must HIDE the Staking-mode toggle and force
+  // issueToken=true (a token deploy still works there), else the pool default
+  // would make every deploy revert. Family deploys gate on this same probe:
+  // all deployers redeploy together, so the active chain's answer stands in for
+  // the whole family (the resume/extend paths inherit the same gate).
+  const gateChainId = selectedChains[0] ?? DEFAULT_CHAIN_ID;
+  const poolSupport = useDeployerPoolSupport(gateChainId);
+  // Only FORCE a token once the probe has definitively said "unsupported"
+  // (false) — undefined (in flight) leaves the user's choice untouched.
+  const poolUnsupported = poolSupport.supported === false;
+
+  // A predates-pool deployer can't run a pool: pin issueToken=true there so the
+  // hidden toggle can't leave a stale `false` that would revert the deploy.
+  useEffect(() => {
+    if (poolUnsupported) setIssueToken(true);
+  }, [poolUnsupported]);
 
   const toggleChain = (chainId: number) =>
     setSelectedChains((prev) =>
@@ -469,7 +506,11 @@ function DeployForm() {
 
   return (
     <Card>
-      <PendingFamilyResume onResume={() => setMultiReady(true)} />
+      {/* Resume MUST rehydrate the full form (not just multiReady): a pre-pool
+          record left the mode at its default, and deploying pool-mode siblings
+          would derive a different familyId and overwrite the one-slot pending
+          record. hydrateFamilyForm repopulates every field and locks the salt. */}
+      <PendingFamilyResume onResume={hydrateFamilyForm} />
 
       {extend && (
         <div className="border-core-orange/30 bg-core-orange/5 mb-4 rounded-xl border p-4">
@@ -494,32 +535,47 @@ function DeployForm() {
         <Caption className="text-surface-grey-2 mb-1.5 block">
           Staking mode
         </Caption>
-        <div className="border-paper-2 inline-flex rounded-xl border p-1">
-          {(
-            [
-              [false, "No token (pool)"],
-              [true, "Issue a token"],
-            ] as const
-          ).map(([mode, label]) => (
-            <button
-              key={label}
-              type="button"
-              onClick={() => setIssueToken(mode)}
-              className={`rounded-lg px-4 py-1.5 text-sm font-semibold transition-colors ${
-                issueToken === mode
-                  ? "bg-core-orange text-white"
-                  : "text-surface-grey-2 hover:text-text-standard"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-        <Caption className="text-surface-grey mt-1.5 block">
-          {issueToken
-            ? "Depositors receive a transferable ERC-20, redeemable 1:1 for the deposit asset."
-            : "No token is issued — deposits are simply tracked, withdrawable any time."}
-        </Caption>
+        {poolUnsupported ? (
+          // Deployer predates pool mode — a pool deploy would revert here, so
+          // the toggle is hidden and the mode is pinned to "issue a token".
+          <Caption className="text-surface-grey block">
+            This chain&apos;s deployer predates pool mode — deploys issue a
+            token.
+          </Caption>
+        ) : (
+          <>
+            <div className="border-paper-2 inline-flex rounded-xl border p-1">
+              {(
+                [
+                  [false, "No token (pool)"],
+                  [true, "Issue a token"],
+                ] as const
+              ).map(([mode, label]) => (
+                <button
+                  key={label}
+                  type="button"
+                  // Extend locks the whole config to the existing family:
+                  // flipping the mode would deploy a sibling under a DIFFERENT
+                  // familyId (the symbol/salt differ), silently orphaning it.
+                  disabled={extend !== null}
+                  onClick={() => setIssueToken(mode)}
+                  className={`rounded-lg px-4 py-1.5 text-sm font-semibold transition-colors ${
+                    issueToken === mode
+                      ? "bg-core-orange text-white"
+                      : "text-surface-grey-2 hover:text-text-standard"
+                  } ${extend !== null ? "cursor-not-allowed opacity-60" : ""}`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <Caption className="text-surface-grey mt-1.5 block">
+              {issueToken
+                ? "Depositors receive a transferable ERC-20, redeemable 1:1 for the deposit asset."
+                : "No token is issued — deposits are simply tracked, withdrawable any time."}
+            </Caption>
+          </>
+        )}
       </div>
 
       <Field label={issueToken ? "Token name" : "Community name"}>
@@ -929,7 +985,11 @@ function FamilyDeploySection({
 }
 
 /** Resume banner when a multi-chain deploy was left unfinished. */
-function PendingFamilyResume({ onResume }: { onResume: () => void }) {
+function PendingFamilyResume({
+  onResume,
+}: {
+  onResume: (record: PendingFamilyRecord) => void;
+}) {
   const pending = usePendingFamily();
   const { address } = useAccount();
   if (!pending) return null;
@@ -955,7 +1015,7 @@ function PendingFamilyResume({ onResume }: { onResume: () => void }) {
           app="fund"
           variant="secondary"
           className="mt-3"
-          onClick={onResume}
+          onClick={() => onResume(pending)}
         >
           Resume
         </Button>

--- a/src/app/app/deploy/page.tsx
+++ b/src/app/app/deploy/page.tsx
@@ -72,6 +72,12 @@ function DeployForm() {
 
   const [name, setName] = useState("");
   const [symbol, setSymbol] = useState("");
+  // Pool (no token) vs classic token instance. POOL IS THE DEFAULT: most
+  // communities just want a shared deposit pot, and a transferable ERC-20 is
+  // the opt-in. The mode is NOT committed into the familyId, so a multi-chain
+  // run keeps every sibling consistent by feeding this ONE flag to each
+  // chain's deploy (see use-deploy-family) — consistency is enforced here.
+  const [issueToken, setIssueToken] = useState(false);
   const [cycleSeconds, setCycleSeconds] = useState(0);
   const [owner, setOwner] = useState("");
 
@@ -118,6 +124,9 @@ function DeployForm() {
     const p = record.params;
     setName(p.tokenName);
     setSymbol(p.tokenSymbol);
+    // Records saved before pool mode existed were all token deploys — a
+    // missing flag means TRUE here (new deploys default to pool = false).
+    setIssueToken(p.issueToken ?? true);
     setOwner(p.owner);
     setMaxPoints(p.maxVotingPoints);
     setCycleSeconds(p.cycleSeconds);
@@ -209,6 +218,11 @@ function DeployForm() {
     [democratic, expiryValid, cleanExpiry],
   );
 
+  // Pool mode issues no token: the pool's symbol() is the UNDERLYING asset's
+  // (WXDAI/USDC), so the wizard hides the symbol field and passes "" in the
+  // struct — a deterministic value, keeping salts and familyIds stable.
+  const effectiveSymbol = issueToken ? symbol.trim() : "";
+
   // Shared salt for the whole run — deterministic default, custom override.
   // When extending an existing family, the salt is LOCKED to the stored value so
   // the deterministic familyId matches its siblings.
@@ -218,9 +232,9 @@ function DeployForm() {
     // A stable default keyed on the config so re-mounts don't reshuffle it, plus
     // per-form entropy so distinct deploys never collide on the factory CREATE2.
     return keccak256(
-      toHex(`${name.trim()}|${symbol.trim()}|${cycleSeconds}|${ownerValue}`),
+      toHex(`${name.trim()}|${effectiveSymbol}|${cycleSeconds}|${ownerValue}`),
     );
-  }, [extend, customSalt, name, symbol, cycleSeconds, ownerValue]);
+  }, [extend, customSalt, name, effectiveSymbol, cycleSeconds, ownerValue]);
 
   // familyId is CREATOR-scoped on-chain (CrowdStakeDeployer.deploy derives it
   // from msg.sender), so the creator dimension is the CONNECTED WALLET — never
@@ -231,7 +245,7 @@ function DeployForm() {
       creator: address,
       salt,
       tokenName: name.trim(),
-      tokenSymbol: symbol.trim(),
+      tokenSymbol: effectiveSymbol,
       maxVotingPoints: pointsValid ? BigInt(cleanPoints) : 0n,
       registryKind: registryCode,
       distributionKind: distributionCode,
@@ -243,7 +257,7 @@ function DeployForm() {
     address,
     salt,
     name,
-    symbol,
+    effectiveSymbol,
     pointsValid,
     cleanPoints,
     registryCode,
@@ -262,7 +276,7 @@ function DeployForm() {
       creator: address,
       owner: ownerValue as Address,
       tokenName: name.trim(),
-      tokenSymbol: symbol.trim(),
+      tokenSymbol: effectiveSymbol,
       maxVotingPoints: pointsValid ? BigInt(cleanPoints) : 0n,
       registryKind: registryCode,
       distributionKind: distributionCode,
@@ -270,6 +284,7 @@ function DeployForm() {
       proposalExpiry: proposalExpirySeconds,
       tokenImageURI: tokenImg.trim(),
       bannerImageURI: bannerImg.trim(),
+      issueToken,
       cycleSeconds,
       salt,
       chainIds: selectedChains,
@@ -283,7 +298,8 @@ function DeployForm() {
     address,
     ownerValue,
     name,
-    symbol,
+    effectiveSymbol,
+    issueToken,
     pointsValid,
     cleanPoints,
     registryCode,
@@ -309,7 +325,8 @@ function DeployForm() {
 
   const commonValid =
     name.trim().length > 0 &&
-    symbol.trim().length > 0 &&
+    // Pools have no ticker of their own — the symbol field is hidden.
+    (!issueToken || symbol.trim().length > 0) &&
     cycleValid &&
     pointsValid &&
     ownerValid &&
@@ -367,7 +384,9 @@ function DeployForm() {
           rightIcon={<ArrowRight weight="bold" />}
           onClick={() => {
             addInstance({
-              label: symbol.trim() || "New instance",
+              // Pools have no ticker — label them by community name.
+              label:
+                (issueToken ? symbol.trim() : name.trim()) || "New instance",
               chainId: single.chainId,
               addresses: inst,
             });
@@ -391,7 +410,7 @@ function DeployForm() {
           <dl className="mt-3 space-y-2">
             {(
               [
-                ["Token", inst.token],
+                [issueToken ? "Token" : "Pool", inst.token],
                 ["Distribution Manager", inst.distributionManager],
                 ["Cycle Module", inst.cycleModule],
                 ["Voting Module", inst.votingModule],
@@ -424,7 +443,7 @@ function DeployForm() {
       ? keccak256(toHex(customSalt.trim()))
       : keccak256(
           toHex(
-            `${name.trim()}|${symbol.trim()}|${cycleSeconds}|${ownerValue}|${crypto.randomUUID()}`,
+            `${name.trim()}|${effectiveSymbol}|${cycleSeconds}|${ownerValue}|${crypto.randomUUID()}`,
           ),
         );
     void single.deploy({
@@ -434,7 +453,7 @@ function DeployForm() {
         CHAINS[singleChainId]?.blockTimeSeconds ?? 5,
       ),
       tokenName: name.trim(),
-      tokenSymbol: symbol.trim(),
+      tokenSymbol: effectiveSymbol,
       maxVotingPoints: BigInt(cleanPoints),
       salt: classicSalt,
       registryKind: registryCode,
@@ -444,6 +463,7 @@ function DeployForm() {
       tokenImageURI: tokenImg.trim(),
       bannerImageURI: bannerImg.trim(),
       crossChain: false,
+      issueToken,
     });
   };
 
@@ -470,16 +490,50 @@ function DeployForm() {
         </div>
       )}
 
-      <Field label="Token name">
+      <div className="mb-4">
+        <Caption className="text-surface-grey-2 mb-1.5 block">
+          Staking mode
+        </Caption>
+        <div className="border-paper-2 inline-flex rounded-xl border p-1">
+          {(
+            [
+              [false, "No token (pool)"],
+              [true, "Issue a token"],
+            ] as const
+          ).map(([mode, label]) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => setIssueToken(mode)}
+              className={`rounded-lg px-4 py-1.5 text-sm font-semibold transition-colors ${
+                issueToken === mode
+                  ? "bg-core-orange text-white"
+                  : "text-surface-grey-2 hover:text-text-standard"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <Caption className="text-surface-grey mt-1.5 block">
+          {issueToken
+            ? "Depositors receive a transferable ERC-20, redeemable 1:1 for the deposit asset."
+            : "No token is issued — deposits are simply tracked, withdrawable any time."}
+        </Caption>
+      </div>
+
+      <Field label={issueToken ? "Token name" : "Community name"}>
         <Input
           value={name}
           onChange={setName}
           placeholder="Acme Community Stake"
         />
       </Field>
-      <Field label="Token symbol">
-        <Input value={symbol} onChange={setSymbol} placeholder="ACME" />
-      </Field>
+      {issueToken && (
+        <Field label="Token symbol">
+          <Input value={symbol} onChange={setSymbol} placeholder="ACME" />
+        </Field>
+      )}
 
       <div className="mb-4">
         <Caption className="text-surface-grey-2 mb-1.5 block">Chains</Caption>
@@ -712,7 +766,9 @@ function DeployForm() {
           onUseFamily={() => {
             const primaryChainId =
               familyConfig?.primaryChainId ?? singleChainId;
-            const label = symbol.trim() || "New family";
+            // Pools have no ticker — label them by community name.
+            const label =
+              (issueToken ? symbol.trim() : name.trim()) || "New family";
             const withInstances = family.deployedRows.filter((r) => r.instance);
             const primary =
               withInstances.find((r) => r.chainId === primaryChainId) ??
@@ -796,9 +852,9 @@ function DeployForm() {
       )}
 
       <Body className="text-surface-grey mt-6 text-sm">
-        Deploys the full system — token, cycle module, voting module + power,
-        recipient registry, and a distribution manager — wired and owned by you.
-        Yield is distributed{" "}
+        Deploys the full system — {issueToken ? "token" : "deposit pool"}, cycle
+        module, voting module + power, recipient registry, and a distribution
+        manager — wired and owned by you. Yield is distributed{" "}
         {distributionKind === "proportional"
           ? "proportionally to community votes"
           : distributionKind === "equal"

--- a/src/app/app/deposit/_components/family-deposit.tsx
+++ b/src/app/app/deposit/_components/family-deposit.tsx
@@ -17,6 +17,7 @@ import { formatAmount, parseAmount } from "@/lib/format";
 import { shortChainName, txUrl } from "@/lib/chains";
 import { useWalletActions } from "@/components/wallet/wallet-actions";
 import type { FamilyState } from "@/hooks/use-family";
+import { useInstanceKind } from "@/hooks/use-instance-kind";
 import {
   useFamilyDeposit,
   type DepositAllocation,
@@ -34,6 +35,8 @@ const SPONSORED_NATIVE_RESERVE = 10n ** 15n; // ~0.001 native
 /**
  * Multi-asset family mint: deposit into a community token across every chain it
  * lives on, in whatever asset you hold on each. One panel, per-chain amounts.
+ * Pool-mode families deposit the same way (identical calldata) — only the
+ * "mint"/"you receive" framing changes, since no token is issued.
  */
 export function FamilyDeposit({
   family,
@@ -43,6 +46,7 @@ export function FamilyDeposit({
   tokenSymbol: string;
 }) {
   const { sponsored } = useWalletActions();
+  const { isPool } = useInstanceKind();
   const dep = useFamilyDeposit(family);
   // Per-chain input + asset mode (native chains can pick native or wrapped).
   const [amounts, setAmounts] = useState<Record<number, string>>({});
@@ -110,11 +114,14 @@ export function FamilyDeposit({
     <Card>
       <Caption className="text-surface-grey-2 flex items-center gap-1.5">
         <Globe size={14} weight="fill" className="text-core-orange" />
-        Mint {tokenSymbol} across your chains
+        {isPool
+          ? "Deposit across your chains"
+          : `Mint ${tokenSymbol} across your chains`}
       </Caption>
       <Body className="text-surface-grey mt-1 text-sm">
-        Deposit whatever you hold on each chain — you mint {tokenSymbol} on
-        every chain from your local balance there.
+        {isPool
+          ? "Deposit whatever you hold on each chain — each chain's deposit comes from your local balance there."
+          : `Deposit whatever you hold on each chain — you mint ${tokenSymbol} on every chain from your local balance there.`}
       </Body>
 
       <ul className="mt-4 space-y-4">
@@ -195,7 +202,7 @@ export function FamilyDeposit({
                 {over && (
                   <Caption className="text-system-red">Exceeds balance</Caption>
                 )}
-                {row && <DepositRowStatus row={row} />}
+                {row && <DepositRowStatus row={row} pool={isPool} />}
               </div>
             </li>
           );
@@ -204,7 +211,7 @@ export function FamilyDeposit({
 
       <div className="bg-paper-1 mt-5 flex items-center justify-between rounded-xl px-4 py-3">
         <Caption className="text-surface-grey-2">
-          You mint{" "}
+          {isPool ? "You deposit" : "You mint"}{" "}
           {activeCount > 0
             ? `on ${activeCount} chain${activeCount === 1 ? "" : "s"}`
             : "—"}
@@ -213,8 +220,10 @@ export function FamilyDeposit({
           ≈{" "}
           {totalNormalized.toLocaleString("en-US", {
             maximumFractionDigits: 2,
-          })}{" "}
-          {tokenSymbol}
+          })}
+          {/* Pools have no ticker, and per-chain deposit assets can differ —
+              a bare normalized total is the only honest suffix-less sum. */}
+          {isPool ? "" : ` ${tokenSymbol}`}
         </span>
       </div>
 
@@ -234,7 +243,13 @@ export function FamilyDeposit({
             ? { disabled: true }
             : {})}
         >
-          {activeCount > 1 ? `Mint on ${activeCount} chains` : "Mint"}
+          {isPool
+            ? activeCount > 1
+              ? `Deposit on ${activeCount} chains`
+              : "Deposit"
+            : activeCount > 1
+              ? `Mint on ${activeCount} chains`
+              : "Mint"}
         </Button>
         {settled && anyFailed && (
           <Button
@@ -252,7 +267,7 @@ export function FamilyDeposit({
   );
 }
 
-function DepositRowStatus({ row }: { row: DepositRow }) {
+function DepositRowStatus({ row, pool }: { row: DepositRow; pool: boolean }) {
   if (row.state === "approving")
     return (
       <Caption className="text-surface-grey-2 flex items-center gap-1">
@@ -273,7 +288,7 @@ function DepositRowStatus({ row }: { row: DepositRow }) {
         rel="noreferrer"
         className="text-system-green flex items-center gap-1 text-xs font-semibold hover:underline"
       >
-        <CheckCircle size={13} weight="fill" /> Minted{" "}
+        <CheckCircle size={13} weight="fill" /> {pool ? "Deposited" : "Minted"}{" "}
         <ArrowSquareOut size={11} />
       </a>
     );

--- a/src/app/app/deposit/page.tsx
+++ b/src/app/app/deposit/page.tsx
@@ -43,12 +43,15 @@ export default function DepositPage() {
       <PageHeader
         title="Deposit"
         subtitle={
-          isPool
-            ? isFamily
-              ? "Deposit across the chains this community lives on — whatever you hold on each. Your principal stays withdrawable; only the interest is distributed."
-              : `Deposit ${depositSym} — your principal stays fully withdrawable, only the interest is distributed.`
-            : resolving
-              ? `Deposit to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
+          // Check `resolving` FIRST: while the family (and thus its mode) is
+          // still loading, a pool family would otherwise flash the token
+          // "mint {symbol} 1:1" copy before resolving to the pool subtitle.
+          resolving
+            ? `Deposit to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
+            : isPool
+              ? isFamily
+                ? "Deposit across the chains this community lives on — whatever you hold on each. Your principal stays withdrawable; only the interest is distributed."
+                : `Deposit ${depositSym} — your principal stays fully withdrawable, only the interest is distributed.`
               : isFamily
                 ? `Mint ${symbol} across the chains this community lives on — deposit whatever you hold on each. Your principal stays withdrawable; only the interest is distributed.`
                 : `Stake ${depositSym} to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
@@ -87,7 +90,11 @@ function DepositForm() {
 
   const { symbol, decimals } = useInstanceToken();
   // Pool mode: no token arrives — hide the "You receive" framing entirely.
-  const { isPool } = useInstanceKind();
+  // `isPool` drives the neutral "Your deposit:" copy (safe default while the
+  // probe is undefined); the token-ASSERTING "You receive X {symbol}" row is
+  // gated on `kind === "token"` so a pool never flashes it pre-resolution.
+  const { kind, isPool } = useInstanceKind();
+  const isToken = kind === "token";
   const nativeSym = useNativeSymbol();
   const hasWrapped = Boolean(wrappedToken);
   // The native toggle only makes sense when the instance accepts native.
@@ -170,8 +177,10 @@ function DepositForm() {
         decimals={depositDecimals}
       />
 
-      {/* Pools mint nothing back — a deposit is a deposit, so no receive row. */}
-      {!isPool && (
+      {/* Pools mint nothing back — a deposit is a deposit, so no receive row.
+          Render only once the probe confirms a TOKEN (undefined stays neutral,
+          so a pool never flashes "You receive X" before the probe resolves). */}
+      {isToken && (
         <div className="bg-paper-1 mt-4 flex items-center justify-between rounded-xl px-4 py-3">
           <Caption className="text-surface-grey-2">You receive</Caption>
           <span className="font-breadDisplay text-text-standard font-bold">

--- a/src/app/app/deposit/page.tsx
+++ b/src/app/app/deposit/page.tsx
@@ -14,6 +14,7 @@ import { useWalletActions } from "@/components/wallet/wallet-actions";
 import { useAmountFormatter } from "@/components/demo-mode-provider";
 import { useActiveChain, useNativeSymbol } from "@/hooks/use-chain";
 import { useFamily } from "@/hooks/use-family";
+import { useInstanceKind } from "@/hooks/use-instance-kind";
 import { FamilyDeposit } from "@/app/app/deposit/_components/family-deposit";
 import {
   useApproveWrapped,
@@ -27,6 +28,8 @@ import {
 
 export default function DepositPage() {
   const { symbol } = useInstanceToken();
+  // Pool mode: nothing is minted — a deposit is just a deposit.
+  const { isPool } = useInstanceKind();
   const native = useNativeSymbol();
   const { yieldKind, wrappedSymbol } = useActiveChain();
   const family = useFamily();
@@ -40,11 +43,15 @@ export default function DepositPage() {
       <PageHeader
         title="Deposit"
         subtitle={
-          resolving
-            ? `Deposit to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
-            : isFamily
-              ? `Mint ${symbol} across the chains this community lives on — deposit whatever you hold on each. Your principal stays withdrawable; only the interest is distributed.`
-              : `Stake ${depositSym} to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
+          isPool
+            ? isFamily
+              ? "Deposit across the chains this community lives on — whatever you hold on each. Your principal stays withdrawable; only the interest is distributed."
+              : `Deposit ${depositSym} — your principal stays fully withdrawable, only the interest is distributed.`
+            : resolving
+              ? `Deposit to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
+              : isFamily
+                ? `Mint ${symbol} across the chains this community lives on — deposit whatever you hold on each. Your principal stays withdrawable; only the interest is distributed.`
+                : `Stake ${depositSym} to mint ${symbol} 1:1. Your principal stays fully withdrawable — only the interest is distributed.`
         }
       />
       {resolving ? (
@@ -79,6 +86,8 @@ function DepositForm() {
   const [amount, setAmount] = useState("");
 
   const { symbol, decimals } = useInstanceToken();
+  // Pool mode: no token arrives — hide the "You receive" framing entirely.
+  const { isPool } = useInstanceKind();
   const nativeSym = useNativeSymbol();
   const hasWrapped = Boolean(wrappedToken);
   // The native toggle only makes sense when the instance accepts native.
@@ -161,12 +170,15 @@ function DepositForm() {
         decimals={depositDecimals}
       />
 
-      <div className="bg-paper-1 mt-4 flex items-center justify-between rounded-xl px-4 py-3">
-        <Caption className="text-surface-grey-2">You receive</Caption>
-        <span className="font-breadDisplay text-text-standard font-bold">
-          {parsed ? fmt(parsed) : "0"} {symbol}
-        </span>
-      </div>
+      {/* Pools mint nothing back — a deposit is a deposit, so no receive row. */}
+      {!isPool && (
+        <div className="bg-paper-1 mt-4 flex items-center justify-between rounded-xl px-4 py-3">
+          <Caption className="text-surface-grey-2">You receive</Caption>
+          <span className="font-breadDisplay text-text-standard font-bold">
+            {parsed ? fmt(parsed) : "0"} {symbol}
+          </span>
+        </div>
+      )}
 
       {overBalance && (
         <Caption className="text-system-red mt-2 block">
@@ -196,7 +208,7 @@ function DepositForm() {
       />
 
       <Body className="text-surface-grey mt-6 text-sm">
-        Your {symbol} balance:{" "}
+        {isPool ? "Your deposit:" : `Your ${symbol} balance:`}{" "}
         <span className="text-text-standard font-semibold">
           {fmt(stake.data)} {symbol}
         </span>

--- a/src/app/app/distribute/page.tsx
+++ b/src/app/app/distribute/page.tsx
@@ -16,6 +16,7 @@ import { useApy } from "@/hooks/use-apy";
 import { useActiveChain } from "@/hooks/use-chain";
 import { useFamily } from "@/hooks/use-family";
 import { useFamilyStats } from "@/hooks/use-family-stats";
+import { useInstanceKind } from "@/hooks/use-instance-kind";
 import {
   useAmountFormatter,
   useAmountFormatter18,
@@ -47,6 +48,8 @@ function Distribute() {
   const tokenStats = useTokenStats();
   const { yieldAccrued } = tokenStats;
   const { symbol } = useInstanceToken();
+  // Pool mode: yield is paid out in the underlying asset, not minted as a token.
+  const { isPool } = useInstanceKind();
   const { live, ratePerMs } = useLiveYieldDetails();
   const { blockTimeSeconds } = useActiveChain();
   const family = useFamily();
@@ -231,9 +234,9 @@ function Distribute() {
       </Card>
 
       <Body className="text-surface-grey mt-6 text-sm">
-        Distribution claims the protocol&apos;s accrued yield as freshly minted{" "}
-        {symbol}, splits it across recipients proportionally to their votes, and
-        starts a new cycle — all in one transaction.
+        {isPool
+          ? `Distribution pays the accrued yield out in ${symbol}, splits it across recipients proportionally to their votes, and starts a new cycle — all in one transaction.`
+          : `Distribution claims the protocol's accrued yield as freshly minted ${symbol}, splits it across recipients proportionally to their votes, and starts a new cycle — all in one transaction.`}
       </Body>
     </div>
   );

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -22,6 +22,7 @@ import {
   useFamilyStats,
 } from "@/hooks/use-family-stats";
 import { useApy } from "@/hooks/use-apy";
+import { useInstanceKind } from "@/hooks/use-instance-kind";
 import { useVoteCount } from "@/hooks/use-vote-count";
 import { shortChainName } from "@/lib/chains";
 import { useCycle } from "@/hooks/use-cycle";
@@ -47,6 +48,9 @@ export default function PortfolioPage() {
   const { isReady } = useDistributionReady();
   const isRecipient = useIsRecipient();
   const { symbol: tokenSymbol } = useInstanceToken();
+  // Pool instances issue no token: the position is just "your deposit"
+  // (symbol() is the underlying asset's, so amounts still read naturally).
+  const { isPool } = useInstanceKind();
   const fmt = useAmountFormatter();
   const fmt18 = useAmountFormatter18();
   const nativeSym = useNativeSymbol();
@@ -119,16 +123,24 @@ export default function PortfolioPage() {
       <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <StatCard
           label={
-            familyMode
-              ? `Your ${tokenSymbol} · all chains`
-              : `Your ${tokenSymbol}`
+            isPool
+              ? familyMode
+                ? "Your deposit · all chains"
+                : "Your deposit"
+              : familyMode
+                ? `Your ${tokenSymbol} · all chains`
+                : `Your ${tokenSymbol}`
           }
           value={
             familyMode
               ? `${fmt18(fpos.balance18)} ${tokenSymbol}`
               : `${fmt(balance.data)} ${tokenSymbol}`
           }
-          sub={balanceBreakdown ?? `Redeemable 1:1 for ${baseSym}`}
+          sub={
+            balanceBreakdown ??
+            // A pool deposit IS the base asset — nothing to redeem it for.
+            (isPool ? "Withdrawable any time" : `Redeemable 1:1 for ${baseSym}`)
+          }
           accent
         />
         <StatCard

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -133,7 +133,11 @@ export default function PortfolioPage() {
           }
           value={
             familyMode
-              ? `${fmt18(fpos.balance18)} ${tokenSymbol}`
+              ? // A family's cross-chain sum mixes each chain's underlying
+                // (WXDAI, USDC, …), so for a POOL the ticker suffix would be
+                // dishonest — drop it (family-deposit does the same for its
+                // summed total). Single-chain and token families keep it.
+                `${fmt18(fpos.balance18)}${isPool ? "" : ` ${tokenSymbol}`}`
               : `${fmt(balance.data)} ${tokenSymbol}`
           }
           sub={

--- a/src/app/app/withdraw/_components/family-withdraw.tsx
+++ b/src/app/app/withdraw/_components/family-withdraw.tsx
@@ -16,6 +16,7 @@ import { GasModeNote } from "@/components/dapp/gas-mode-note";
 import { formatAmount, parseAmount } from "@/lib/format";
 import { shortChainName, txUrl } from "@/lib/chains";
 import { useActiveChainId } from "@/components/instance-provider";
+import { useInstanceKind } from "@/hooks/use-instance-kind";
 import { useInstanceToken } from "@/hooks/use-token";
 import {
   useFamilyWithdraw,
@@ -32,6 +33,9 @@ import type { FamilyState } from "@/hooks/use-family";
 export function FamilyWithdraw({ family }: { family: FamilyState }) {
   const activeChainId = useActiveChainId();
   const { symbol } = useInstanceToken();
+  // Pool mode: same burn calldata, but the copy says "withdraw" — there is no
+  // token to burn, only a deposit to pay out.
+  const { isPool } = useInstanceKind();
   const { rows, withdrawOn, withdrawAll, anyBusy } = useFamilyWithdraw(family);
   // Per-chain amount inputs, parsed with THAT chain's token decimals.
   const [amounts, setAmounts] = useState<Record<number, string>>({});
@@ -70,7 +74,9 @@ export function FamilyWithdraw({ family }: { family: FamilyState }) {
     <Card>
       <Caption className="text-surface-grey-2 flex items-center gap-1.5">
         <Globe size={14} weight="fill" className="text-core-orange" />
-        Withdraw {symbol} across your chains
+        {isPool
+          ? "Withdraw across your chains"
+          : `Withdraw ${symbol} across your chains`}
       </Caption>
 
       <div className="mt-3">
@@ -86,8 +92,9 @@ export function FamilyWithdraw({ family }: { family: FamilyState }) {
         </ActionButton>
       </div>
       <Caption className="text-surface-grey mt-1.5 block">
-        burns your full balance on every chain — you receive the local asset on
-        each
+        {isPool
+          ? "withdraws your full deposit on every chain — you receive the local asset on each"
+          : "burns your full balance on every chain — you receive the local asset on each"}
       </Caption>
       <div className="mt-1">
         <GasModeNote />
@@ -110,8 +117,10 @@ export function FamilyWithdraw({ family }: { family: FamilyState }) {
       </ul>
 
       <Body className="text-surface-grey mt-6 text-sm">
-        Each withdrawal burns {symbol} on that chain and sends you its base
-        asset 1:1. Your principal is always fully withdrawable.
+        {isPool
+          ? "Each withdrawal pays your deposit on that chain out in its base asset. "
+          : `Each withdrawal burns ${symbol} on that chain and sends you its base asset 1:1. `}
+        Your principal is always fully withdrawable.
       </Body>
     </Card>
   );

--- a/src/app/app/withdraw/page.tsx
+++ b/src/app/app/withdraw/page.tsx
@@ -9,6 +9,7 @@ import { TxStatus } from "@/components/dapp/tx-status";
 import { formatAmount, parseAmount } from "@/lib/format";
 import { useActiveChain, useNativeSymbol } from "@/hooks/use-chain";
 import { useFamily } from "@/hooks/use-family";
+import { useInstanceKind } from "@/hooks/use-instance-kind";
 import { FamilyWithdraw } from "@/app/app/withdraw/_components/family-withdraw";
 import {
   useInstanceToken,
@@ -25,6 +26,8 @@ function useRedeemSymbol() {
 
 export default function WithdrawPage() {
   const { symbol } = useInstanceToken();
+  // Pool mode: there's nothing to burn — withdrawing just pays the deposit out.
+  const { isPool } = useInstanceKind();
   const redeemSym = useRedeemSymbol();
   const family = useFamily();
   const isFamily = family.isFamily && !family.isLoading;
@@ -35,9 +38,13 @@ export default function WithdrawPage() {
       <PageHeader
         title="Withdraw"
         subtitle={
-          isFamily
-            ? `Burn ${symbol} to redeem your principal 1:1 on every chain you hold it. Your stake is always fully withdrawable.`
-            : `Burn ${symbol} to redeem your ${redeemSym} principal 1:1. Your stake is always fully withdrawable.`
+          isPool
+            ? isFamily
+              ? "Withdraw your deposit on every chain you hold one. Your stake is always fully withdrawable."
+              : `Withdraw your ${redeemSym} deposit any time. Your stake is always fully withdrawable.`
+            : isFamily
+              ? `Burn ${symbol} to redeem your principal 1:1 on every chain you hold it. Your stake is always fully withdrawable.`
+              : `Burn ${symbol} to redeem your ${redeemSym} principal 1:1. Your stake is always fully withdrawable.`
         }
       />
       {/* Family mode: the token lives on several chains, so withdrawing the
@@ -57,6 +64,7 @@ export default function WithdrawPage() {
 function WithdrawForm() {
   const [amount, setAmount] = useState("");
   const { symbol, decimals } = useInstanceToken();
+  const { isPool } = useInstanceKind();
   const redeemSym = useRedeemSymbol();
   const balance = useTokenBalance();
   const { withdraw, ...tx } = useWithdraw();
@@ -94,7 +102,9 @@ function WithdrawForm() {
 
       {overBalance && (
         <Caption className="text-system-red mt-2 block">
-          Amount exceeds your {symbol} balance.
+          {isPool
+            ? "Amount exceeds your deposit."
+            : `Amount exceeds your ${symbol} balance.`}
         </Caption>
       )}
 

--- a/src/app/app/yield/page.tsx
+++ b/src/app/app/yield/page.tsx
@@ -10,6 +10,7 @@ import { useAmountFormatter } from "@/components/demo-mode-provider";
 import { useBaseAssetSymbol } from "@/hooks/use-chain";
 import { useFamily, type FamilyState } from "@/hooks/use-family";
 import { useFamilyYieldSplit } from "@/hooks/use-family-yield-split";
+import { useInstanceKind } from "@/hooks/use-instance-kind";
 import { FamilySplitStatus } from "@/app/app/yield/_components/family-split-status";
 import {
   useClaimKeptYield,
@@ -195,6 +196,8 @@ function SplitForm({ family }: { family: FamilyState }) {
 
 function KeptYieldCard() {
   const { symbol } = useInstanceToken();
+  // Pool mode: kept yield pays out in the underlying — nothing is minted.
+  const { isPool } = useInstanceKind();
   const baseSym = useBaseAssetSymbol();
   const { supported } = useYieldSplit();
   const kept = useKeptYield();
@@ -237,8 +240,9 @@ function KeptYieldCard() {
       />
 
       <Body className="text-surface-grey mt-6 text-sm">
-        Claiming mints your kept yield as {symbol}, redeemable 1:1 for {baseSym}{" "}
-        on the withdraw page.
+        {isPool
+          ? `Claiming pays your kept yield out in ${symbol}.`
+          : `Claiming mints your kept yield as ${symbol}, redeemable 1:1 for ${baseSym} on the withdraw page.`}
       </Body>
     </Card>
   );

--- a/src/components/dapp/instance-branding.tsx
+++ b/src/components/dapp/instance-branding.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useInstanceKind } from "@/hooks/use-instance-kind";
 import { useInstanceMetadata } from "@/hooks/use-instance-metadata";
 import { useInstanceToken } from "@/hooks/use-token";
 import { SafeImage } from "@/components/dapp/safe-image";
@@ -20,15 +21,19 @@ export function InstanceHeaderBanner() {
   );
 }
 
-/** The active instance's token image, falling back to a symbol-initial disc. */
+/** The active instance's token image, falling back to an initial disc. */
 export function InstanceTokenBadge({ className }: { className?: string }) {
   const { tokenImageURI } = useInstanceMetadata();
-  const { symbol } = useInstanceToken();
+  const { name, symbol } = useInstanceToken();
+  const { isPool } = useInstanceKind();
+  // Pools carry the UNDERLYING's symbol (every Gnosis pool would badge "W") —
+  // their identity is the community name. Token instances keep the ticker.
+  const label = isPool ? name || symbol : symbol;
   const box = cn("h-10 w-10 shrink-0 rounded-full object-cover", className);
   return (
     <SafeImage
       uri={tokenImageURI}
-      alt={`${symbol} token`}
+      alt={isPool ? `${label} pool` : `${label} token`}
       className={box}
       fallback={
         <div
@@ -37,7 +42,7 @@ export function InstanceTokenBadge({ className }: { className?: string }) {
             "bg-core-orange/15 text-core-orange flex items-center justify-center text-sm font-bold",
           )}
         >
-          {symbol.slice(0, 1).toUpperCase()}
+          {(label || "?").slice(0, 1).toUpperCase()}
         </div>
       }
     />

--- a/src/components/dapp/instance-header.tsx
+++ b/src/components/dapp/instance-header.tsx
@@ -72,7 +72,11 @@ export function InstanceHeader() {
   // Pool instances have no ticker of their own — symbol() is the UNDERLYING
   // asset's, so it still suffixes amounts, but the $TICKER identity row and
   // the Transfer-derived Backers chip (pools emit no Transfer logs) are hidden.
-  const { isPool } = useInstanceKind();
+  // Gate those TOKEN-asserting surfaces on `kind === "token"` (NOT `!isPool`):
+  // while the probe is undefined they must render NEUTRAL, else a pool would
+  // flash a $TICKER row and a Backers chip for a frame before the probe lands.
+  const { kind: instanceKind } = useInstanceKind();
+  const isToken = instanceKind === "token";
   const { totalSupply } = useTokenStats();
   const { recipients } = useRecipients();
   const cycle = useCycle();
@@ -84,7 +88,9 @@ export function InstanceHeader() {
   // Unique holders across every family chain (union — one person on two
   // chains is one backer). Counted from a bounded Transfer-log window, so
   // communities older than the lookback undercount until backfill exists.
-  const backers = useBackers(family);
+  // Only scan once the probe confirms a TOKEN — pools emit no Transfer logs, so
+  // scanning one is a doomed query (and the chip is hidden anyway).
+  const backers = useBackers(family, isToken);
   // Total funding generated — v2's flagship number: everything EVER distributed
   // (all chains) + what's accruing right now. Mounting the header kicks off the
   // history event scan, but it shares the history page's localStorage cache, so
@@ -137,7 +143,7 @@ export function InstanceHeader() {
             {name || symbol || "Crowdstaking instance"}
           </Heading3>
           <div className="mt-1 flex flex-wrap items-center gap-2">
-            {!isPool && (
+            {isToken && (
               <span className="text-surface-grey-2 font-mono text-sm">
                 ${symbol}
               </span>
@@ -189,8 +195,10 @@ export function InstanceHeader() {
           {recipients.length}
         </Chip>
         {/* Backer counts come from Transfer logs — pools emit none, so the
-            chip would flatline at 0 and imply transfers exist. Hide it. */}
-        {!isPool && (
+            chip would flatline at 0 and imply transfers exist. Gate on
+            `kind === "token"` so it stays hidden until the probe confirms a
+            token (undefined renders nothing, not a premature "0" chip). */}
+        {isToken && (
           <Chip
             icon={<UsersFour size={18} weight="fill" />}
             label="Backers"

--- a/src/components/dapp/instance-header.tsx
+++ b/src/components/dapp/instance-header.tsx
@@ -15,6 +15,7 @@ import {
 import { parseUnits } from "viem";
 import { InstanceTokenBadge } from "@/components/dapp/instance-branding";
 import { LiveYield } from "@/components/dapp/live-yield";
+import { useInstanceKind } from "@/hooks/use-instance-kind";
 import { useInstanceToken, useTokenStats } from "@/hooks/use-token";
 import { useRecipients } from "@/hooks/use-recipients";
 import { useCycle } from "@/hooks/use-cycle";
@@ -68,6 +69,10 @@ function Chip({
  */
 export function InstanceHeader() {
   const { name, symbol, decimals } = useInstanceToken();
+  // Pool instances have no ticker of their own — symbol() is the UNDERLYING
+  // asset's, so it still suffixes amounts, but the $TICKER identity row and
+  // the Transfer-derived Backers chip (pools emit no Transfer logs) are hidden.
+  const { isPool } = useInstanceKind();
   const { totalSupply } = useTokenStats();
   const { recipients } = useRecipients();
   const cycle = useCycle();
@@ -132,9 +137,11 @@ export function InstanceHeader() {
             {name || symbol || "Crowdstaking instance"}
           </Heading3>
           <div className="mt-1 flex flex-wrap items-center gap-2">
-            <span className="text-surface-grey-2 font-mono text-sm">
-              ${symbol}
-            </span>
+            {!isPool && (
+              <span className="text-surface-grey-2 font-mono text-sm">
+                ${symbol}
+              </span>
+            )}
             <span
               className={cn(
                 "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold",
@@ -181,15 +188,19 @@ export function InstanceHeader() {
         <Chip icon={<UsersThree size={18} weight="fill" />} label="Recipients">
           {recipients.length}
         </Chip>
-        <Chip
-          icon={<UsersFour size={18} weight="fill" />}
-          label="Backers"
-          title="Unique holders, counted from recent on-chain transfers. Communities older than the scanned window may show fewer backers than they really have."
-        >
-          {backers.count !== undefined
-            ? `${backers.partial || backers.capped ? "≈ " : ""}${backers.count}`
-            : "—"}
-        </Chip>
+        {/* Backer counts come from Transfer logs — pools emit none, so the
+            chip would flatline at 0 and imply transfers exist. Hide it. */}
+        {!isPool && (
+          <Chip
+            icon={<UsersFour size={18} weight="fill" />}
+            label="Backers"
+            title="Unique holders, counted from recent on-chain transfers. Communities older than the scanned window may show fewer backers than they really have."
+          >
+            {backers.count !== undefined
+              ? `${backers.partial || backers.capped ? "≈ " : ""}${backers.count}`
+              : "—"}
+          </Chip>
+        )}
         <Chip icon={<ArrowsClockwise size={18} weight="fill" />} label="Cycle">
           <span className="flex items-center gap-1.5">
             #{cycle.cycleNumber?.toString() ?? "—"}

--- a/src/hooks/use-backers.ts
+++ b/src/hooks/use-backers.ts
@@ -25,10 +25,19 @@ export interface BackersState {
  * Takes the caller's already-loaded family (the header calls useFamily for its
  * other stats — don't fan the family resolution out twice).
  *
+ * `enabled` gates the scans: backers are reconstructed from ERC-20 Transfer
+ * logs, which POOLS never emit, so the header passes `kind === "token"` to keep
+ * this hook from firing a doomed Transfer scan on a pool (and to stay neutral
+ * while the kind probe is still resolving). Disabled → no scans, count
+ * undefined, isLoading false.
+ *
  * CAVEAT: counts reflect the scanned block window; tokens older than the
  * lookback undercount until a "load older"-style extension exists.
  */
-export function useBackers(family: FamilyState): BackersState {
+export function useBackers(
+  family: FamilyState,
+  enabled: boolean,
+): BackersState {
   const instance = useInstance();
   const activeChainId = useActiveChainId();
   const [state, setState] = useState<BackersState>({
@@ -54,6 +63,13 @@ export function useBackers(family: FamilyState): BackersState {
     .join("|");
 
   useEffect(() => {
+    // Disabled (e.g. a pool, or the kind probe hasn't resolved to "token"):
+    // never scan, and drop any in-flight loading state so "—" isn't shown as
+    // a stuck spinner.
+    if (!enabled) {
+      setState({ isLoading: false, partial: false, capped: false });
+      return;
+    }
     if (family.isLoading || targets.length === 0) return;
     let cancelled = false;
     setState((s) => ({ ...s, isLoading: true }));
@@ -98,7 +114,7 @@ export function useBackers(family: FamilyState): BackersState {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [targetKey, family.isLoading]);
+  }, [enabled, targetKey, family.isLoading]);
 
   return state;
 }

--- a/src/hooks/use-deploy-family.ts
+++ b/src/hooks/use-deploy-family.ts
@@ -52,6 +52,13 @@ export interface FamilyDeployConfig {
   proposalExpiry: bigint;
   tokenImageURI: string;
   bannerImageURI: string;
+  /**
+   * Issue a transferable ERC-20 (true) or run in pool mode (false — the
+   * default: no token, deposits tracked in the underlying). ONE flag for the
+   * whole run: familyId does NOT commit the mode, so cross-chain consistency
+   * is enforced HERE by sending the same shared config to every chain.
+   */
+  issueToken: boolean;
   /** ONE duration; each chain's cycleLength derives from its block time. */
   cycleSeconds: number;
   /** Shared salt for the whole run (drives the familyId). */
@@ -104,6 +111,7 @@ function serializeParams(cfg: FamilyDeployConfig): PendingFamilyParams {
     proposalExpiry: cfg.proposalExpiry.toString(),
     tokenImageURI: cfg.tokenImageURI,
     bannerImageURI: cfg.bannerImageURI,
+    issueToken: cfg.issueToken,
   };
 }
 
@@ -286,6 +294,9 @@ export function useDeployFamily(config: FamilyDeployConfig | null) {
               tokenImageURI: cfg.tokenImageURI,
               bannerImageURI: cfg.bannerImageURI,
               crossChain: true,
+              // Same mode on EVERY chain of the family (not committed into
+              // the familyId — the shared config is the consistency guarantee).
+              issueToken: cfg.issueToken,
             },
           ],
         });

--- a/src/hooks/use-deploy.ts
+++ b/src/hooks/use-deploy.ts
@@ -1,13 +1,76 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { decodeEventLog, type Address, type Hex, type Log } from "viem";
-import { useChainId, useWaitForTransactionReceipt } from "wagmi";
+import {
+  BaseError,
+  ContractFunctionRevertedError,
+  decodeEventLog,
+  type Address,
+  type Hex,
+  type Log,
+} from "viem";
+import {
+  useChainId,
+  useReadContract,
+  useWaitForTransactionReceipt,
+} from "wagmi";
 import { deployerAbi } from "@/lib/abis";
 import { CHAINS } from "@/lib/chains";
 import { parseTxError } from "@/hooks/use-tx";
 import { useWalletActions } from "@/components/wallet/wallet-actions";
 import type { InstanceAddresses } from "@/lib/instance";
+
+/** True when a read failed because the contract REVERTED (vs a flaky RPC). */
+function isRevert(error: unknown): boolean {
+  return (
+    error instanceof BaseError &&
+    error.walk((e) => e instanceof ContractFunctionRevertedError) !== null
+  );
+}
+
+export interface DeployerPoolSupport {
+  /** true = deployer exposes supportsPoolMode() (a 14-field pool deploy works);
+   *  false = it predates pool mode (deploys MUST issue a token); undefined while
+   *  the probe is in flight or on a chain with no deployer. */
+  supported: boolean | undefined;
+  /** The probe is still resolving (hydration-safe: undefined until it lands). */
+  isPending: boolean;
+}
+
+/**
+ * Feature-detect whether a chain's pinned deployer understands pool mode.
+ *
+ * Appending `issueToken` to deploy()'s Params changed its SELECTOR, so the
+ * new 14-field call REVERTS on the OLD live deployers. Until pool-capable
+ * deployers ship, the wizard must probe first: `supportsPoolMode()` reads true
+ * on a capable deployer and REVERTS on an old one (the same probe-and-revert
+ * pattern as useYieldSplit's `supported`). A revert IS the answer (unsupported
+ * — don't retry it), but a transient RPC failure isn't: without retry it would
+ * wrongly report "supported" on a capable chain and let a reverting deploy
+ * through, so classify with BaseError.walk and retry non-revert errors.
+ */
+export function useDeployerPoolSupport(chainId: number): DeployerPoolSupport {
+  const deployer = CHAINS[chainId]?.deployer ?? undefined;
+  const read = useReadContract({
+    address: deployer,
+    abi: deployerAbi,
+    functionName: "supportsPoolMode",
+    chainId,
+    query: {
+      enabled: Boolean(deployer),
+      retry: (failureCount, error) => !isRevert(error) && failureCount < 2,
+      staleTime: Infinity,
+    },
+  });
+  // No deployer on this chain → nothing to probe (undefined, not pending).
+  if (!deployer) return { supported: undefined, isPending: false };
+  const supported = read.isError
+    ? false
+    : read.data !== undefined
+      ? Boolean(read.data)
+      : undefined;
+  return { supported, isPending: read.isPending };
+}
 
 export interface DeployParams {
   owner: Address;

--- a/src/hooks/use-deploy.ts
+++ b/src/hooks/use-deploy.ts
@@ -27,6 +27,9 @@ export interface DeployParams {
   bannerImageURI?: string;
   // Multi-chain family instance (see lib/families.ts). Default false = classic.
   crossChain?: boolean;
+  // Issue a transferable ERC-20? Default FALSE = pool mode (a StakePool sits
+  // at the instance's token slot — deposits tracked, no token minted).
+  issueToken?: boolean;
 }
 
 /** Decode the deployed instance out of a receipt's SystemDeployed event. */
@@ -138,6 +141,9 @@ export function useDeployInstance() {
             tokenImageURI: p.tokenImageURI ?? "",
             bannerImageURI: p.bannerImageURI ?? "",
             crossChain: p.crossChain ?? false,
+            // Default FALSE = pool mode (no token issued) — the struct's
+            // zero value, matching the contract's own default.
+            issueToken: p.issueToken ?? false,
           },
         ],
       });

--- a/src/hooks/use-instance-kind.ts
+++ b/src/hooks/use-instance-kind.ts
@@ -1,8 +1,17 @@
 "use client";
 
+import { BaseError, ContractFunctionRevertedError } from "viem";
 import { useReadContract } from "wagmi";
 import { poolAbi } from "@/lib/abis";
 import { useActiveChainId, useInstance } from "@/components/instance-provider";
+
+/** True when a read failed because the contract REVERTED (vs a flaky RPC). */
+function isRevert(error: unknown): boolean {
+  return (
+    error instanceof BaseError &&
+    error.walk((e) => e instanceof ContractFunctionRevertedError) !== null
+  );
+}
 
 /**
  * What sits at `instance.token`: a classic transferable token, or a StakePool
@@ -22,8 +31,15 @@ export interface InstanceKindState {
 
 /**
  * Feature-detect the instance kind by probing `isPool()` on the token slot —
- * pools return true, classic tokens revert (the same probe-and-revert pattern
- * as useYieldSplit's `supported`). No retry: a revert IS the answer.
+ * pools return true, classic tokens REVERT (the same probe-and-revert pattern
+ * as useYieldSplit's `supported`).
+ *
+ * A revert IS the answer ("token" — don't retry it), but a transient RPC
+ * failure is NOT: mapping any error → "token" would flash token-asserting UI
+ * (the $TICKER row, "You receive X", the Backers chip) on a POOL whenever its
+ * first read hit a flaky RPC. So classify with BaseError.walk like the recast
+ * probe: revert → "token"; a non-revert error leaves `kind` undefined and
+ * retries up to twice, keeping pool-neutral UI until a real answer lands.
  *
  * Instance switches happen IN PLACE (no remount), but wagmi keys this query on
  * chainId + address + functionName, so switching instances re-probes the new
@@ -37,14 +53,19 @@ export function useInstanceKind(): InstanceKindState {
     abi: poolAbi,
     functionName: "isPool",
     chainId,
-    query: { retry: false },
+    query: {
+      retry: (failureCount, error) => !isRevert(error) && failureCount < 2,
+    },
   });
-  const kind: InstanceKind | undefined = read.isError
-    ? "token"
-    : read.data !== undefined
-      ? read.data
-        ? "pool"
-        : "token"
-      : undefined;
+  // Only a REVERT asserts "token"; a non-revert error keeps kind undefined
+  // (the query is still retrying) so the UI stays pool-neutral.
+  const kind: InstanceKind | undefined =
+    read.isError && isRevert(read.error)
+      ? "token"
+      : read.data !== undefined
+        ? read.data
+          ? "pool"
+          : "token"
+        : undefined;
   return { kind, isPool: kind === "pool" };
 }

--- a/src/hooks/use-instance-kind.ts
+++ b/src/hooks/use-instance-kind.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useReadContract } from "wagmi";
+import { poolAbi } from "@/lib/abis";
+import { useActiveChainId, useInstance } from "@/components/instance-provider";
+
+/**
+ * What sits at `instance.token`: a classic transferable token, or a StakePool
+ * (no token issued — deposits tracked in the underlying asset, no
+ * transfer/approve, symbol() is the UNDERLYING's).
+ */
+export type InstanceKind = "pool" | "token";
+
+export interface InstanceKindState {
+  /** undefined while the probe is in flight (hydration-safe first render). */
+  kind: InstanceKind | undefined;
+  /** Convenience: kind === "pool". False while undetermined, so every pool-only
+   *  copy branch renders the classic (token) copy until the probe resolves —
+   *  token instances stay byte-identical to before pool mode existed. */
+  isPool: boolean;
+}
+
+/**
+ * Feature-detect the instance kind by probing `isPool()` on the token slot —
+ * pools return true, classic tokens revert (the same probe-and-revert pattern
+ * as useYieldSplit's `supported`). No retry: a revert IS the answer.
+ *
+ * Instance switches happen IN PLACE (no remount), but wagmi keys this query on
+ * chainId + address + functionName, so switching instances re-probes the new
+ * token address automatically — no stale kind can bleed across instances.
+ */
+export function useInstanceKind(): InstanceKindState {
+  const a = useInstance();
+  const chainId = useActiveChainId();
+  const read = useReadContract({
+    address: a.token,
+    abi: poolAbi,
+    functionName: "isPool",
+    chainId,
+    query: { retry: false },
+  });
+  const kind: InstanceKind | undefined = read.isError
+    ? "token"
+    : read.data !== undefined
+      ? read.data
+        ? "pool"
+        : "token"
+      : undefined;
+  return { kind, isPool: kind === "pool" };
+}

--- a/src/lib/abis/crowdstake-deployer.ts
+++ b/src/lib/abis/crowdstake-deployer.ts
@@ -11,9 +11,16 @@ import { parseAbi } from "viem";
  * eth_call. The Instance tuple's `registry` is remapped to `recipientRegistry`
  * in use-deploy; `secondaryDistributionStrategy` is the equal strategy in
  * split mode (zero address otherwise).
+ *
+ * `issueToken` is APPENDED to Params (struct-append keeps old callers'
+ * calldata meaningful): false — the zero value, and the app's default — is
+ * POOL MODE (a StakePool at the Instance tuple's `token` slot, no ERC-20
+ * issued); true deploys the classic transferable token. It is NOT part of
+ * familyIdOf/votingFamilyIdOf — family-wide mode consistency is enforced by
+ * the deploy wizard sending one shared config to every chain.
  */
 export const deployerAbi = parseAbi([
-  "function deploy((address owner, uint256 cycleLength, string tokenName, string tokenSymbol, uint256 maxVotingPoints, bytes32 salt, uint8 registryKind, address[] initialRecipients, uint256 proposalExpiry, uint8 distributionKind, string tokenImageURI, string bannerImageURI, bool crossChain) p) returns ((address cycleModule, address registry, address token, address votingPowerStrategy, address distributionManager, address distributionStrategy, address secondaryDistributionStrategy, address votingModule))",
+  "function deploy((address owner, uint256 cycleLength, string tokenName, string tokenSymbol, uint256 maxVotingPoints, bytes32 salt, uint8 registryKind, address[] initialRecipients, uint256 proposalExpiry, uint8 distributionKind, string tokenImageURI, string bannerImageURI, bool crossChain, bool issueToken) p) returns ((address cycleModule, address registry, address token, address votingPowerStrategy, address distributionManager, address distributionStrategy, address secondaryDistributionStrategy, address votingModule))",
   "function familyIdOf(address creator, bytes32 salt, string tokenName, string tokenSymbol, uint256 maxVotingPoints, uint8 registryKind, uint8 distributionKind) pure returns (bytes32)",
   "function votingFamilyIdOf(address creator, bytes32 salt, string tokenName, string tokenSymbol, uint256 maxVotingPoints, uint8 distributionKind, address[] initialRecipients, uint256 proposalExpiry) pure returns (bytes32)",
   "function familyInstances(bytes32 familyId) view returns ((address cycleModule, address registry, address token, address votingPowerStrategy, address distributionManager, address distributionStrategy, address secondaryDistributionStrategy, address votingModule))",

--- a/src/lib/abis/crowdstake-deployer.ts
+++ b/src/lib/abis/crowdstake-deployer.ts
@@ -24,6 +24,11 @@ export const deployerAbi = parseAbi([
   "function familyIdOf(address creator, bytes32 salt, string tokenName, string tokenSymbol, uint256 maxVotingPoints, uint8 registryKind, uint8 distributionKind) pure returns (bytes32)",
   "function votingFamilyIdOf(address creator, bytes32 salt, string tokenName, string tokenSymbol, uint256 maxVotingPoints, uint8 distributionKind, address[] initialRecipients, uint256 proposalExpiry) pure returns (bytes32)",
   "function familyInstances(bytes32 familyId) view returns ((address cycleModule, address registry, address token, address votingPowerStrategy, address distributionManager, address distributionStrategy, address secondaryDistributionStrategy, address votingModule))",
+  // Capability flag added alongside the appended `issueToken` param (sibling
+  // contracts branch). Deployers that predate pool mode DON'T expose this — the
+  // read REVERTS, which is exactly how useDeployerPoolSupport detects that a
+  // 14-field deploy() would revert there and forces issueToken=true.
+  "function supportsPoolMode() view returns (bool)",
   "event SystemDeployed(address indexed owner, address indexed deployer, bytes32 indexed salt, (address cycleModule, address registry, address token, address votingPowerStrategy, address distributionManager, address distributionStrategy, address secondaryDistributionStrategy, address votingModule) instance)",
   "event FamilyDeployed(bytes32 indexed familyId, address indexed creator, address indexed owner)",
   "error ZeroOwner()",

--- a/src/lib/abis/index.ts
+++ b/src/lib/abis/index.ts
@@ -1,4 +1,5 @@
 export { tokenAbi } from "./token";
+export { poolAbi } from "./pool";
 export { distributionManagerAbi } from "./distribution-manager";
 export { cycleModuleAbi } from "./cycle-module";
 export { votingModuleAbi } from "./voting-module";

--- a/src/lib/abis/pool.ts
+++ b/src/lib/abis/pool.ts
@@ -3,9 +3,10 @@ import { parseAbi } from "viem";
 /**
  * StakePool — the no-token instance kind. The pool is deliberately
  * ABI-compatible with every read the app already does on `instance.token`
- * (balanceOf/totalSupply/decimals/name/symbol, yieldAccrued/totalYieldAccrued,
- * yieldSplitOf/keptYieldOf/claimKeptYield/setYieldSplit, and the same
- * mint/burn deposit-withdraw signatures), so those calls keep using tokenAbi.
+ * (balanceOf/totalSupply/decimals/name/symbol, getVotes/delegates,
+ * yieldAccrued/totalYieldAccrued, yieldSplitOf/keptYieldOf/claimKeptYield/
+ * setYieldSplit, and the same mint/burn deposit-withdraw signatures), so those
+ * calls keep using tokenAbi.
  * This ABI carries only the pool's EXTRA surface: the `isPool()` probe the UI
  * feature-detects the kind with (token instances revert on it — the same
  * pattern as useYieldSplit's `supported`), and the Deposited/Withdrawn events

--- a/src/lib/abis/pool.ts
+++ b/src/lib/abis/pool.ts
@@ -1,0 +1,19 @@
+import { parseAbi } from "viem";
+
+/**
+ * StakePool — the no-token instance kind. The pool is deliberately
+ * ABI-compatible with every read the app already does on `instance.token`
+ * (balanceOf/totalSupply/decimals/name/symbol, yieldAccrued/totalYieldAccrued,
+ * yieldSplitOf/keptYieldOf/claimKeptYield/setYieldSplit, and the same
+ * mint/burn deposit-withdraw signatures), so those calls keep using tokenAbi.
+ * This ABI carries only the pool's EXTRA surface: the `isPool()` probe the UI
+ * feature-detects the kind with (token instances revert on it — the same
+ * pattern as useYieldSplit's `supported`), and the Deposited/Withdrawn events
+ * a pool emits instead of ERC-20 Transfer events (a pool has no
+ * transfer/approve/allowance at all).
+ */
+export const poolAbi = parseAbi([
+  "function isPool() view returns (bool)",
+  "event Deposited(address indexed receiver, uint256 amount)",
+  "event Withdrawn(address indexed receiver, uint256 amount)",
+]);

--- a/src/lib/families.ts
+++ b/src/lib/families.ts
@@ -290,6 +290,15 @@ export interface PendingFamilyParams {
   proposalExpiry: string;
   tokenImageURI: string;
   bannerImageURI: string;
+  /**
+   * Issue a transferable ERC-20 (true) or pool mode (false). Optional because
+   * records saved BEFORE pool mode existed all deployed tokens — readers must
+   * treat a missing value as TRUE so resuming/extending an old family keeps
+   * its mode (new deploys default to false = pool). Not part of the familyId:
+   * cross-chain mode consistency is enforced by the deploy wizard's shared
+   * config, not the id derivation.
+   */
+  issueToken?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Tokenless pool mode — frontend

Adds **pool mode** as the *default* deploy path: a `StakePool` sits at the instance's `token` slot with no ERC-20 issued. Deposits are tracked, principal is withdrawable any time, no transfer/approve surface. The pool is deliberately ABI-compatible with every read/write the app already does on `instance.token` (balanceOf/totalSupply/decimals/name/symbol, the yield surface, and identical mint/burn signatures), so the existing token hooks work unchanged — only copy branches.

### What's in it
- **`useInstanceKind()`** — probes `isPool()` (retry:false; revert → "token"), hydration-safe, re-probed on in-place instance switches (wagmi keys on chainId + address).
- **ABIs** — new `src/lib/abis/pool.ts` (isPool + Deposited/Withdrawn); `issueToken` appended to the deployer `Params` tuple.
- **Deploy wizard** — "Staking mode" toggle defaulting to **No token (pool)**; symbol field hidden and name relabeled "Community name" in pool mode; `issueToken` wired through both `use-deploy.ts` and `use-deploy-family.ts` (family mode-consistency enforced by the shared config).
- **Copy branching** (surgical; token mode byte-identical) — portfolio, deposit (+ family), withdraw (+ family), distribute, yield, instance header/branding.
- **e2e** — `e2e/verify-pool-mode.ts` deploys a pool on an anvil Gnosis fork, exercises deposit/yield-split/withdraw through the frontend ABIs, and asserts no ERC-20 transfer surface.

### Verified vs assumed
- **Verified via build/lint/typecheck:** the deployer tuple shape, all token-hook compat reads, no block elements in Caption/Body.
- **Assumed against spec (contracts branch not yet pushed):** the exact `StakePool` behavior — `symbol()` = underlying's, `name()` = instance name, pool passed `""` for the symbol param. `verify-pool-mode.ts` is committed as a **harness** and has NOT been run against a live deployer (no pool-mode-capable deployer exists yet). Run it once the contracts branch lands.

### Checks
`pnpm lint && pnpm format:check && pnpm build` all green.