### PR TITLE
feat: tokenless pool mode (issueToken toggle, default off)

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -224,8 +224,10 @@ contract Deploy is Script {
         //     references in step 5d, then transfer ownership to the intended owner.
         distributionManager = factory.create(
             baseDistManagerBeacon,
-            abi.encodeWithSelector(
-                BaseDistributionManager.initialize.selector,
+            // encodeWithSignature: `initialize` is overloaded (7-arg yield-module form), so
+            // `.selector` is ambiguous. This is the classic 6-arg token-mode initializer.
+            abi.encodeWithSignature(
+                "initialize(address,address,address,address,address,address)",
                 cycleModule,
                 registry,
                 p.baseToken,

--- a/contracts/script/DeployCrowdStakeDeployer.s.sol
+++ b/contracts/script/DeployCrowdStakeDeployer.s.sol
@@ -16,6 +16,8 @@ import {AdminRecipientRegistry} from "../src/implementation/registries/AdminReci
 import {VotingRecipientRegistry} from "../src/implementation/registries/VotingRecipientRegistry.sol";
 import {SexyDaiYield} from "../src/implementation/token/SexyDaiYield.sol";
 import {StableYield} from "../src/implementation/token/StableYield.sol";
+import {PoolNativeYield} from "../src/implementation/pool/PoolNativeYield.sol";
+import {PoolStableYield} from "../src/implementation/pool/PoolStableYield.sol";
 
 /// @notice Fresh, self-contained deploy of the ONE canonical CrowdStakeDeployer plus its
 ///         own CrowdStakeFactory and beacons. The token + distribution-manager impls now
@@ -45,39 +47,34 @@ contract DeployCrowdStakeDeployer is Script {
 
         CrowdStakeFactory factory = new CrowdStakeFactory(me);
 
-        address cycleBeacon = address(new UpgradeableBeacon(address(new CycleModule()), me));
-        address adminRegBeacon = address(new UpgradeableBeacon(address(new AdminRecipientRegistry()), me));
-        address votingRegBeacon = address(new UpgradeableBeacon(address(new VotingRecipientRegistry()), me));
-        address tokenBeacon = address(new UpgradeableBeacon(_tokenImpl(asset, yieldVault), me));
-        address distBeacon = address(new UpgradeableBeacon(address(new BaseDistributionManager()), me));
-        address multiDistBeacon = address(new UpgradeableBeacon(address(new MultiStrategyDistributionManager()), me));
-        address stratBeacon = address(new UpgradeableBeacon(address(new VotingDistributionStrategy()), me));
-        address equalStratBeacon = address(new UpgradeableBeacon(address(new EqualDistributionStrategy()), me));
-        address votingBeacon = address(new UpgradeableBeacon(address(new BasisPointsVotingModule()), me));
-
-        address[] memory beacons = new address[](9);
-        beacons[0] = cycleBeacon;
-        beacons[1] = adminRegBeacon;
-        beacons[2] = votingRegBeacon;
-        beacons[3] = tokenBeacon;
-        beacons[4] = distBeacon;
-        beacons[5] = multiDistBeacon;
-        beacons[6] = stratBeacon;
-        beacons[7] = equalStratBeacon;
-        beacons[8] = votingBeacon;
+        // Beacons packed straight into the array (avoids ~10 named stack locals → stack-too-deep).
+        // Index order MUST match the CrowdStakeDeployer constructor argument order below.
+        address[] memory beacons = new address[](10);
+        beacons[0] = address(new UpgradeableBeacon(address(new CycleModule()), me)); // cycle
+        beacons[1] = address(new UpgradeableBeacon(address(new AdminRecipientRegistry()), me)); // admin registry
+        beacons[2] = address(new UpgradeableBeacon(address(new VotingRecipientRegistry()), me)); // voting registry
+        beacons[3] = address(new UpgradeableBeacon(_tokenImpl(asset, yieldVault), me)); // token
+        // Pool-mode impl matching the same YIELD_KIND (native → PoolNativeYield, stable → PoolStableYield).
+        beacons[4] = address(new UpgradeableBeacon(_poolImpl(asset, yieldVault), me)); // pool
+        beacons[5] = address(new UpgradeableBeacon(address(new BaseDistributionManager()), me)); // dist manager
+        beacons[6] = address(new UpgradeableBeacon(address(new MultiStrategyDistributionManager()), me)); // multi dist
+        beacons[7] = address(new UpgradeableBeacon(address(new VotingDistributionStrategy()), me)); // voting strategy
+        beacons[8] = address(new UpgradeableBeacon(address(new EqualDistributionStrategy()), me)); // equal strategy
+        beacons[9] = address(new UpgradeableBeacon(address(new BasisPointsVotingModule()), me)); // voting module
         factory.allowlistBeacons(beacons);
 
         CrowdStakeDeployer d = new CrowdStakeDeployer(
             address(factory),
-            cycleBeacon,
-            adminRegBeacon,
-            votingRegBeacon,
-            tokenBeacon,
-            distBeacon,
-            multiDistBeacon,
-            stratBeacon,
-            equalStratBeacon,
-            votingBeacon
+            beacons[0],
+            beacons[1],
+            beacons[2],
+            beacons[3],
+            beacons[4],
+            beacons[5],
+            beacons[6],
+            beacons[7],
+            beacons[8],
+            beacons[9]
         );
 
         vm.stopBroadcast();
@@ -96,5 +93,14 @@ contract DeployCrowdStakeDeployer is Script {
     /// @dev Deploy the token implementation matching YIELD_KIND (broadcast-safe).
     function _tokenImpl(address asset, address yieldVault) internal returns (address) {
         return _stable() ? address(new StableYield(asset, yieldVault)) : address(new SexyDaiYield(asset, yieldVault));
+    }
+
+    /// @dev Deploy the pool-mode implementation matching YIELD_KIND (broadcast-safe). Mirrors
+    ///      _tokenImpl: PoolStableYield for "stable", PoolNativeYield otherwise.
+    function _poolImpl(address asset, address yieldVault) internal returns (address) {
+        return
+            _stable()
+                ? address(new PoolStableYield(asset, yieldVault))
+                : address(new PoolNativeYield(asset, yieldVault));
     }
 }

--- a/contracts/script/DeployGnosis.s.sol
+++ b/contracts/script/DeployGnosis.s.sol
@@ -154,8 +154,10 @@ contract DeployGnosis is Script {
         // 5a. Distribution manager — baseToken = the token itself; placeholders for votingModule/strategy.
         distributionManager = factory.create(
             baseDistManagerBeacon,
-            abi.encodeWithSelector(
-                BaseDistributionManager.initialize.selector,
+            // encodeWithSignature: `initialize` is overloaded (7-arg yield-module form), so
+            // `.selector` is ambiguous. This is the classic 6-arg token-mode initializer.
+            abi.encodeWithSignature(
+                "initialize(address,address,address,address,address,address)",
                 cycleModule,
                 registry,
                 token, // baseToken == the SexyDaiYield token (the yield module)

--- a/contracts/src/CrowdStakeDeployer.sol
+++ b/contracts/src/CrowdStakeDeployer.sol
@@ -361,19 +361,24 @@ contract CrowdStakeDeployer {
         // 5-6. Distribution manager + strategies (kind-dependent; deployer-owned, wired below).
         //      The DM's baseToken and the strategy's yieldToken are the distributedAsset (the
         //      underlying in pool mode, the token in token mode).
+        //
+        //      The yield module is fixed at DM initialization (there is no post-init setter — review
+        //      S1). In pool mode the yield-bearing surface (the pool) is distinct from the distributed
+        //      asset (the underlying), so pass the pool as the yield module. Token mode passes
+        //      address(0), which the DM resolves to baseToken — byte-identical to the classic path.
+        address yieldModule = p.issueToken ? address(0) : inst.token;
         if (p.distributionKind == uint8(DistributionKind.Proportional)) {
-            _deployProportional(inst, baseSalt, self, p.owner, distributedAsset);
+            _deployProportional(inst, baseSalt, self, p.owner, distributedAsset, yieldModule);
         } else {
             _deployMulti(
-                inst, baseSalt, self, p.owner, distributedAsset, p.distributionKind == uint8(DistributionKind.Split)
+                inst,
+                baseSalt,
+                self,
+                p.owner,
+                distributedAsset,
+                yieldModule,
+                p.distributionKind == uint8(DistributionKind.Split)
             );
-        }
-
-        // In pool mode the yield-bearing surface (the pool) is distinct from the distributed asset
-        // (the underlying), so point the DM's yield module at the pool. Token mode leaves
-        // yieldModule == baseToken (set in initialize), byte-identical to the classic path.
-        if (!p.issueToken) {
-            AbstractDistributionManager(inst.distributionManager).setYieldModule(inst.token);
         }
 
         // 7. Voting module (familyId = 0 → classic chain-bound instance).
@@ -455,22 +460,28 @@ contract CrowdStakeDeployer {
     ///      setDistributionStrategy once the strategy (which references the manager) exists.
     /// @param distributedAsset The ERC-20 the manager distributes: the token in token mode, the
     ///        UNDERLYING asset in pool mode. Used as both the DM's baseToken and the strategy's
-    ///        yieldToken. In pool mode the DM's yieldModule is repointed to the pool by the caller.
+    ///        yieldToken.
+    /// @param yieldModule The yield source fixed at DM init: the pool in pool mode, or address(0)
+    ///        in token mode (the DM resolves address(0) to baseToken). No post-init setter exists.
     function _deployProportional(
         Instance memory inst,
         bytes32 baseSalt,
         address self,
         address owner,
-        address distributedAsset
+        address distributedAsset,
+        address yieldModule
     ) private {
+        // encodeWithSignature: `initialize` is overloaded (7-arg yield-module form), so `.selector`
+        // is ambiguous. The 7-arg initializer fixes the yield module at construction (review S1).
         inst.distributionManager = FACTORY.create(
             DIST_MANAGER_BEACON,
-            abi.encodeWithSelector(
-                BaseDistributionManager.initialize.selector,
+            abi.encodeWithSignature(
+                "initialize(address,address,address,address,address,address,address)",
                 inst.cycleModule,
                 inst.registry,
                 distributedAsset,
                 self, // placeholder votingModule
+                yieldModule, // pool in pool mode; address(0) → baseToken in token mode
                 address(0), // placeholder strategy
                 self // deployer owns it temporarily
             ),
@@ -494,24 +505,30 @@ contract CrowdStakeDeployer {
     ///      yield is distributed by votes and half equally; otherwise it is purely equal.
     /// @param distributedAsset The ERC-20 the manager distributes: the token in token mode, the
     ///        UNDERLYING asset in pool mode. Used as the DM's baseToken and every strategy's
-    ///        yieldToken. In pool mode the DM's yieldModule is repointed to the pool by the caller.
+    ///        yieldToken.
+    /// @param yieldModule The yield source fixed at DM init: the pool in pool mode, or address(0)
+    ///        in token mode (the DM resolves address(0) to baseToken). No post-init setter exists.
     function _deployMulti(
         Instance memory inst,
         bytes32 baseSalt,
         address self,
         address owner,
         address distributedAsset,
+        address yieldModule,
         bool split
     ) private {
         IDistributionStrategy[] memory none = new IDistributionStrategy[](0);
+        // encodeWithSignature: `initialize` is overloaded (7-arg yield-module form), so `.selector`
+        // is ambiguous. The 7-arg initializer fixes the yield module at construction (review S1).
         inst.distributionManager = FACTORY.create(
             MULTI_DIST_MANAGER_BEACON,
-            abi.encodeWithSelector(
-                MultiStrategyDistributionManager.initialize.selector,
+            abi.encodeWithSignature(
+                "initialize(address,address,address,address,address,address[],address)",
                 inst.cycleModule,
                 inst.registry,
                 distributedAsset,
                 self, // placeholder votingModule
+                yieldModule, // pool in pool mode; address(0) → baseToken in token mode
                 none, // empty; strategies wired below via setStrategies
                 self // deployer owns it temporarily
             ),

--- a/contracts/src/CrowdStakeDeployer.sol
+++ b/contracts/src/CrowdStakeDeployer.sol
@@ -10,16 +10,23 @@ import {EqualDistributionStrategy} from "./implementation/strategies/EqualDistri
 import {AdminRecipientRegistry} from "./implementation/registries/AdminRecipientRegistry.sol";
 import {VotingRecipientRegistry} from "./implementation/registries/VotingRecipientRegistry.sol";
 import {SexyDaiYield} from "./implementation/token/SexyDaiYield.sol";
-import {AbstractToken} from "./abstract/AbstractToken.sol";
 import {TimeWeightedVotingPower} from "./implementation/TimeWeightedVotingPower.sol";
 import {IVotingPowerStrategy} from "./interfaces/IVotingPowerStrategy.sol";
 import {IVotesCheckpoints} from "./interfaces/IVotesCheckpoints.sol";
 import {IDistributionStrategy} from "./interfaces/IDistributionStrategy.sol";
+import {IStakePool} from "./interfaces/IStakePool.sol";
 
 /// @notice Minimal view of CrowdStakeFactory's deployment entrypoints.
 interface ICrowdStakeFactory {
     function create(address beacon, bytes calldata payload, bytes32 salt) external returns (address);
     function createToken(address beacon, bytes calldata payload, bytes32 salt) external returns (address);
+}
+
+/// @notice The subset shared by the token (AbstractToken) and the pool (AbstractStakePool) that
+///         the deployer wires identically, so mode branching stays confined to construction.
+interface IYieldSurface {
+    function setYieldClaimer(address yieldClaimer) external;
+    function transferOwnership(address newOwner) external;
 }
 
 /// @title CrowdStakeDeployer
@@ -41,6 +48,7 @@ contract CrowdStakeDeployer {
     address public immutable REGISTRY_BEACON; // AdminRecipientRegistry
     address public immutable VOTING_REGISTRY_BEACON; // VotingRecipientRegistry
     address public immutable TOKEN_BEACON;
+    address public immutable POOL_BEACON; // StakePool (pool mode; matches TOKEN_BEACON's yield kind)
     address public immutable DIST_MANAGER_BEACON; // BaseDistributionManager (single strategy)
     address public immutable MULTI_DIST_MANAGER_BEACON; // MultiStrategyDistributionManager
     address public immutable STRATEGY_BEACON; // VotingDistributionStrategy
@@ -86,6 +94,33 @@ contract CrowdStakeDeployer {
         // Cross-chain family: true = this instance joins the familyIdOf(...) family and its
         // voting module accepts ONLY chain-agnostic castCrossChainVote ballots.
         bool crossChain;
+        // Token vs pool mode. ZERO VALUE (false) = POOL MODE = default: NO token is issued,
+        // deposits are ledger entries in a StakePool, and distributions pay the UNDERLYING asset.
+        // true = classic token mode (a SexyDaiYield/StableYield ERC-20 is minted), byte-identical
+        // to the pre-pool-mode deploy path.
+        bool issueToken;
+    }
+
+    /// @notice The PRE-pool-mode Params layout (13 fields, no issueToken). Kept ONLY so pinned,
+    ///         per-instance IPFS frontends that encode the OLD `deploy` selector (0xfd759538) still
+    ///         work against this deployer instead of hard-reverting on the changed selector.
+    /// @dev Field order MUST stay byte-identical to the historical Params. The {deploy} overload
+    ///      that takes this fills issueToken = true (classic token mode) and delegates to the new
+    ///      path, so a legacy call deploys exactly the classic token instance it always did.
+    struct LegacyParams {
+        address owner;
+        uint256 cycleLength;
+        string tokenName;
+        string tokenSymbol;
+        uint256 maxVotingPoints;
+        bytes32 salt;
+        uint8 registryKind;
+        address[] initialRecipients;
+        uint256 proposalExpiry;
+        uint8 distributionKind;
+        string tokenImageURI;
+        string bannerImageURI;
+        bool crossChain;
     }
 
     struct Instance {
@@ -124,6 +159,7 @@ contract CrowdStakeDeployer {
         address registryBeacon,
         address votingRegistryBeacon,
         address tokenBeacon,
+        address poolBeacon,
         address distManagerBeacon,
         address multiDistManagerBeacon,
         address strategyBeacon,
@@ -135,11 +171,22 @@ contract CrowdStakeDeployer {
         REGISTRY_BEACON = registryBeacon;
         VOTING_REGISTRY_BEACON = votingRegistryBeacon;
         TOKEN_BEACON = tokenBeacon;
+        POOL_BEACON = poolBeacon;
         DIST_MANAGER_BEACON = distManagerBeacon;
         MULTI_DIST_MANAGER_BEACON = multiDistManagerBeacon;
         STRATEGY_BEACON = strategyBeacon;
         EQUAL_STRATEGY_BEACON = equalStrategyBeacon;
         VOTING_BEACON = votingBeacon;
+    }
+
+    /// @notice On-chain capability probe: this deployer understands pool mode (the issueToken
+    ///         toggle) and exposes a POOL_BEACON.
+    /// @dev Appending `issueToken` to Params changed deploy()'s selector (0xfd759538 → 0x1be9a993),
+    ///      so a new-ABI call against an OLD deployer reverts. The deploy wizard calls this probe to
+    ///      decide whether to surface the pool toggle; old deployers lack the function and the
+    ///      staticcall reverts, which the wizard reads as "no pool mode".
+    function supportsPoolMode() external pure returns (bool) {
+        return true;
     }
 
     /// @notice The deterministic identity a deploy(p) with p.crossChain would create/extend.
@@ -197,7 +244,14 @@ contract CrowdStakeDeployer {
     }
 
     /// @notice Deploy a full, working CrowdStake instance in one transaction.
-    function deploy(Params calldata p) external returns (Instance memory inst) {
+    function deploy(Params calldata p) external returns (Instance memory) {
+        return _deploy(p, msg.sender);
+    }
+
+    /// @dev Shared deploy body. `creator` is the ORIGINAL caller (msg.sender of the public
+    ///      entrypoint) so family scoping/salting/events stay correct even when invoked through the
+    ///      legacy overload — never read msg.sender here (it would be `this` on a self-call).
+    function _deploy(Params memory p, address creator) internal returns (Instance memory inst) {
         if (p.owner == address(0)) revert ZeroOwner();
         if (p.cycleLength == 0) revert ZeroCycleLength();
         if (p.registryKind > uint8(RegistryKind.Voting)) revert InvalidRegistryKind();
@@ -209,13 +263,17 @@ contract CrowdStakeDeployer {
             if (p.proposalExpiry == 0) revert ZeroProposalExpiry();
         }
 
+        // NOTE: familyId derivation is intentionally NOT a function of issueToken (token vs pool
+        // mode). Enforcing that every sibling in a cross-chain family shares the same mode is the
+        // deploy wizard's job, not the on-chain derivation's — keeping issueToken out of the
+        // family id preserves byte-identical family ids for existing token-mode families.
         bytes32 familyId;
         if (p.crossChain) {
             // Voting-kind families commit their founding cohort + expiry; admin-kind stays on the
             // base derivation (byte-identical to today).
             if (p.registryKind == uint8(RegistryKind.Voting)) {
                 familyId = votingFamilyIdOf(
-                    msg.sender,
+                    creator,
                     p.salt,
                     p.tokenName,
                     p.tokenSymbol,
@@ -226,19 +284,13 @@ contract CrowdStakeDeployer {
                 );
             } else {
                 familyId = familyIdOf(
-                    msg.sender,
-                    p.salt,
-                    p.tokenName,
-                    p.tokenSymbol,
-                    p.maxVotingPoints,
-                    p.registryKind,
-                    p.distributionKind
+                    creator, p.salt, p.tokenName, p.tokenSymbol, p.maxVotingPoints, p.registryKind, p.distributionKind
                 );
             }
             if (familyInstances[familyId].votingModule != address(0)) revert FamilyAlreadyDeployed();
         }
 
-        bytes32 baseSalt = keccak256(abi.encodePacked(p.salt, msg.sender));
+        bytes32 baseSalt = keccak256(abi.encodePacked(p.salt, creator));
         address self = address(this);
 
         // 1. Cycle module (deployer-owned for wiring).
@@ -271,22 +323,57 @@ contract CrowdStakeDeployer {
             );
         }
 
-        // 3. Token (deployer-owned so it can set the yield claimer).
-        inst.token = FACTORY.createToken(
-            TOKEN_BEACON,
-            abi.encodeWithSelector(SexyDaiYield.initialize.selector, p.tokenName, p.tokenSymbol, self),
-            keccak256(abi.encodePacked(baseSalt, "token"))
-        );
+        // 3. Yield surface (deployer-owned so it can set the yield claimer).
+        //    - Token mode (issueToken == true): a SexyDaiYield/StableYield ERC-20 is minted.
+        //    - Pool mode (issueToken == false, the ZERO-VALUE default): a StakePool records ledger
+        //      entries and issues NO token. `inst.token` carries the POOL address here — intentional:
+        //      the frontend treats inst.token as the balance/yield surface regardless of mode.
+        //    Both impls share the initialize(string,string,address) shape and both implement
+        //    IVotesCheckpoints, so steps 4/7 and the yield-claimer wiring are mode-agnostic.
+        //
+        //    The asset the DistributionManager claims and distributes:
+        //      - token mode: the token itself (yieldModule == baseToken, as in the classic path).
+        //      - pool mode:  the UNDERLYING asset (WXDAI/USDC). The pool is the yield source, but
+        //                    baseToken = underlying so recipients receive the real asset.
+        address distributedAsset;
+        if (p.issueToken) {
+            inst.token = FACTORY.createToken(
+                TOKEN_BEACON,
+                abi.encodeWithSelector(SexyDaiYield.initialize.selector, p.tokenName, p.tokenSymbol, self),
+                keccak256(abi.encodePacked(baseSalt, "token"))
+            );
+            distributedAsset = inst.token;
+        } else {
+            inst.token = FACTORY.createToken(
+                POOL_BEACON,
+                abi.encodeWithSignature("initialize(string,string,address)", p.tokenName, p.tokenSymbol, self),
+                keccak256(abi.encodePacked(baseSalt, "token"))
+            );
+            distributedAsset = IStakePool(inst.token).underlyingAsset();
+        }
 
-        // 4. Time-weighted voting power (immutable; deployed directly).
+        // 4. Time-weighted voting power (immutable; deployed directly). Reads only
+        //    numCheckpoints/checkpoints via IVotesCheckpoints, which both the token (ERC20Votes)
+        //    and the pool implement identically — so the SAME strategy is used unchanged.
         inst.votingPowerStrategy =
             address(new TimeWeightedVotingPower(IVotesCheckpoints(inst.token), AbstractCycleModule(inst.cycleModule)));
 
         // 5-6. Distribution manager + strategies (kind-dependent; deployer-owned, wired below).
+        //      The DM's baseToken and the strategy's yieldToken are the distributedAsset (the
+        //      underlying in pool mode, the token in token mode).
         if (p.distributionKind == uint8(DistributionKind.Proportional)) {
-            _deployProportional(inst, baseSalt, self, p.owner);
+            _deployProportional(inst, baseSalt, self, p.owner, distributedAsset);
         } else {
-            _deployMulti(inst, baseSalt, self, p.owner, p.distributionKind == uint8(DistributionKind.Split));
+            _deployMulti(
+                inst, baseSalt, self, p.owner, distributedAsset, p.distributionKind == uint8(DistributionKind.Split)
+            );
+        }
+
+        // In pool mode the yield-bearing surface (the pool) is distinct from the distributed asset
+        // (the underlying), so point the DM's yield module at the pool. Token mode leaves
+        // yieldModule == baseToken (set in initialize), byte-identical to the classic path.
+        if (!p.issueToken) {
+            AbstractDistributionManager(inst.distributionManager).setYieldModule(inst.token);
         }
 
         // 7. Voting module (familyId = 0 → classic chain-bound instance).
@@ -306,10 +393,11 @@ contract CrowdStakeDeployer {
             keccak256(abi.encodePacked(baseSalt, "voting"))
         );
 
-        // Wire shared references + authorise the manager as the token's yield claimer.
+        // Wire shared references + authorise the manager as the yield surface's yield claimer.
+        // setYieldClaimer(address) has the same signature on the token and the pool.
         AbstractDistributionManager(inst.distributionManager).setVotingModule(inst.votingModule);
         AbstractCycleModule(inst.cycleModule).setDistributionManager(inst.distributionManager);
-        AbstractToken(inst.token).setYieldClaimer(inst.distributionManager);
+        IYieldSurface(inst.token).setYieldClaimer(inst.distributionManager);
 
         // Seed instance artwork on the distribution manager while still owner-of-record.
         if (bytes(p.tokenImageURI).length != 0 || bytes(p.bannerImageURI).length != 0) {
@@ -317,30 +405,71 @@ contract CrowdStakeDeployer {
         }
 
         // Hand the temporarily-owned contracts to the final owner.
-        AbstractToken(inst.token).transferOwnership(p.owner);
+        // transferOwnership(address) has the same signature on the token and the pool.
+        IYieldSurface(inst.token).transferOwnership(p.owner);
         AbstractDistributionManager(inst.distributionManager).transferOwnership(p.owner);
         AbstractCycleModule(inst.cycleModule).transferOwnership(p.owner);
 
         // Record the family sibling only after full wiring, so a resolved instance is usable.
         if (p.crossChain) {
             familyInstances[familyId] = inst;
-            emit FamilyDeployed(familyId, msg.sender, p.owner);
+            emit FamilyDeployed(familyId, creator, p.owner);
         }
 
-        emit SystemDeployed(p.owner, msg.sender, p.salt, inst);
+        emit SystemDeployed(p.owner, creator, p.salt, inst);
+    }
+
+    /// @notice Backward-compatible deploy for callers encoding the PRE-pool-mode ABI.
+    /// @dev Pinned, per-instance IPFS frontends encode the old `deploy((...13 fields...))` selector
+    ///      (0xfd759538). Appending issueToken changed the primary {deploy} selector to 0x1be9a993,
+    ///      so without this overload those frozen frontends would hard-revert. This overload accepts
+    ///      the legacy 13-field struct, sets issueToken = true (classic token mode — what those
+    ///      frontends always got), and forwards to the new path. Result is byte-identical to a
+    ///      pre-pool-mode deploy.
+    function deploy(LegacyParams calldata legacy) external returns (Instance memory) {
+        // Delegate through the internal body (NOT this.deploy) so msg.sender — the family
+        // creator/salt — is the original caller, not the deployer.
+        return _deploy(
+            Params({
+                owner: legacy.owner,
+                cycleLength: legacy.cycleLength,
+                tokenName: legacy.tokenName,
+                tokenSymbol: legacy.tokenSymbol,
+                maxVotingPoints: legacy.maxVotingPoints,
+                salt: legacy.salt,
+                registryKind: legacy.registryKind,
+                initialRecipients: legacy.initialRecipients,
+                proposalExpiry: legacy.proposalExpiry,
+                distributionKind: legacy.distributionKind,
+                tokenImageURI: legacy.tokenImageURI,
+                bannerImageURI: legacy.bannerImageURI,
+                crossChain: legacy.crossChain,
+                issueToken: true // legacy callers always got a classic token instance
+            }),
+            msg.sender
+        );
     }
 
     /// @dev Proportional: BaseDistributionManager (single strategy) + VotingDistributionStrategy.
     ///      The manager is created with a placeholder strategy, then wired via
     ///      setDistributionStrategy once the strategy (which references the manager) exists.
-    function _deployProportional(Instance memory inst, bytes32 baseSalt, address self, address owner) private {
+    /// @param distributedAsset The ERC-20 the manager distributes: the token in token mode, the
+    ///        UNDERLYING asset in pool mode. Used as both the DM's baseToken and the strategy's
+    ///        yieldToken. In pool mode the DM's yieldModule is repointed to the pool by the caller.
+    function _deployProportional(
+        Instance memory inst,
+        bytes32 baseSalt,
+        address self,
+        address owner,
+        address distributedAsset
+    ) private {
         inst.distributionManager = FACTORY.create(
             DIST_MANAGER_BEACON,
             abi.encodeWithSelector(
                 BaseDistributionManager.initialize.selector,
                 inst.cycleModule,
                 inst.registry,
-                inst.token,
+                distributedAsset,
                 self, // placeholder votingModule
                 address(0), // placeholder strategy
                 self // deployer owns it temporarily
@@ -351,7 +480,7 @@ contract CrowdStakeDeployer {
         inst.distributionStrategy = FACTORY.create(
             STRATEGY_BEACON,
             abi.encodeWithSelector(
-                VotingDistributionStrategy.initialize.selector, inst.token, inst.distributionManager, owner
+                VotingDistributionStrategy.initialize.selector, distributedAsset, inst.distributionManager, owner
             ),
             keccak256(abi.encodePacked(baseSalt, "strategy"))
         );
@@ -363,7 +492,17 @@ contract CrowdStakeDeployer {
     ///      with an empty strategy set, then wired via setStrategies once the strategies (which
     ///      reference the manager) exist. `split` adds a VotingDistributionStrategy so half the
     ///      yield is distributed by votes and half equally; otherwise it is purely equal.
-    function _deployMulti(Instance memory inst, bytes32 baseSalt, address self, address owner, bool split) private {
+    /// @param distributedAsset The ERC-20 the manager distributes: the token in token mode, the
+    ///        UNDERLYING asset in pool mode. Used as the DM's baseToken and every strategy's
+    ///        yieldToken. In pool mode the DM's yieldModule is repointed to the pool by the caller.
+    function _deployMulti(
+        Instance memory inst,
+        bytes32 baseSalt,
+        address self,
+        address owner,
+        address distributedAsset,
+        bool split
+    ) private {
         IDistributionStrategy[] memory none = new IDistributionStrategy[](0);
         inst.distributionManager = FACTORY.create(
             MULTI_DIST_MANAGER_BEACON,
@@ -371,7 +510,7 @@ contract CrowdStakeDeployer {
                 MultiStrategyDistributionManager.initialize.selector,
                 inst.cycleModule,
                 inst.registry,
-                inst.token,
+                distributedAsset,
                 self, // placeholder votingModule
                 none, // empty; strategies wired below via setStrategies
                 self // deployer owns it temporarily
@@ -382,7 +521,7 @@ contract CrowdStakeDeployer {
         address equalStrat = FACTORY.create(
             EQUAL_STRATEGY_BEACON,
             abi.encodeWithSelector(
-                EqualDistributionStrategy.initialize.selector, inst.token, inst.distributionManager, owner
+                EqualDistributionStrategy.initialize.selector, distributedAsset, inst.distributionManager, owner
             ),
             keccak256(abi.encodePacked(baseSalt, "equal-strategy"))
         );
@@ -393,7 +532,7 @@ contract CrowdStakeDeployer {
             inst.distributionStrategy = FACTORY.create(
                 STRATEGY_BEACON,
                 abi.encodeWithSelector(
-                    VotingDistributionStrategy.initialize.selector, inst.token, inst.distributionManager, owner
+                    VotingDistributionStrategy.initialize.selector, distributedAsset, inst.distributionManager, owner
                 ),
                 keccak256(abi.encodePacked(baseSalt, "strategy"))
             );

--- a/contracts/src/abstract/AbstractDistributionManager.sol
+++ b/contracts/src/abstract/AbstractDistributionManager.sol
@@ -106,9 +106,6 @@ abstract contract AbstractDistributionManager is Initializable, OwnableUpgradeab
     /// @notice Emitted when the voting module is set or changed
     event VotingModuleSet(address indexed votingModule);
 
-    /// @notice Emitted when the yield module is set independently of the base token (pool mode)
-    event YieldModuleSet(address indexed yieldModule);
-
     /// @notice Emitted when the instance image metadata changes
     event InstanceMetadataSet(string tokenImageURI, string bannerImageURI);
 
@@ -125,18 +122,6 @@ abstract contract AbstractDistributionManager is Initializable, OwnableUpgradeab
         emit VotingModuleSet(_votingModule);
     }
 
-    /// @notice Sets the yield module independently of the base token.
-    /// @dev In the default token path yieldModule == baseToken (set in initialize). In POOL MODE
-    ///      the yield-bearing surface (the StakePool) is distinct from the base token that gets
-    ///      distributed (the UNDERLYING asset), so the deployer wires them apart: baseToken =
-    ///      underlying, yieldModule = pool. Owner-only; the deployer owns the manager while wiring.
-    /// @param _yieldModule Address of the yield module (the pool in pool mode)
-    function setYieldModule(address _yieldModule) external onlyOwner {
-        if (_yieldModule == address(0)) revert ZeroAddress();
-        _getAbstractDistributionManagerStorage().yieldModule = IYieldModule(_yieldModule);
-        emit YieldModuleSet(_yieldModule);
-    }
-
     /// @notice Set the instance's token + banner image URIs (owner only). The
     ///         deployer seeds these at deploy; the instance owner can update later.
     function setInstanceMetadata(string calldata tokenImageURI_, string calldata bannerImageURI_) external onlyOwner {
@@ -149,7 +134,9 @@ abstract contract AbstractDistributionManager is Initializable, OwnableUpgradeab
 
     // ============ Initialization ============
 
-    /// @dev Initializes the distribution manager
+    /// @dev Initializes the distribution manager (classic token path). The yield module defaults
+    ///      to the base token — byte-identical to the pre-pool-mode behavior. Kept so existing
+    ///      concrete initializers and beacons stay unchanged.
     /// @param _cycleManager Address of the cycle manager
     /// @param _recipientRegistry Address of the recipient registry
     /// @param _baseToken Address of the base token with yield
@@ -162,15 +149,39 @@ abstract contract AbstractDistributionManager is Initializable, OwnableUpgradeab
         address _votingModule,
         address _owner
     ) internal onlyInitializing {
+        // yieldModule == address(0) → defaults to baseToken, exactly as the classic token path did.
+        __AbstractDistributionManager_init(
+            _cycleManager, _recipientRegistry, _baseToken, _votingModule, address(0), _owner
+        );
+    }
+
+    /// @dev Initializes the distribution manager with the yield module fixed at construction.
+    /// @dev POOL MODE: the yield-bearing surface (the StakePool) is distinct from the base token
+    ///      that gets distributed (the UNDERLYING asset), so the deployer wires them apart at init:
+    ///      baseToken = underlying, yieldModule = pool. Fixing the yield module here (rather than
+    ///      via a post-init owner setter) removes any owner-controlled lever to repoint yield after
+    ///      deployment — the address is immutable for the life of the proxy (review S1).
+    /// @param _yieldModule Address of the yield module; address(0) defaults to _baseToken (token mode).
+    function __AbstractDistributionManager_init(
+        address _cycleManager,
+        address _recipientRegistry,
+        address _baseToken,
+        address _votingModule,
+        address _yieldModule,
+        address _owner
+    ) internal onlyInitializing {
         __Ownable_init(_owner);
-        __AbstractDistributionManager_init_unchained(_cycleManager, _recipientRegistry, _baseToken, _votingModule);
+        __AbstractDistributionManager_init_unchained(
+            _cycleManager, _recipientRegistry, _baseToken, _votingModule, _yieldModule
+        );
     }
 
     function __AbstractDistributionManager_init_unchained(
         address _cycleManager,
         address _recipientRegistry,
         address _baseToken,
-        address _votingModule
+        address _votingModule,
+        address _yieldModule
     ) internal onlyInitializing {
         if (_cycleManager == address(0)) revert ZeroAddress();
         if (_recipientRegistry == address(0)) revert ZeroAddress();
@@ -183,8 +194,9 @@ abstract contract AbstractDistributionManager is Initializable, OwnableUpgradeab
         $.baseToken = IERC20(_baseToken);
         $.votingModule = IVotingModule(_votingModule);
 
-        // Assume base token implements IYieldModule
-        $.yieldModule = IYieldModule(_baseToken);
+        // Default (token path): the base token IS the yield module — byte-identical to before.
+        // Pool mode: the deployer passes the pool explicitly, and it is now fixed for good.
+        $.yieldModule = IYieldModule(_yieldModule == address(0) ? _baseToken : _yieldModule);
     }
 
     /// @notice Checks if distribution is ready

--- a/contracts/src/abstract/AbstractDistributionManager.sol
+++ b/contracts/src/abstract/AbstractDistributionManager.sol
@@ -106,6 +106,9 @@ abstract contract AbstractDistributionManager is Initializable, OwnableUpgradeab
     /// @notice Emitted when the voting module is set or changed
     event VotingModuleSet(address indexed votingModule);
 
+    /// @notice Emitted when the yield module is set independently of the base token (pool mode)
+    event YieldModuleSet(address indexed yieldModule);
+
     /// @notice Emitted when the instance image metadata changes
     event InstanceMetadataSet(string tokenImageURI, string bannerImageURI);
 
@@ -120,6 +123,18 @@ abstract contract AbstractDistributionManager is Initializable, OwnableUpgradeab
         if (_votingModule == address(0)) revert ZeroAddress();
         _getAbstractDistributionManagerStorage().votingModule = IVotingModule(_votingModule);
         emit VotingModuleSet(_votingModule);
+    }
+
+    /// @notice Sets the yield module independently of the base token.
+    /// @dev In the default token path yieldModule == baseToken (set in initialize). In POOL MODE
+    ///      the yield-bearing surface (the StakePool) is distinct from the base token that gets
+    ///      distributed (the UNDERLYING asset), so the deployer wires them apart: baseToken =
+    ///      underlying, yieldModule = pool. Owner-only; the deployer owns the manager while wiring.
+    /// @param _yieldModule Address of the yield module (the pool in pool mode)
+    function setYieldModule(address _yieldModule) external onlyOwner {
+        if (_yieldModule == address(0)) revert ZeroAddress();
+        _getAbstractDistributionManagerStorage().yieldModule = IYieldModule(_yieldModule);
+        emit YieldModuleSet(_yieldModule);
     }
 
     /// @notice Set the instance's token + banner image URIs (owner only). The

--- a/contracts/src/base/BaseDistributionManager.sol
+++ b/contracts/src/base/BaseDistributionManager.sol
@@ -53,7 +53,9 @@ contract BaseDistributionManager is AbstractDistributionManager, ReentrancyGuard
     /// @notice Emitted when the distribution strategy is set or changed
     event StrategySet(address indexed strategy);
 
-    /// @notice Initializes the BaseDistributionManager with a single distribution strategy
+    /// @notice Initializes the BaseDistributionManager with a single distribution strategy.
+    /// @dev Classic token path: the yield module defaults to the base token. Byte-identical to
+    ///      the pre-pool-mode initializer — existing beacons/instances are unaffected.
     /// @param _cycleManager Address of the cycle manager
     /// @param _recipientRegistry Address of the recipient registry
     /// @param _baseToken Address of the base token with yield
@@ -68,8 +70,42 @@ contract BaseDistributionManager is AbstractDistributionManager, ReentrancyGuard
         address _strategy,
         address _owner
     ) external initializer {
+        // yieldModule defaults to baseToken (token mode), exactly as before.
+        _initialize(_cycleManager, _recipientRegistry, _baseToken, _votingModule, address(0), _strategy, _owner);
+    }
+
+    /// @notice Initializes the BaseDistributionManager with the yield module fixed at construction.
+    /// @dev POOL MODE overload: the deployer passes the pool as `_yieldModule` at proxy creation, so
+    ///      the yield source is immutable for the life of the proxy — there is NO post-init owner
+    ///      setter to repoint it (review S1). Passing address(0) is identical to the classic
+    ///      initializer (yieldModule = baseToken).
+    /// @param _yieldModule Address of the yield module; address(0) defaults to _baseToken.
+    function initialize(
+        address _cycleManager,
+        address _recipientRegistry,
+        address _baseToken,
+        address _votingModule,
+        address _yieldModule,
+        address _strategy,
+        address _owner
+    ) external initializer {
+        _initialize(_cycleManager, _recipientRegistry, _baseToken, _votingModule, _yieldModule, _strategy, _owner);
+    }
+
+    /// @dev Shared initializer body for both overloads.
+    function _initialize(
+        address _cycleManager,
+        address _recipientRegistry,
+        address _baseToken,
+        address _votingModule,
+        address _yieldModule,
+        address _strategy,
+        address _owner
+    ) private {
         // Initialize parent AbstractDistributionManager
-        __AbstractDistributionManager_init(_cycleManager, _recipientRegistry, _baseToken, _votingModule, _owner);
+        __AbstractDistributionManager_init(
+            _cycleManager, _recipientRegistry, _baseToken, _votingModule, _yieldModule, _owner
+        );
         __ReentrancyGuard_init();
 
         // Set the single strategy

--- a/contracts/src/base/MultiStrategyDistributionManager.sol
+++ b/contracts/src/base/MultiStrategyDistributionManager.sol
@@ -58,7 +58,9 @@ contract MultiStrategyDistributionManager is AbstractDistributionManager, Reentr
     /// @notice Thrown when configuring an empty strategy set via setStrategies
     error NoStrategies();
 
-    /// @notice Initializes the MultiStrategyDistributionManager with multiple strategies
+    /// @notice Initializes the MultiStrategyDistributionManager with multiple strategies.
+    /// @dev Classic token path: the yield module defaults to the base token. Byte-identical to
+    ///      the pre-pool-mode initializer — existing beacons/instances are unaffected.
     /// @param _cycleManager Address of the cycle manager
     /// @param _recipientRegistry Address of the recipient registry
     /// @param _baseToken Address of the base token with yield
@@ -76,8 +78,42 @@ contract MultiStrategyDistributionManager is AbstractDistributionManager, Reentr
         IDistributionStrategy[] calldata _strategies,
         address _owner
     ) external initializer {
+        // yieldModule defaults to baseToken (token mode), exactly as before.
+        _initialize(_cycleManager, _recipientRegistry, _baseToken, _votingModule, address(0), _strategies, _owner);
+    }
+
+    /// @notice Initializes the MultiStrategyDistributionManager with the yield module fixed at construction.
+    /// @dev POOL MODE overload: the deployer passes the pool as `_yieldModule` at proxy creation, so
+    ///      the yield source is immutable for the life of the proxy — there is NO post-init owner
+    ///      setter to repoint it (review S1). Passing address(0) is identical to the classic
+    ///      initializer (yieldModule = baseToken).
+    /// @param _yieldModule Address of the yield module; address(0) defaults to _baseToken.
+    function initialize(
+        address _cycleManager,
+        address _recipientRegistry,
+        address _baseToken,
+        address _votingModule,
+        address _yieldModule,
+        IDistributionStrategy[] calldata _strategies,
+        address _owner
+    ) external initializer {
+        _initialize(_cycleManager, _recipientRegistry, _baseToken, _votingModule, _yieldModule, _strategies, _owner);
+    }
+
+    /// @dev Shared initializer body for both overloads.
+    function _initialize(
+        address _cycleManager,
+        address _recipientRegistry,
+        address _baseToken,
+        address _votingModule,
+        address _yieldModule,
+        IDistributionStrategy[] calldata _strategies,
+        address _owner
+    ) private {
         // Initialize parent AbstractDistributionManager
-        __AbstractDistributionManager_init(_cycleManager, _recipientRegistry, _baseToken, _votingModule, _owner);
+        __AbstractDistributionManager_init(
+            _cycleManager, _recipientRegistry, _baseToken, _votingModule, _yieldModule, _owner
+        );
         __ReentrancyGuard_init();
 
         // Store strategies (may be empty; isDistributionReady() guards a zero-strategy manager).

--- a/contracts/src/implementation/pool/AbstractStakePool.sol
+++ b/contracts/src/implementation/pool/AbstractStakePool.sol
@@ -230,6 +230,12 @@ abstract contract AbstractStakePool is IStakePool, IVotesCheckpoints, Initializa
     /// @dev Mirrors AbstractToken.claimYield (AbstractToken.sol:232) but pays the underlying by
     ///      redeeming from the vault instead of minting pool balance. Only the donated portion is
     ///      claimable here; holders' kept shares stay reserved for them.
+    /// @dev INVARIANT: assumes the yield vault is a standard ERC-4626 that rounds convertToAssets
+    ///      DOWN and previewWithdraw UP (sDAI and Morpho conform). yieldAccrued() values the
+    ///      position via the round-down convertToAssets, and _claimUnderlying withdraws exactly
+    ///      `amount_`; because the accrued figure never over-counts, a claim can always be satisfied
+    ///      by a round-up-cost withdraw. A vault that rounds the other way could report more accrued
+    ///      than is withdrawable and brick claims — do NOT wire such a vault in as the yield source.
     function claimYield(uint256 amount_, address receiver_) external virtual {
         AbstractStakePoolStorage storage $ = _getAbstractStakePoolStorage();
         if (msg.sender != $.yieldClaimer) revert OnlyClaimer();

--- a/contracts/src/implementation/pool/AbstractStakePool.sol
+++ b/contracts/src/implementation/pool/AbstractStakePool.sol
@@ -1,0 +1,553 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IStakePool} from "../../interfaces/IStakePool.sol";
+import {IVotesCheckpoints} from "../../interfaces/IVotesCheckpoints.sol";
+import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+/// @title AbstractStakePool
+/// @author BreadKit
+/// @notice Tokenless "pool mode" counterpart of {AbstractToken}. Communities can run an
+///         instance where NO token is issued: deposits become ledger entries here, but yield,
+///         voting and distribution mechanics are byte-for-byte the same as the token path.
+/// @dev This contract is ABI-compatible with the surface the rest of the system consumes from
+///      the token (the yield module, the deposit/withdraw entrypoints, the voting-power source),
+///      WITHOUT being an ERC-20. It has NO transfer/approve/allowance and emits NO Transfer
+///      events, which is precisely what keeps it invisible to wallets and explorers as a token.
+///
+///      The logic mirrors {AbstractToken} (see the cited line refs against
+///      contracts/src/abstract/AbstractToken.sol) with two structural differences:
+///        1. The ledger is a plain balance/supply mapping instead of ERC20VotesUpgradeable.
+///        2. Yield claims (donated pool + kept shares) pay the UNDERLYING asset by redeeming
+///           from the vault, rather than minting more pool balance. In pool mode the deployer
+///           wires the DistributionManager's baseToken = the underlying asset, so recipients
+///           receive the real asset.
+///
+///      Voting power: every deposit/withdraw writes an OZ Checkpoints.Checkpoint208 keyed by
+///      block.number with the holder's post-change balance (auto self-delegated). This is the
+///      exact shape ERC20Votes produces, so the EXISTING TimeWeightedVotingPower strategy — which
+///      only reads numCheckpoints(account)/checkpoints(account,i) via IVotesCheckpoints — is
+///      deployed against the pool unchanged (see TimeWeightedVotingPower.sol:36-45, :90-98).
+///
+///      Inheriting contracts must implement _deposit, _remit, _yieldAccrued, _claimUnderlying,
+///      decimals() and symbol() — the same responsibilities SexyDaiYield/StableYield carry.
+abstract contract AbstractStakePool is IStakePool, IVotesCheckpoints, Initializable, OwnableUpgradeable {
+    using Checkpoints for Checkpoints.Trace208;
+
+    // ============ Errors (mirror AbstractToken.sol:26-50) ============
+
+    /// @notice Thrown when attempting to deposit zero
+    error MintZero();
+    /// @notice Thrown when attempting to withdraw zero
+    error BurnZero();
+    /// @notice Thrown when attempting to claim zero yield
+    error ClaimZero();
+    /// @notice Thrown when claimed amount exceeds available yield
+    error YieldInsufficient();
+    /// @notice Thrown when a non-claimer address attempts to claim yield
+    error OnlyClaimer();
+    /// @notice Thrown when a yield split exceeds 100% (10,000 bps)
+    error InvalidYieldSplit();
+    /// @notice Thrown when finalizing with no pending claimer
+    error NoPendingClaimer();
+    /// @notice Thrown when preparing a new claimer while one is already pending
+    error PendingClaimer();
+    /// @notice Thrown when finalizing before the 14-day timelock has elapsed
+    error TimelockNotElapsed();
+    /// @notice Thrown when setting yield claimer after it has already been set
+    error AlreadySetClaimer();
+    /// @notice Thrown when preparing a new claimer that matches the current one
+    error SameClaimer();
+    /// @notice Thrown when a native ETH transfer fails
+    error NativeTransferFailed();
+    /// @notice Thrown when a zero address is provided
+    error ZeroAddress();
+    /// @notice Thrown when a withdrawal exceeds the holder's ledger balance
+    error InsufficientBalance();
+
+    // ============ Ledger + EIP-7201 Namespaced Storage ============
+
+    /// @custom:storage-location erc7201:crowdstake.storage.AbstractStakePool
+    struct AbstractStakePoolStorage {
+        /// @notice Instance display name (the token's name() analogue)
+        string name;
+        /// @notice Ledger balance per holder (no ERC-20 Transfer semantics)
+        mapping(address => uint256) balanceOf;
+        /// @notice Total ledger supply
+        uint256 totalSupply;
+        /// @notice Per-holder self-delegated voting checkpoints (block.number => balance)
+        mapping(address => Checkpoints.Trace208) checkpoints;
+        /// @notice Address authorized to claim accrued yield (mirrors AbstractToken.sol:57)
+        address yieldClaimer;
+        /// @notice Address awaiting timelock to become the new yield claimer (AbstractToken.sol:59)
+        address pendingYieldClaimer;
+        /// @notice Timestamp after which the pending yield claimer can be finalized (AbstractToken.sol:61)
+        uint256 pendingFinishedAt;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.AbstractStakePool")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant ABSTRACT_STAKE_POOL_STORAGE =
+        0xa22a978ee2696d2efc2332b8f51ba192878a27319b07ef0b6ab02074b8399d00;
+
+    function _getAbstractStakePoolStorage() internal pure returns (AbstractStakePoolStorage storage $) {
+        assembly {
+            $.slot := ABSTRACT_STAKE_POOL_STORAGE
+        }
+    }
+
+    // ============ Yield Split Storage (mirrors AbstractToken.sol:77-111) ============
+
+    /// @notice Basis-points denominator for yield splits (100% = 10,000)
+    uint256 public constant YIELD_SPLIT_BPS = 10_000;
+
+    /// @dev Precision scale for the yield-per-token accumulator (AbstractToken.sol:82).
+    ///      High enough that the truncation lost per accrual (supply / YIELD_PRECISION wei)
+    ///      stays sub-wei for any realistic supply; any dust lands in the donated pool.
+    uint256 private constant YIELD_PRECISION = 1e27;
+
+    /// @custom:storage-location erc7201:crowdstake.storage.PoolYieldSplit
+    struct YieldSplitStorage {
+        uint256 accYieldPerToken;
+        uint256 accountedYield;
+        uint256 keepWeight;
+        uint256 keepWeightIndex;
+        uint256 keptYieldTotal;
+        mapping(address => uint16) keepBps;
+        mapping(address => uint256) index;
+        mapping(address => uint256) keptYield;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.PoolYieldSplit")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant POOL_YIELD_SPLIT_STORAGE =
+        0x644cf6815b2c79b6f21aa4ac6f2dcbb99137bf5f81d0e31beac1dbf7bec76e00;
+
+    function _getYieldSplitStorage() internal pure returns (YieldSplitStorage storage $) {
+        assembly {
+            $.slot := POOL_YIELD_SPLIT_STORAGE
+        }
+    }
+
+    // ============ Events ============
+
+    /// @notice Emitted when a deposit is recorded in the ledger. NO ERC-20 Transfer event is
+    ///         emitted — that omission is what keeps the pool invisible to wallets/explorers.
+    event Deposited(address indexed receiver, uint256 amount);
+    /// @notice Emitted when a withdrawal is recorded and the underlying is remitted.
+    event Withdrawn(address indexed receiver, uint256 amount);
+    /// @notice Emitted when the yield claimer is set or updated (AbstractToken.sol:151)
+    event YieldClaimerSet(address yieldClaimer);
+    /// @notice Emitted when a new pending yield claimer is proposed (AbstractToken.sol:153)
+    event PendingYieldClaimerSet(address yieldClaimer);
+    /// @notice Emitted when donated yield is claimed (AbstractToken.sol:155)
+    event ClaimedYield(uint256 amount);
+    /// @notice Emitted when a holder updates their yield split (AbstractToken.sol:157)
+    event YieldSplitSet(address indexed account, uint16 keepBps);
+    /// @notice Emitted when a holder claims their kept yield (AbstractToken.sol:159)
+    event KeptYieldClaimed(address indexed account, address receiver, uint256 amount);
+
+    // ============ Initialization ============
+
+    /// @dev Sets the instance name + owner. Concrete pools call this from their initializer.
+    // solhint-disable-next-line func-name-mixedcase
+    function __AbstractStakePool_init(string memory name_, address owner_) internal onlyInitializing {
+        __Ownable_init(owner_);
+        _getAbstractStakePoolStorage().name = name_;
+    }
+
+    // ============ Ledger reads (the token's consumed surface, minus token semantics) ============
+
+    /// @notice Ledger balance of an account
+    function balanceOf(address account_) public view returns (uint256) {
+        return _getAbstractStakePoolStorage().balanceOf[account_];
+    }
+
+    /// @notice Total ledger supply
+    function totalSupply() public view returns (uint256) {
+        return _getAbstractStakePoolStorage().totalSupply;
+    }
+
+    /// @notice Instance name (the token's name() analogue)
+    function name() external view returns (string memory) {
+        return _getAbstractStakePoolStorage().name;
+    }
+
+    /// @notice The UNDERLYING asset's symbol (e.g. WXDAI/USDC). MUST implement in derived.
+    /// @dev Deliberately the underlying's symbol, not a synthetic one: the pool is not a token,
+    ///      so surfaces that read symbol() label it by what was actually deposited.
+    function symbol() external view virtual returns (string memory);
+
+    /// @notice Decimals of the underlying asset. MUST implement in derived.
+    function decimals() external view virtual returns (uint8);
+
+    /// @notice Feature probe used by the frontend to detect pool (vs token) mode. Always true.
+    function isPool() external pure returns (bool) {
+        return true;
+    }
+
+    // ============ Deposit / Withdraw (signatures IDENTICAL to AbstractToken.sol:197/207/218) ============
+
+    /// @notice Records a deposit of `amount_` of collateral for `receiver_` (ERC20 path).
+    /// @dev Signature matches AbstractToken.mint(address,uint256) at AbstractToken.sol:197.
+    function mint(address receiver_, uint256 amount_) external virtual {
+        if (amount_ == 0) revert MintZero();
+        _depositLedger(receiver_, amount_);
+        _deposit(amount_);
+    }
+
+    /// @notice Records a deposit of native ETH for `receiver_` (native path).
+    /// @dev Signature matches AbstractToken.mint(address) at AbstractToken.sol:207.
+    function mint(address receiver_) external payable virtual {
+        if (msg.value == 0) revert MintZero();
+        _depositLedger(receiver_, msg.value);
+        _depositNative(msg.value);
+    }
+
+    /// @notice Burns `amount_` of the caller's ledger balance and remits the underlying to `receiver_`.
+    /// @dev Signature matches AbstractToken.burn(uint256,address) at AbstractToken.sol:218.
+    function burn(uint256 amount_, address receiver_) external virtual {
+        if (amount_ == 0) revert BurnZero();
+        _withdrawLedger(msg.sender, amount_);
+        _remit(receiver_, amount_);
+        emit Withdrawn(receiver_, amount_);
+    }
+
+    // ============ Yield module surface (consumed by BaseDistributionManager) ============
+
+    /// @notice Unclaimed donated yield — the pool the yield claimer can distribute (AbstractToken.sol:368).
+    function yieldAccrued() external view returns (uint256) {
+        return _donatedYieldAccrued();
+    }
+
+    /// @notice Total unclaimed vault surplus: donated pool plus all kept shares (AbstractToken.sol:373).
+    function totalYieldAccrued() external view returns (uint256) {
+        return _yieldAccrued();
+    }
+
+    /// @notice Claims accrued donated yield and remits the UNDERLYING to the receiver.
+    /// @dev Mirrors AbstractToken.claimYield (AbstractToken.sol:232) but pays the underlying by
+    ///      redeeming from the vault instead of minting pool balance. Only the donated portion is
+    ///      claimable here; holders' kept shares stay reserved for them.
+    function claimYield(uint256 amount_, address receiver_) external virtual {
+        AbstractStakePoolStorage storage $ = _getAbstractStakePoolStorage();
+        if (msg.sender != $.yieldClaimer) revert OnlyClaimer();
+        if (amount_ == 0) revert ClaimZero();
+        _accrueGlobalYield();
+        uint256 yield = _donatedYieldAccrued();
+        if (yield == 0) revert YieldInsufficient();
+        if (yield < amount_) revert YieldInsufficient();
+
+        // Redeem the underlying from the vault to the receiver (vs. AbstractToken minting).
+        _claimUnderlying(receiver_, amount_);
+        // The claim consumed vault surplus; keep the high-water mark in sync (AbstractToken.sol:244).
+        _getYieldSplitStorage().accountedYield -= amount_;
+
+        emit ClaimedYield(amount_);
+    }
+
+    // ============ Yield Split (mirrors AbstractToken.sol:254-306) ============
+
+    /// @notice Sets the caller's yield split (AbstractToken.sol:254). Settlement point.
+    function setYieldSplit(uint16 keepBps_) external {
+        if (keepBps_ > YIELD_SPLIT_BPS) revert InvalidYieldSplit();
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        _accrueGlobalYield();
+        _settleAndDetach(msg.sender);
+        // Re-baseline so only yield accrued after this change uses the new split.
+        $.index[msg.sender] = $.accYieldPerToken;
+        $.keepBps[msg.sender] = keepBps_;
+        _attach(msg.sender);
+
+        emit YieldSplitSet(msg.sender, keepBps_);
+    }
+
+    /// @notice The share of their yield an account keeps, in bps (AbstractToken.sol:268).
+    function yieldSplitOf(address account_) external view returns (uint16) {
+        return _getYieldSplitStorage().keepBps[account_];
+    }
+
+    /// @notice An account's kept yield: settled balance plus unsettled share (AbstractToken.sol:273).
+    function keptYieldOf(address account_) external view returns (uint256) {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 kept = $.keptYield[account_];
+        uint256 bps = $.keepBps[account_];
+        if (bps == 0) return kept;
+        uint256 acc = _simulatedAccYieldPerToken();
+        uint256 idx = $.index[account_];
+        if (acc > idx) {
+            kept += balanceOf(account_) * (acc - idx) / YIELD_PRECISION * bps / YIELD_SPLIT_BPS;
+        }
+        return kept;
+    }
+
+    /// @notice Claims the caller's kept yield, remitting the UNDERLYING to `receiver_`.
+    /// @dev Mirrors AbstractToken.claimKeptYield (AbstractToken.sol:288) but pays the underlying
+    ///      by redeeming from the vault instead of minting pool balance. Settlement point.
+    function claimKeptYield(address receiver_) external {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        _accrueGlobalYield();
+        _settleAndDetach(msg.sender);
+        _attach(msg.sender);
+
+        uint256 amount = $.keptYield[msg.sender];
+        if (amount == 0) revert ClaimZero();
+        if (_yieldAccrued() < amount) revert YieldInsufficient();
+        $.keptYield[msg.sender] = 0;
+        $.keptYieldTotal -= amount;
+
+        _claimUnderlying(receiver_, amount);
+        // The claim consumed vault surplus; keep the high-water mark in sync (AbstractToken.sol:303).
+        $.accountedYield -= amount;
+
+        emit KeptYieldClaimed(msg.sender, receiver_, amount);
+    }
+
+    // ============ Yield claimer role + timelock (mirrors AbstractToken.sol:311-345) ============
+
+    /// @notice Current yield claimer address
+    function yieldClaimer() public view returns (address) {
+        return _getAbstractStakePoolStorage().yieldClaimer;
+    }
+
+    /// @notice Address awaiting timelock to become the new yield claimer
+    function pendingYieldClaimer() public view returns (address) {
+        return _getAbstractStakePoolStorage().pendingYieldClaimer;
+    }
+
+    /// @notice Timestamp after which the pending yield claimer can be finalized
+    function pendingFinishedAt() public view returns (uint256) {
+        return _getAbstractStakePoolStorage().pendingFinishedAt;
+    }
+
+    /// @notice Sets the initial yield claimer address (one-time only) (AbstractToken.sol:311).
+    function setYieldClaimer(address yieldClaimer_) external onlyOwner {
+        AbstractStakePoolStorage storage $ = _getAbstractStakePoolStorage();
+        if (yieldClaimer_ == address(0)) revert ZeroAddress();
+        if ($.yieldClaimer != address(0)) revert AlreadySetClaimer();
+        $.yieldClaimer = yieldClaimer_;
+
+        emit YieldClaimerSet(yieldClaimer_);
+    }
+
+    /// @notice Initiates a 14-day timelock to rotate the yield claimer (AbstractToken.sol:323).
+    function prepareNewYieldClaimer(address _newYieldClaimer) external onlyOwner {
+        AbstractStakePoolStorage storage $ = _getAbstractStakePoolStorage();
+        if (_newYieldClaimer == address(0)) revert ZeroAddress();
+        if ($.yieldClaimer == _newYieldClaimer) revert SameClaimer();
+        if ($.pendingFinishedAt > 0) revert PendingClaimer();
+        $.pendingYieldClaimer = _newYieldClaimer;
+        $.pendingFinishedAt = block.timestamp + 14 days;
+
+        emit PendingYieldClaimerSet(_newYieldClaimer);
+    }
+
+    /// @notice Finalizes the pending yield claimer after the 14-day timelock (AbstractToken.sol:336).
+    function finalizeNewYieldClaimer() external {
+        AbstractStakePoolStorage storage $ = _getAbstractStakePoolStorage();
+        if ($.pendingFinishedAt == 0) revert NoPendingClaimer();
+        if (block.timestamp < $.pendingFinishedAt) revert TimelockNotElapsed();
+        $.yieldClaimer = $.pendingYieldClaimer;
+        $.pendingYieldClaimer = address(0);
+        $.pendingFinishedAt = 0;
+
+        emit YieldClaimerSet($.yieldClaimer);
+    }
+
+    // ============ Voting power: IVotesCheckpoints over the ledger ============
+
+    /// @notice Number of voting checkpoints for `account` (mirrors ERC20Votes numCheckpoints).
+    /// @dev The only checkpoint accessor TimeWeightedVotingPower calls at runtime
+    ///      (TimeWeightedVotingPower.sol:90) besides {checkpoints}.
+    function numCheckpoints(address account) external view returns (uint32) {
+        return SafeCast.toUint32(_getAbstractStakePoolStorage().checkpoints[account].length());
+    }
+
+    /// @notice The `pos`-th voting checkpoint for `account` (block.number => balance).
+    /// @dev Matches ERC20Votes' shape so the existing strategy walks it unchanged
+    ///      (TimeWeightedVotingPower.sol:98).
+    function checkpoints(address account, uint32 pos) external view returns (Checkpoints.Checkpoint208 memory) {
+        return _getAbstractStakePoolStorage().checkpoints[account].at(pos);
+    }
+
+    /// @notice Current voting weight = ledger balance (holders are auto self-delegated).
+    function getVotes(address account) external view returns (uint256) {
+        return _getAbstractStakePoolStorage().checkpoints[account].latest();
+    }
+
+    /// @notice Historical voting weight at a past block (upper-lookup on the checkpoint trace).
+    function getPastVotes(address account, uint256 timepoint) external view returns (uint256) {
+        if (timepoint >= block.number) revert("future lookup");
+        return _getAbstractStakePoolStorage().checkpoints[account].upperLookup(SafeCast.toUint48(timepoint));
+    }
+
+    /// @notice Past total supply is not checkpointed; the strategy never calls it. Reverts.
+    function getPastTotalSupply(uint256) external pure returns (uint256) {
+        revert("unsupported");
+    }
+
+    /// @notice Every holder is auto self-delegated; delegation is fixed to `account`.
+    function delegates(address account) external pure returns (address) {
+        return account;
+    }
+
+    /// @notice Delegation is fixed (auto self-delegation); explicit delegation is a no-op-revert.
+    function delegate(address) external pure {
+        revert("delegation fixed");
+    }
+
+    /// @notice Delegation is fixed (auto self-delegation); signed delegation is unsupported.
+    function delegateBySig(address, uint256, uint256, uint8, bytes32, bytes32) external pure {
+        revert("delegation fixed");
+    }
+
+    // ============ Ledger internals ============
+
+    /// @dev Credits `receiver_` and checkpoints their new balance. Settlement point around the
+    ///      balance change (mirrors AbstractToken._update at AbstractToken.sol:456).
+    function _depositLedger(address receiver_, uint256 amount_) internal {
+        if (receiver_ == address(0)) revert ZeroAddress();
+        AbstractStakePoolStorage storage $ = _getAbstractStakePoolStorage();
+
+        _accrueGlobalYield();
+        _settleAndDetach(receiver_);
+
+        $.balanceOf[receiver_] += amount_;
+        $.totalSupply += amount_;
+        _writeCheckpoint(receiver_, $.balanceOf[receiver_]);
+
+        _attach(receiver_);
+
+        emit Deposited(receiver_, amount_);
+    }
+
+    /// @dev Debits `from_` and checkpoints their new balance. Settlement point around the change.
+    function _withdrawLedger(address from_, uint256 amount_) internal {
+        AbstractStakePoolStorage storage $ = _getAbstractStakePoolStorage();
+        if ($.balanceOf[from_] < amount_) revert InsufficientBalance();
+
+        _accrueGlobalYield();
+        _settleAndDetach(from_);
+
+        $.balanceOf[from_] -= amount_;
+        $.totalSupply -= amount_;
+        _writeCheckpoint(from_, $.balanceOf[from_]);
+
+        _attach(from_);
+    }
+
+    /// @dev Pushes a (block.number, balance) checkpoint. Same shape ERC20Votes writes on delegate
+    ///      vote moves, so the strategy reads it identically. Repeated writes in one block
+    ///      overwrite the current block's entry (OZ Checkpoints._insert semantics).
+    function _writeCheckpoint(address account, uint256 balance) private {
+        _getAbstractStakePoolStorage()
+        .checkpoints[account].push(SafeCast.toUint48(block.number), SafeCast.toUint208(balance));
+    }
+
+    // ============ Yield Split Internals (ported verbatim from AbstractToken.sol:381-452) ============
+
+    /// @dev Attributes fresh vault surplus to current holders via the accumulator (AbstractToken.sol:381).
+    function _accrueGlobalYield() internal {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 raw = _yieldAccrued();
+        uint256 accounted = $.accountedYield;
+        if (raw <= accounted) return;
+        uint256 supply = totalSupply();
+        if (supply > 0) {
+            $.accYieldPerToken += (raw - accounted) * YIELD_PRECISION / supply;
+        }
+        $.accountedYield = raw;
+    }
+
+    /// @dev The accumulator as if _accrueGlobalYield ran now (AbstractToken.sol:395).
+    function _simulatedAccYieldPerToken() private view returns (uint256 acc) {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        acc = $.accYieldPerToken;
+        uint256 raw = _yieldAccrued();
+        uint256 accounted = $.accountedYield;
+        uint256 supply = totalSupply();
+        if (raw > accounted && supply > 0) {
+            acc += (raw - accounted) * YIELD_PRECISION / supply;
+        }
+    }
+
+    /// @dev Vault surplus minus every holder's kept share (AbstractToken.sol:409).
+    function _donatedYieldAccrued() private view returns (uint256) {
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 raw = _yieldAccrued();
+        uint256 unsettledKept =
+            (_simulatedAccYieldPerToken() * $.keepWeight - $.keepWeightIndex) / YIELD_PRECISION / YIELD_SPLIT_BPS;
+        uint256 reserved = $.keptYieldTotal + unsettledKept;
+        return raw > reserved ? raw - reserved : 0;
+    }
+
+    /// @dev Credits pending kept yield and removes the account from the aggregates (AbstractToken.sol:421).
+    function _settleAndDetach(address account_) internal {
+        if (account_ == address(0)) return;
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 bps = $.keepBps[account_];
+        if (bps == 0) return;
+        uint256 balance = balanceOf(account_);
+        uint256 acc = $.accYieldPerToken;
+        uint256 idx = $.index[account_];
+        if (acc > idx) {
+            uint256 kept = balance * (acc - idx) / YIELD_PRECISION * bps / YIELD_SPLIT_BPS;
+            if (kept > 0) {
+                $.keptYield[account_] += kept;
+                $.keptYieldTotal += kept;
+            }
+        }
+        uint256 weight = balance * bps;
+        $.keepWeight -= weight;
+        $.keepWeightIndex -= weight * idx;
+        $.index[account_] = acc;
+    }
+
+    /// @dev Adds the account's current balance/split terms to the aggregates (AbstractToken.sol:444).
+    function _attach(address account_) internal {
+        if (account_ == address(0)) return;
+        YieldSplitStorage storage $ = _getYieldSplitStorage();
+        uint256 bps = $.keepBps[account_];
+        if (bps == 0) return;
+        uint256 weight = balanceOf(account_) * bps;
+        $.keepWeight += weight;
+        $.keepWeightIndex += weight * $.index[account_];
+    }
+
+    // ============ Hooks the concrete pool must implement (mirror the token's) ============
+
+    /// @dev Deposit user collateral into the yield-bearing position (mirrors AbstractToken._deposit).
+    function _deposit(uint256 amount_) internal virtual;
+
+    /// @dev Deposit native collateral into the yield-bearing position (mirrors AbstractToken._depositNative).
+    function _depositNative(
+        uint256 /*amount_*/
+    )
+        internal
+        virtual
+    {
+        revert("native deposits not supported");
+    }
+
+    /// @dev Remit collateral value to a withdrawing user (mirrors AbstractToken._remit).
+    function _remit(address receiver_, uint256 amount_) internal virtual;
+
+    /// @dev Redeem `amount_` of the UNDERLYING from the vault to `receiver_`. This is the pool's
+    ///      replacement for the token's yield-claim mint: claimYield/claimKeptYield pay the real
+    ///      asset. Typically identical to _remit (redeem from the vault), but named separately so
+    ///      implementations can distinguish principal withdrawals from yield claims if needed.
+    function _claimUnderlying(address receiver_, uint256 amount_) internal virtual;
+
+    /// @dev Unclaimed accrued yield = vault-backed assets minus ledger supply (mirrors AbstractToken._yieldAccrued).
+    function _yieldAccrued() internal view virtual returns (uint256);
+
+    /// @dev Transfers native ETH, reverts on failure (AbstractToken.sol:474).
+    function _nativeTransfer(address to_, uint256 amount_) internal {
+        bool success;
+        assembly {
+            success := call(gas(), to_, amount_, 0, 0, 0, 0)
+        }
+        if (!success) revert NativeTransferFailed();
+    }
+}

--- a/contracts/src/implementation/pool/PoolNativeYield.sol
+++ b/contracts/src/implementation/pool/PoolNativeYield.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IWXDAI} from "../../interfaces/IWXDAI.sol";
+import {ISXDAI} from "../../interfaces/ISXDAI.sol";
+import {AbstractStakePool} from "./AbstractStakePool.sol";
+
+/// @title PoolNativeYield
+/// @notice Tokenless "pool mode" counterpart of {SexyDaiYield}: native xDAI → wxDAI → sDAI.
+/// @dev Structurally mirrors SexyDaiYield's deposit/remit/yield logic (deposit native, wrap to
+///      wxDAI, park in the sDAI ERC-4626 vault) but records ledger entries instead of minting a
+///      token. Principal withdrawals ({burn}) unwrap all the way back to native xDAI, exactly as
+///      SexyDaiYield does. Yield claims ({claimYield}/{claimKeptYield}) instead pay the UNDERLYING
+///      ERC-20 (wxDAI): in pool mode the deployer wires the DistributionManager's baseToken =
+///      wxDAI, so distributions move the real wrapped-native asset to recipients.
+contract PoolNativeYield is AbstractStakePool {
+    using SafeERC20 for IERC20;
+
+    error IsCollateral();
+
+    IWXDAI public immutable WX_DAI;
+    ISXDAI public immutable SEXY_DAI;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address _wxDai, address _sexyDai) {
+        WX_DAI = IWXDAI(_wxDai);
+        SEXY_DAI = ISXDAI(_sexyDai);
+        _disableInitializers();
+    }
+
+    function initialize(
+        string memory name_,
+        string memory,
+        /*symbol_ ignored: uses underlying's*/
+        address owner_
+    )
+        external
+        initializer
+    {
+        __AbstractStakePool_init(name_, owner_);
+    }
+
+    /// @dev The pool reports the UNDERLYING (wxDAI) symbol — it is not its own token.
+    function symbol() external view override returns (string memory) {
+        return IERC20Metadata(address(WX_DAI)).symbol();
+    }
+
+    /// @dev The pool reports the UNDERLYING (wxDAI) decimals.
+    function decimals() external view override returns (uint8) {
+        return IERC20Metadata(address(WX_DAI)).decimals();
+    }
+
+    /// @dev Pull wxDAI from the depositor and route it into the sDAI vault (mirrors SexyDaiYield._deposit).
+    function _deposit(uint256 amount_) internal override {
+        IERC20(address(WX_DAI)).safeTransferFrom(msg.sender, address(this), amount_);
+        IERC20(address(WX_DAI)).safeIncreaseAllowance(address(SEXY_DAI), amount_);
+        SEXY_DAI.deposit(amount_, address(this));
+    }
+
+    /// @dev Wrap native xDAI to wxDAI then park in the sDAI vault (mirrors SexyDaiYield._depositNative).
+    function _depositNative(uint256 amount_) internal override {
+        WX_DAI.deposit{value: amount_}();
+        IERC20(address(WX_DAI)).safeIncreaseAllowance(address(SEXY_DAI), amount_);
+        SEXY_DAI.deposit(amount_, address(this));
+    }
+
+    /// @dev Principal withdrawal: redeem sDAI → wxDAI → native xDAI and forward (mirrors SexyDaiYield._remit).
+    function _remit(address receiver_, uint256 amount_) internal override {
+        SEXY_DAI.withdraw(amount_, address(this), address(this));
+        WX_DAI.withdraw(amount_);
+        _nativeTransfer(receiver_, amount_);
+    }
+
+    /// @dev Yield claim: redeem sDAI → wxDAI and transfer the UNDERLYING ERC-20 (wxDAI) to the
+    ///      receiver. Unlike _remit this does NOT unwrap to native, because the DistributionManager's
+    ///      baseToken is wxDAI and distributions move that ERC-20 to recipients.
+    function _claimUnderlying(address receiver_, uint256 amount_) internal override {
+        SEXY_DAI.withdraw(amount_, address(this), address(this));
+        IERC20(address(WX_DAI)).safeTransfer(receiver_, amount_);
+    }
+
+    /// @notice Accept native xDAI unwrapped by WXDAI.withdraw during principal withdrawals.
+    receive() external payable {}
+
+    /// @dev Vault-backed surplus over ledger supply (mirrors SexyDaiYield._yieldAccrued).
+    function _yieldAccrued() internal view override returns (uint256) {
+        uint256 bal = IERC20(address(SEXY_DAI)).balanceOf(address(this));
+        uint256 assets = SEXY_DAI.convertToAssets(bal);
+        uint256 supply = totalSupply();
+        return assets > supply ? assets - supply : 0;
+    }
+
+    /// @notice The underlying asset paid out on yield claims (the wrapped-native, wxDAI).
+    /// @dev The deployer reads this to wire the DistributionManager's baseToken in pool mode.
+    function underlyingAsset() external view returns (address) {
+        return address(WX_DAI);
+    }
+
+    /// @notice Rescue tokens accidentally sent here — never the vault collateral.
+    function rescueToken(address tok_, uint256 amount_) external onlyOwner {
+        if (tok_ == address(SEXY_DAI)) revert IsCollateral();
+        IERC20(tok_).safeTransfer(owner(), amount_);
+    }
+}

--- a/contracts/src/implementation/pool/PoolNativeYield.sol
+++ b/contracts/src/implementation/pool/PoolNativeYield.sol
@@ -53,6 +53,10 @@ contract PoolNativeYield is AbstractStakePool {
     }
 
     /// @dev Pull wxDAI from the depositor and route it into the sDAI vault (mirrors SexyDaiYield._deposit).
+    /// @dev Fee-on-transfer underlyings are UNSUPPORTED (same as the token path): the ledger credits
+    ///      `amount_`, but a transfer-fee asset would deposit less than `amount_` into the vault, so
+    ///      the ledger supply would over-count the backing. wxDAI is a plain 1:1 wrapper, so this
+    ///      holds; do not repoint this pool at a fee-charging wrapped-native token.
     function _deposit(uint256 amount_) internal override {
         IERC20(address(WX_DAI)).safeTransferFrom(msg.sender, address(this), amount_);
         IERC20(address(WX_DAI)).safeIncreaseAllowance(address(SEXY_DAI), amount_);

--- a/contracts/src/implementation/pool/PoolStableYield.sol
+++ b/contracts/src/implementation/pool/PoolStableYield.sol
@@ -57,6 +57,9 @@ contract PoolStableYield is AbstractStakePool {
     }
 
     /// @dev Pull the stablecoin from the depositor and route it into the vault (mirrors StableYield._deposit).
+    /// @dev Fee-on-transfer underlyings are UNSUPPORTED (same as the token path): the ledger credits
+    ///      `amount_`, but a transfer-fee asset would deposit less than `amount_` into the vault, so
+    ///      the ledger supply would over-count the backing. Only use plain-transfer underlyings.
     function _deposit(uint256 amount_) internal override {
         ASSET.safeTransferFrom(msg.sender, address(this), amount_);
         ASSET.safeIncreaseAllowance(address(YIELD_VAULT), amount_);

--- a/contracts/src/implementation/pool/PoolStableYield.sol
+++ b/contracts/src/implementation/pool/PoolStableYield.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IERC4626Yield} from "../../interfaces/IERC4626Yield.sol";
+import {AbstractStakePool} from "./AbstractStakePool.sol";
+
+/// @title PoolStableYield
+/// @notice Tokenless "pool mode" counterpart of {StableYield}: an ERC-20 stablecoin (e.g. USDC)
+///         parked in an ERC-4626 savings vault, recorded as ledger entries with no token issued.
+/// @dev Structurally mirrors StableYield: no native path (you can't turn native currency into a
+///      stablecoin here), decimals mirror the underlying, and `vault.asset() == ASSET` is enforced
+///      in the constructor. Principal withdrawals and yield claims BOTH pay the underlying
+///      stablecoin, so _remit and _claimUnderlying are the same redeem-to-receiver operation. In
+///      pool mode the deployer wires the DistributionManager's baseToken = the stablecoin.
+contract PoolStableYield is AbstractStakePool {
+    using SafeERC20 for IERC20;
+
+    error IsCollateral();
+    error VaultAssetMismatch();
+    error NativeNotSupported();
+
+    IERC20 public immutable ASSET;
+    IERC4626Yield public immutable YIELD_VAULT;
+    uint8 private immutable _underlyingDecimals;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address _asset, address _yieldVault) {
+        if (IERC4626Yield(_yieldVault).asset() != _asset) revert VaultAssetMismatch();
+        ASSET = IERC20(_asset);
+        YIELD_VAULT = IERC4626Yield(_yieldVault);
+        _underlyingDecimals = IERC20Metadata(_asset).decimals();
+        _disableInitializers();
+    }
+
+    function initialize(
+        string memory name_,
+        string memory,
+        /*symbol_ ignored: uses underlying's*/
+        address owner_
+    )
+        external
+        initializer
+    {
+        __AbstractStakePool_init(name_, owner_);
+    }
+
+    /// @dev The pool reports the UNDERLYING stablecoin's symbol — it is not its own token.
+    function symbol() external view override returns (string memory) {
+        return IERC20Metadata(address(ASSET)).symbol();
+    }
+
+    /// @dev Mirror the stablecoin's decimals (e.g. 6 for USDC) so the ledger stays in its units.
+    function decimals() external view override returns (uint8) {
+        return _underlyingDecimals;
+    }
+
+    /// @dev Pull the stablecoin from the depositor and route it into the vault (mirrors StableYield._deposit).
+    function _deposit(uint256 amount_) internal override {
+        ASSET.safeTransferFrom(msg.sender, address(this), amount_);
+        ASSET.safeIncreaseAllowance(address(YIELD_VAULT), amount_);
+        YIELD_VAULT.deposit(amount_, address(this));
+    }
+
+    /// @dev No native path (mirrors StableYield._depositNative).
+    function _depositNative(uint256) internal pure override {
+        revert NativeNotSupported();
+    }
+
+    /// @dev Principal withdrawal: redeem the stablecoin from the vault to the redeemer (StableYield._remit).
+    function _remit(address receiver_, uint256 amount_) internal override {
+        YIELD_VAULT.withdraw(amount_, receiver_, address(this));
+    }
+
+    /// @dev Yield claim: same redeem-to-receiver as _remit — the underlying is the stablecoin, which
+    ///      is exactly what the DistributionManager's baseToken is wired to in pool mode.
+    function _claimUnderlying(address receiver_, uint256 amount_) internal override {
+        YIELD_VAULT.withdraw(amount_, receiver_, address(this));
+    }
+
+    /// @dev Vault-backed surplus over ledger supply (mirrors StableYield._yieldAccrued).
+    function _yieldAccrued() internal view override returns (uint256) {
+        uint256 shares = IERC20(address(YIELD_VAULT)).balanceOf(address(this));
+        uint256 assets = YIELD_VAULT.convertToAssets(shares);
+        uint256 supply = totalSupply();
+        return assets > supply ? assets - supply : 0;
+    }
+
+    /// @notice The underlying asset paid out on yield claims and principal withdrawals.
+    /// @dev The deployer reads this to wire the DistributionManager's baseToken in pool mode.
+    function underlyingAsset() external view returns (address) {
+        return address(ASSET);
+    }
+
+    /// @notice Rescue tokens accidentally sent here — never the vault collateral.
+    function rescueToken(address tok_, uint256 amount_) external onlyOwner {
+        if (tok_ == address(YIELD_VAULT)) revert IsCollateral();
+        IERC20(tok_).safeTransfer(owner(), amount_);
+    }
+}

--- a/contracts/src/interfaces/IStakePool.sol
+++ b/contracts/src/interfaces/IStakePool.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title IStakePool
+/// @notice The surface a tokenless "pool mode" instance exposes. It is ABI-compatible with the
+///         parts of the token that the rest of the system consumes (deposit/withdraw, the yield
+///         module, the yield split, the yield-claimer role) WITHOUT being an ERC-20: there is no
+///         transfer/approve/allowance and no Transfer event, which is what keeps a pool invisible
+///         to wallets and explorers as a token.
+/// @dev Deposit/withdraw signatures are IDENTICAL to AbstractToken (mint/burn at
+///      AbstractToken.sol:197/207/218) so the same deploy wiring and frontend entrypoints work.
+///      Voting power is exposed separately via {IVotesCheckpoints}, which the pool also implements.
+interface IStakePool {
+    // ---- Ledger reads ----
+    function balanceOf(address account) external view returns (uint256);
+    function totalSupply() external view returns (uint256);
+    function name() external view returns (string memory);
+    /// @notice The UNDERLYING asset's symbol (e.g. WXDAI/USDC) — the pool is not its own token.
+    function symbol() external view returns (string memory);
+    /// @notice Decimals of the underlying asset.
+    function decimals() external view returns (uint8);
+    /// @notice Feature probe: always true. Lets the frontend detect pool (vs token) mode.
+    function isPool() external pure returns (bool);
+    /// @notice The UNDERLYING asset paid out on yield claims (and principal withdrawals). The
+    ///         deployer reads this to wire the DistributionManager's baseToken in pool mode.
+    function underlyingAsset() external view returns (address);
+
+    // ---- Deposit / withdraw (signatures identical to the token) ----
+    function mint(address receiver) external payable;
+    function mint(address receiver, uint256 amount) external;
+    function burn(uint256 amount, address receiver) external;
+
+    // ---- Yield module (consumed by BaseDistributionManager) ----
+    function yieldAccrued() external view returns (uint256);
+    function totalYieldAccrued() external view returns (uint256);
+    /// @notice Claims donated yield, paying the UNDERLYING asset (redeemed from the vault).
+    function claimYield(uint256 amount, address receiver) external;
+
+    // ---- Yield claimer role + timelocked rotation ----
+    function yieldClaimer() external view returns (address);
+    function setYieldClaimer(address yieldClaimer) external;
+    function prepareNewYieldClaimer(address yieldClaimer) external;
+    function finalizeNewYieldClaimer() external;
+
+    // ---- Per-holder yield split ----
+    function setYieldSplit(uint16 keepBps) external;
+    function yieldSplitOf(address account) external view returns (uint16);
+    function keptYieldOf(address account) external view returns (uint256);
+    /// @notice Claims the caller's kept yield, paying the UNDERLYING asset (redeemed from the vault).
+    function claimKeptYield(address receiver) external;
+}

--- a/contracts/test/CrowdStakeDeployer.t.sol
+++ b/contracts/test/CrowdStakeDeployer.t.sol
@@ -17,7 +17,9 @@ import {EqualDistributionStrategy} from "../src/implementation/strategies/EqualD
 import {AdminRecipientRegistry} from "../src/implementation/registries/AdminRecipientRegistry.sol";
 import {VotingRecipientRegistry} from "../src/implementation/registries/VotingRecipientRegistry.sol";
 import {SexyDaiYield} from "../src/implementation/token/SexyDaiYield.sol";
+import {PoolNativeYield} from "../src/implementation/pool/PoolNativeYield.sol";
 import {AbstractToken} from "../src/abstract/AbstractToken.sol";
+import {IStakePool} from "../src/interfaces/IStakePool.sol";
 
 interface IOwnable {
     function owner() external view returns (address);
@@ -47,6 +49,7 @@ contract CrowdStakeDeployerTest is Test {
         address votingRegistryBeacon =
             address(new UpgradeableBeacon(address(new VotingRecipientRegistry()), address(this)));
         address tokenBeacon = address(new UpgradeableBeacon(address(new SexyDaiYield(WXDAI, SXDAI)), address(this)));
+        address poolBeacon = address(new UpgradeableBeacon(address(new PoolNativeYield(WXDAI, SXDAI)), address(this)));
         address distBeacon = address(new UpgradeableBeacon(address(new BaseDistributionManager()), address(this)));
         address multiDistBeacon =
             address(new UpgradeableBeacon(address(new MultiStrategyDistributionManager()), address(this)));
@@ -55,16 +58,17 @@ contract CrowdStakeDeployerTest is Test {
             address(new UpgradeableBeacon(address(new EqualDistributionStrategy()), address(this)));
         address votingBeacon = address(new UpgradeableBeacon(address(new BasisPointsVotingModule()), address(this)));
 
-        address[] memory beacons = new address[](9);
+        address[] memory beacons = new address[](10);
         beacons[0] = cycleBeacon;
         beacons[1] = registryBeacon;
         beacons[2] = votingRegistryBeacon;
         beacons[3] = tokenBeacon;
-        beacons[4] = distBeacon;
-        beacons[5] = multiDistBeacon;
-        beacons[6] = stratBeacon;
-        beacons[7] = equalStratBeacon;
-        beacons[8] = votingBeacon;
+        beacons[4] = poolBeacon;
+        beacons[5] = distBeacon;
+        beacons[6] = multiDistBeacon;
+        beacons[7] = stratBeacon;
+        beacons[8] = equalStratBeacon;
+        beacons[9] = votingBeacon;
         factory.allowlistBeacons(beacons);
 
         deployer = new CrowdStakeDeployer(
@@ -73,6 +77,7 @@ contract CrowdStakeDeployerTest is Test {
             registryBeacon,
             votingRegistryBeacon,
             tokenBeacon,
+            poolBeacon,
             distBeacon,
             multiDistBeacon,
             stratBeacon,
@@ -95,7 +100,8 @@ contract CrowdStakeDeployerTest is Test {
             distributionKind: 0, // proportional
             tokenImageURI: "",
             bannerImageURI: "",
-            crossChain: false
+            crossChain: false,
+            issueToken: true // token mode (these shared helpers keep asserting classic token behavior)
         });
     }
 
@@ -117,7 +123,8 @@ contract CrowdStakeDeployerTest is Test {
             distributionKind: 0, // proportional
             tokenImageURI: "",
             bannerImageURI: "",
-            crossChain: false
+            crossChain: false,
+            issueToken: true // token mode (these shared helpers keep asserting classic token behavior)
         });
     }
 
@@ -127,6 +134,116 @@ contract CrowdStakeDeployerTest is Test {
         assertEq(AdminRecipientRegistry(i.registry).getRecipientCount(), 0, "admin starts empty");
         assertEq(AbstractToken(i.token).yieldClaimer(), i.distributionManager, "yieldClaimer wired");
         assertEq(AbstractCycleModule(i.cycleModule).getCurrentCycle(), 1, "cycle #1");
+    }
+
+    // ---- Pool mode (issueToken toggle) ----
+
+    /// @dev supportsPoolMode() is the on-chain capability probe the wizard gates the toggle on.
+    function test_SupportsPoolModeProbe() public view {
+        assertTrue(deployer.supportsPoolMode(), "deployer advertises pool-mode support");
+    }
+
+    /// @dev issueToken=false (the zero-value default) deploys a pool, not a token, and wires the
+    ///      DM's yieldModule = pool while baseToken = the underlying asset.
+    function test_DeploysPoolInstance() public {
+        CrowdStakeDeployer.Params memory p = _adminParams("pool-1");
+        p.issueToken = false; // POOL MODE
+        CrowdStakeDeployer.Instance memory i = deployer.deploy(p);
+
+        assertTrue(IStakePool(i.token).isPool(), "instance.token is a pool");
+        assertEq(IStakePool(i.token).yieldClaimer(), i.distributionManager, "pool yieldClaimer wired");
+        // DM distributes the underlying (WXDAI here), reads yield from the pool.
+        assertEq(address(AbstractDistributionManager(i.distributionManager).baseToken()), WXDAI, "baseToken=underlying");
+        assertEq(
+            address(AbstractDistributionManager(i.distributionManager).yieldModule()), i.token, "yieldModule=the pool"
+        );
+        assertEq(IOwnable(i.token).owner(), OWNER, "pool handed to final owner");
+    }
+
+    /// @dev The default Params.issueToken zero-value is pool mode.
+    function test_DefaultIssueTokenZeroValueIsPoolMode() public {
+        // Build params WITHOUT touching issueToken → it defaults to false → pool.
+        CrowdStakeDeployer.Params memory p = CrowdStakeDeployer.Params({
+            owner: OWNER,
+            cycleLength: 100,
+            tokenName: "Default",
+            tokenSymbol: "DFLT",
+            maxVotingPoints: 10_000,
+            salt: "default-mode",
+            registryKind: 0,
+            initialRecipients: new address[](0),
+            proposalExpiry: 0,
+            distributionKind: 0,
+            tokenImageURI: "",
+            bannerImageURI: "",
+            crossChain: false,
+            issueToken: false
+        });
+        CrowdStakeDeployer.Instance memory i = deployer.deploy(p);
+        assertTrue(IStakePool(i.token).isPool(), "zero-value issueToken => pool mode");
+    }
+
+    // ---- Backward-compatible legacy deploy (pinned IPFS frontends) ----
+
+    /// @dev The pre-pool-mode 13-field selector (0xfd759538) still deploys a classic TOKEN instance.
+    ///      Encoded as raw legacy calldata to prove a frozen frontend's bytes still work.
+    function test_LegacySelectorDeploysClassicToken() public {
+        CrowdStakeDeployer.LegacyParams memory legacy = CrowdStakeDeployer.LegacyParams({
+            owner: OWNER,
+            cycleLength: 100,
+            tokenName: "Legacy Stake",
+            tokenSymbol: "LEGA",
+            maxVotingPoints: 10_000,
+            salt: "legacy-1",
+            registryKind: 0,
+            initialRecipients: new address[](0),
+            proposalExpiry: 0,
+            distributionKind: 0,
+            tokenImageURI: "",
+            bannerImageURI: "",
+            crossChain: false
+        });
+
+        // Raw calldata with the OLD selector, as a pinned frontend would ABI-encode it.
+        bytes memory callData = abi.encodeWithSelector(bytes4(0xfd759538), legacy);
+        (bool ok, bytes memory ret) = address(deployer).call(callData);
+        assertTrue(ok, "legacy-selector call succeeds against the new deployer");
+
+        CrowdStakeDeployer.Instance memory i = abi.decode(ret, (CrowdStakeDeployer.Instance));
+        // Classic token: it is NOT a pool (no isPool()), and yieldModule == baseToken == token.
+        (bool isPoolOk,) = i.token.call(abi.encodeWithSignature("isPool()"));
+        assertFalse(isPoolOk, "legacy deploy yields a classic token, not a pool");
+        assertEq(AbstractToken(i.token).yieldClaimer(), i.distributionManager, "token yieldClaimer wired");
+        assertEq(address(AbstractDistributionManager(i.distributionManager).baseToken()), i.token, "baseToken == token");
+    }
+
+    /// @dev The legacy overload must scope the family to the ORIGINAL caller (msg.sender), not the
+    ///      deployer — proving it delegates through the internal body, not `this.deploy`.
+    function test_LegacyCrossChain_ScopedToOriginalCaller() public {
+        CrowdStakeDeployer.LegacyParams memory legacy = CrowdStakeDeployer.LegacyParams({
+            owner: OWNER,
+            cycleLength: 100,
+            tokenName: "Legacy XChain",
+            tokenSymbol: "LGXC",
+            maxVotingPoints: 10_000,
+            salt: "legacy-xchain",
+            registryKind: 0,
+            initialRecipients: new address[](0),
+            proposalExpiry: 0,
+            distributionKind: 0,
+            tokenImageURI: "",
+            bannerImageURI: "",
+            crossChain: true
+        });
+        bytes32 familyId = deployer.familyIdOf(FOUNDER, "legacy-xchain", "Legacy XChain", "LGXC", 10_000, 0, 0);
+
+        vm.prank(FOUNDER);
+        deployer.deploy(legacy);
+
+        // The sibling is recorded under FOUNDER's familyId, not the deployer's.
+        (,,,,,,, address votingModule) = deployer.familyInstances(familyId);
+        assertTrue(votingModule != address(0), "family scoped to the original caller (FOUNDER)");
+        assertEq(BasisPointsVotingModule(votingModule).familyId(), familyId, "module familyId matches caller-scoped id");
     }
 
     function test_DeploysVotingInstance() public {

--- a/contracts/test/CrowdStakeDeployer.t.sol
+++ b/contracts/test/CrowdStakeDeployer.t.sol
@@ -183,6 +183,69 @@ contract CrowdStakeDeployerTest is Test {
         assertTrue(IStakePool(i.token).isPool(), "zero-value issueToken => pool mode");
     }
 
+    // ---- Review S1: the yield module is fixed at DM init; no post-init setter exists ----
+
+    /// @dev The removed owner-only `setYieldModule(address)` (selector 0xbe3df19f) is gone from the
+    ///      shared beacon-proxied DM base. A call to that selector hits no function and, absent a
+    ///      payable fallback, reverts — while the yieldModule wired at init is untouched. This is the
+    ///      core S1 mitigation: no live token instance's owner can ever be handed a distribution-
+    ///      bricking lever if an existing DM beacon is pointed at this implementation.
+    function test_S1_SetYieldModuleSelectorNoLongerExists() public {
+        CrowdStakeDeployer.Params memory p = _adminParams("s1-gone");
+        p.issueToken = false; // pool mode: yieldModule = pool, baseToken = underlying
+        CrowdStakeDeployer.Instance memory i = deployer.deploy(p);
+
+        address dm = i.distributionManager;
+        address before = address(AbstractDistributionManager(dm).yieldModule());
+        assertEq(before, i.token, "precondition: yieldModule = pool");
+
+        // Old setter selector, as any caller (even a future owner) would encode it.
+        bytes memory oldSetter = abi.encodeWithSignature("setYieldModule(address)", address(0xDEAD));
+        assertEq(bytes4(oldSetter), bytes4(0xbe3df19f), "old selector pinned");
+
+        // As the final owner: the call finds no such function and reverts (no fallback).
+        vm.prank(OWNER);
+        (bool ok,) = dm.call(oldSetter);
+        assertFalse(ok, "setYieldModule(address) no longer exists -> reverts");
+
+        // And the yield module is exactly what init fixed it to — no state changed.
+        assertEq(address(AbstractDistributionManager(dm).yieldModule()), before, "yieldModule unchanged");
+    }
+
+    /// @dev End-to-end: in pool mode the yield module is fixed at DM initialization and the owner
+    ///      cannot repoint it by ANY path (there is no setter, and re-initialize reverts). Proves the
+    ///      pool wiring works purely through the initializer, not a post-deploy owner call.
+    function test_S1_PoolModeYieldModuleFixedAtInit_OwnerCannotRepoint() public {
+        CrowdStakeDeployer.Params memory p = _adminParams("s1-fixed");
+        p.issueToken = false; // POOL MODE
+        CrowdStakeDeployer.Instance memory i = deployer.deploy(p);
+
+        // The pool wiring was set purely at init: yieldModule = pool, baseToken = underlying.
+        assertEq(address(AbstractDistributionManager(i.distributionManager).yieldModule()), i.token, "init: pool");
+        assertEq(address(AbstractDistributionManager(i.distributionManager).baseToken()), WXDAI, "init: underlying");
+        assertEq(IOwnable(i.distributionManager).owner(), OWNER, "owner is final owner, not deployer");
+
+        // The owner cannot re-run initialize to repoint the yield module (initializer is spent).
+        vm.prank(OWNER);
+        (bool reinitOk,) = i.distributionManager
+            .call(
+                abi.encodeWithSignature(
+                    "initialize(address,address,address,address,address,address,address)",
+                    i.cycleModule,
+                    i.registry,
+                    WXDAI,
+                    i.votingModule,
+                    address(0xDEAD), // attacker-chosen yield module
+                    address(0),
+                    OWNER
+                )
+            );
+        assertFalse(reinitOk, "re-initialize reverts (InvalidInitialization)");
+
+        // Yield module is still the pool the deployer fixed at init.
+        assertEq(address(AbstractDistributionManager(i.distributionManager).yieldModule()), i.token, "still the pool");
+    }
+
     // ---- Backward-compatible legacy deploy (pinned IPFS frontends) ----
 
     /// @dev The pre-pool-mode 13-field selector (0xfd759538) still deploys a classic TOKEN instance.

--- a/contracts/test/DistributionCycleIntegration.t.sol
+++ b/contracts/test/DistributionCycleIntegration.t.sol
@@ -45,8 +45,8 @@ contract DistributionCycleIntegrationTest is Test {
         vm.etch(mockVotingModule, hex"00");
         vm.etch(mockStrategy, hex"00");
 
-        bytes memory managerInit = abi.encodeWithSelector(
-            BaseDistributionManager.initialize.selector,
+        bytes memory managerInit = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address,address)",
             address(cycleModule),
             mockRegistry,
             mockBaseToken,
@@ -122,8 +122,8 @@ contract DistributionCycleIntegrationTest is Test {
             abi.encodeWithSelector(AbstractCycleModule.initialize.selector, CYCLE_LENGTH, owner);
         CycleModule freshCycle = CycleModule(address(new ERC1967Proxy(address(freshCycleImpl), freshCycleInit)));
 
-        bytes memory managerInit = abi.encodeWithSelector(
-            BaseDistributionManager.initialize.selector,
+        bytes memory managerInit = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address,address)",
             address(freshCycle),
             mockRegistry,
             mockBaseToken,

--- a/contracts/test/DistributionStrategies.t.sol
+++ b/contracts/test/DistributionStrategies.t.sol
@@ -822,8 +822,8 @@ contract MultiStrategyDistributionManagerTest is Test {
 
         // Deploy manager behind proxy
         MultiStrategyDistributionManager impl = new MultiStrategyDistributionManager();
-        bytes memory initData = abi.encodeWithSelector(
-            MultiStrategyDistributionManager.initialize.selector,
+        bytes memory initData = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address[],address)",
             address(cycleModule),
             address(registry),
             address(yieldToken),
@@ -880,8 +880,8 @@ contract MultiStrategyDistributionManagerTest is Test {
         MockRecipientRegistry emptyRegistry = new MockRecipientRegistry(emptyRecipients);
 
         MultiStrategyDistributionManager impl = new MultiStrategyDistributionManager();
-        bytes memory initData = abi.encodeWithSelector(
-            MultiStrategyDistributionManager.initialize.selector,
+        bytes memory initData = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address[],address)",
             address(cycleModule),
             address(emptyRegistry),
             address(yieldToken),
@@ -916,8 +916,8 @@ contract MultiStrategyDistributionManagerTest is Test {
         iStrategies[1] = IDistributionStrategy(address(s2));
 
         MultiStrategyDistributionManager impl = new MultiStrategyDistributionManager();
-        bytes memory initData = abi.encodeWithSelector(
-            MultiStrategyDistributionManager.initialize.selector,
+        bytes memory initData = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address[],address)",
             address(cycleModule),
             address(multiRegistry),
             address(yieldToken),
@@ -989,8 +989,8 @@ contract MultiStrategyDistributionManagerTest is Test {
     function testEmptyInitThenSetStrategies() public {
         IDistributionStrategy[] memory none = new IDistributionStrategy[](0);
         MultiStrategyDistributionManager impl = new MultiStrategyDistributionManager();
-        bytes memory initData = abi.encodeWithSelector(
-            MultiStrategyDistributionManager.initialize.selector,
+        bytes memory initData = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address[],address)",
             address(cycleModule),
             address(registry),
             address(yieldToken),
@@ -1021,8 +1021,8 @@ contract MultiStrategyDistributionManagerTest is Test {
         IDistributionStrategy[] memory strategies = new IDistributionStrategy[](1);
         strategies[0] = IDistributionStrategy(address(0));
         MultiStrategyDistributionManager impl = new MultiStrategyDistributionManager();
-        bytes memory initData = abi.encodeWithSelector(
-            MultiStrategyDistributionManager.initialize.selector,
+        bytes memory initData = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address[],address)",
             address(cycleModule),
             address(registry),
             address(yieldToken),

--- a/contracts/test/FactoryModuleDeployment.t.sol
+++ b/contracts/test/FactoryModuleDeployment.t.sol
@@ -228,8 +228,8 @@ contract FactoryModuleDeploymentTest is Test {
         vm.etch(mockVotingModule, hex"00");
         vm.etch(mockStrategy, hex"00");
 
-        bytes memory payload = abi.encodeWithSelector(
-            BaseDistributionManager.initialize.selector,
+        bytes memory payload = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address,address)",
             cycleAddr,
             registryAddr,
             mockBaseToken,
@@ -267,8 +267,8 @@ contract FactoryModuleDeploymentTest is Test {
         strategies[0] = IDistributionStrategy(mockStrategy1);
         strategies[1] = IDistributionStrategy(mockStrategy2);
 
-        bytes memory payload = abi.encodeWithSelector(
-            MultiStrategyDistributionManager.initialize.selector,
+        bytes memory payload = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address[],address)",
             cycleAddr,
             registryAddr,
             mockBaseToken,
@@ -282,6 +282,81 @@ contract FactoryModuleDeploymentTest is Test {
         assertEq(address(manager.cycleManager()), cycleAddr);
         assertEq(address(manager.recipientRegistry()), registryAddr);
         assertEq(manager.getStrategyCount(), 2);
+    }
+
+    // ============ review S1: the yield module is fixed at DM initialization ============
+
+    /// @dev The classic 6-arg initializer defaults the yield module to the base token — byte-identical
+    ///      to the pre-pool-mode behavior. Guards against a regression in the token path.
+    function test_S1_ClassicInitializerDefaultsYieldModuleToBaseToken() public {
+        address dm = _initMultiDm(address(0)); // 6-arg form (no yield module)
+        assertEq(address(MultiStrategyDistributionManager(dm).yieldModule()), MOCK_BASE_TOKEN, "yieldModule=baseToken");
+        assertEq(address(MultiStrategyDistributionManager(dm).baseToken()), MOCK_BASE_TOKEN, "baseToken unchanged");
+    }
+
+    /// @dev The 7-arg (pool-mode) initializer fixes the yield module to the address passed at init —
+    ///      distinct from the base token — and there is no setter to change it afterwards (S1).
+    function test_S1_PoolInitializerFixesYieldModuleAtInit() public {
+        address dm = _initMultiDm(MOCK_POOL); // 7-arg form with an explicit yield module
+        assertEq(address(MultiStrategyDistributionManager(dm).yieldModule()), MOCK_POOL, "yieldModule=pool");
+        assertEq(address(MultiStrategyDistributionManager(dm).baseToken()), MOCK_BASE_TOKEN, "baseToken=underlying");
+    }
+
+    /// @dev The 7-arg initializer with a zero yield module resolves to the base token — same as the
+    ///      classic path, so the token mode can flow through the pool-aware initializer unchanged.
+    function test_S1_PoolInitializerZeroYieldModuleDefaultsToBaseToken() public {
+        address dm = _initMultiDm7(address(0));
+        assertEq(address(MultiStrategyDistributionManager(dm).yieldModule()), MOCK_BASE_TOKEN, "zero => baseToken");
+    }
+
+    address internal constant MOCK_BASE_TOKEN = address(0xBA5E);
+    address internal constant MOCK_POOL = address(0xB007); // stands in for a StakePool in pool mode
+
+    /// @dev Deploys a MultiStrategyDistributionManager proxy. If `yieldModule` is zero, uses the
+    ///      classic 6-arg initializer; otherwise the 7-arg pool-mode initializer.
+    function _initMultiDm(address yieldModule) internal returns (address) {
+        return yieldModule == address(0) ? _initMultiDm6() : _initMultiDm7(yieldModule);
+    }
+
+    function _initMultiDm6() internal returns (address) {
+        (address cycleAddr, address registryAddr) = _cycleAndRegistry("s1-6");
+        vm.etch(MOCK_BASE_TOKEN, hex"00");
+        IDistributionStrategy[] memory none = new IDistributionStrategy[](0);
+        bytes memory payload = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address[],address)",
+            cycleAddr,
+            registryAddr,
+            MOCK_BASE_TOKEN,
+            address(0xBEEF), // placeholder votingModule
+            none,
+            owner
+        );
+        return factory.create(multiDistManagerBeacon, payload, keccak256("s1-6-salt"));
+    }
+
+    function _initMultiDm7(address yieldModule) internal returns (address) {
+        (address cycleAddr, address registryAddr) = _cycleAndRegistry("s1-7");
+        vm.etch(MOCK_BASE_TOKEN, hex"00");
+        IDistributionStrategy[] memory none = new IDistributionStrategy[](0);
+        bytes memory payload = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address,address[],address)",
+            cycleAddr,
+            registryAddr,
+            MOCK_BASE_TOKEN,
+            address(0xBEEF), // placeholder votingModule
+            yieldModule,
+            none,
+            owner
+        );
+        return factory.create(multiDistManagerBeacon, payload, keccak256(abi.encodePacked("s1-7-salt", yieldModule)));
+    }
+
+    function _cycleAndRegistry(bytes32 tag) internal returns (address cycleAddr, address registryAddr) {
+        bytes memory cyclePayload = abi.encodeWithSelector(AbstractCycleModule.initialize.selector, 1000, owner);
+        cycleAddr = factory.create(cycleModuleBeacon, cyclePayload, keccak256(abi.encodePacked(tag, "cycle")));
+        bytes memory registryPayload = abi.encodeWithSignature("initialize(address)", owner);
+        registryAddr =
+            factory.create(adminRegistryBeacon, registryPayload, keccak256(abi.encodePacked(tag, "registry")));
     }
 
     // ============ when computing addresses ============

--- a/contracts/test/PoolModeIntegration.t.sol
+++ b/contracts/test/PoolModeIntegration.t.sol
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+import {CrowdStakeFactory} from "../src/CrowdStakeFactory.sol";
+import {CrowdStakeDeployer} from "../src/CrowdStakeDeployer.sol";
+import {CycleModule} from "../src/implementation/CycleModule.sol";
+import {AbstractCycleModule} from "../src/abstract/AbstractCycleModule.sol";
+import {BasisPointsVotingModule} from "../src/base/BasisPointsVotingModule.sol";
+import {BaseDistributionManager} from "../src/base/BaseDistributionManager.sol";
+import {MultiStrategyDistributionManager} from "../src/base/MultiStrategyDistributionManager.sol";
+import {AbstractDistributionManager} from "../src/abstract/AbstractDistributionManager.sol";
+import {VotingDistributionStrategy} from "../src/implementation/strategies/VotingDistributionStrategy.sol";
+import {EqualDistributionStrategy} from "../src/implementation/strategies/EqualDistributionStrategy.sol";
+import {AdminRecipientRegistry} from "../src/implementation/registries/AdminRecipientRegistry.sol";
+import {VotingRecipientRegistry} from "../src/implementation/registries/VotingRecipientRegistry.sol";
+import {StableYield} from "../src/implementation/token/StableYield.sol";
+import {PoolStableYield} from "../src/implementation/pool/PoolStableYield.sol";
+import {AbstractToken} from "../src/abstract/AbstractToken.sol";
+import {IStakePool} from "../src/interfaces/IStakePool.sol";
+
+import {MockUSDC, MockStableVault} from "./StableYield.t.sol";
+
+/// @notice Full-instance integration for BOTH modes deployed through CrowdStakeDeployer:
+///         deposit → vault appreciation → vote (real BasisPointsVotingModule +
+///         TimeWeightedVotingPower strategy) → claimAndDistribute → recipients paid per
+///         allocations, Distributed events emitted, cycle advanced.
+///         - Pool mode (issueToken=false): recipients receive the UNDERLYING (USDC).
+///         - Token mode (issueToken=true): unchanged classic behavior.
+contract PoolModeIntegrationTest is Test {
+    CrowdStakeDeployer internal deployer;
+    MockUSDC internal usdc;
+    MockStableVault internal vault;
+
+    address internal constant OWNER = address(0xABCD);
+    address internal recipientA = address(0xA1);
+    address internal recipientB = address(0xB2);
+
+    uint256 internal aliceKey = 0xA11CE;
+    uint256 internal bobKey = 0xB0B;
+    address internal alice;
+    address internal bob;
+
+    uint256 internal constant ONE = 1e6; // 1 USDC
+    uint256 internal constant CYCLE = 100;
+    uint256 internal constant MAX_POINTS = 100;
+
+    function setUp() public {
+        alice = vm.addr(aliceKey);
+        bob = vm.addr(bobKey);
+
+        usdc = new MockUSDC();
+        vault = new MockStableVault(address(usdc));
+
+        CrowdStakeFactory factory = new CrowdStakeFactory(address(this));
+
+        // Both TOKEN and POOL beacons use the STABLE (USDC + 4626) impls so one deployer can build
+        // both modes over the same underlying for an apples-to-apples comparison.
+        address[] memory beacons = new address[](10);
+        beacons[0] = address(new UpgradeableBeacon(address(new CycleModule()), address(this)));
+        beacons[1] = address(new UpgradeableBeacon(address(new AdminRecipientRegistry()), address(this)));
+        beacons[2] = address(new UpgradeableBeacon(address(new VotingRecipientRegistry()), address(this)));
+        beacons[3] =
+            address(new UpgradeableBeacon(address(new StableYield(address(usdc), address(vault))), address(this)));
+        beacons[4] =
+            address(new UpgradeableBeacon(address(new PoolStableYield(address(usdc), address(vault))), address(this)));
+        beacons[5] = address(new UpgradeableBeacon(address(new BaseDistributionManager()), address(this)));
+        beacons[6] = address(new UpgradeableBeacon(address(new MultiStrategyDistributionManager()), address(this)));
+        beacons[7] = address(new UpgradeableBeacon(address(new VotingDistributionStrategy()), address(this)));
+        beacons[8] = address(new UpgradeableBeacon(address(new EqualDistributionStrategy()), address(this)));
+        beacons[9] = address(new UpgradeableBeacon(address(new BasisPointsVotingModule()), address(this)));
+        factory.allowlistBeacons(beacons);
+
+        deployer = new CrowdStakeDeployer(
+            address(factory),
+            beacons[0],
+            beacons[1],
+            beacons[2],
+            beacons[3],
+            beacons[4],
+            beacons[5],
+            beacons[6],
+            beacons[7],
+            beacons[8],
+            beacons[9]
+        );
+
+        usdc.mintTo(alice, 10_000 * ONE);
+        usdc.mintTo(bob, 10_000 * ONE);
+    }
+
+    function _params(bytes32 salt, bool issueToken) internal pure returns (CrowdStakeDeployer.Params memory) {
+        return CrowdStakeDeployer.Params({
+            owner: OWNER,
+            cycleLength: CYCLE,
+            tokenName: "Integration",
+            tokenSymbol: "INTG",
+            maxVotingPoints: MAX_POINTS,
+            salt: salt,
+            registryKind: 0, // admin
+            initialRecipients: new address[](0),
+            proposalExpiry: 0,
+            distributionKind: 0, // proportional
+            tokenImageURI: "",
+            bannerImageURI: "",
+            crossChain: false,
+            issueToken: issueToken
+        });
+    }
+
+    /// @dev Adds two recipients through the admin registry (owned by OWNER).
+    function _seedRecipients(address registry) internal {
+        // Recipients must be queued in strictly-ascending address order.
+        (address r0, address r1) =
+            uint160(recipientA) < uint160(recipientB) ? (recipientA, recipientB) : (recipientB, recipientA);
+        vm.startPrank(OWNER);
+        AdminRecipientRegistry(registry).queueRecipientAddition(r0);
+        AdminRecipientRegistry(registry).queueRecipientAddition(r1);
+        vm.stopPrank();
+        AdminRecipientRegistry(registry).processQueue();
+    }
+
+    /// @dev Signs + casts a proportional vote for `voter` via the real voting module.
+    function _vote(address votingModule, address voter, uint256 key, uint256[] memory points, uint256 nonce) internal {
+        bytes32 domainSeparator = BasisPointsVotingModule(votingModule).DOMAIN_SEPARATOR();
+        bytes32 structHash = keccak256(
+            abi.encode(
+                keccak256("Vote(address voter,bytes32 pointsHash,uint256 nonce)"),
+                voter,
+                keccak256(abi.encodePacked(points)),
+                nonce
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, digest);
+        BasisPointsVotingModule(votingModule).castVoteWithSignature(voter, points, nonce, abi.encodePacked(r, s, v));
+    }
+
+    // ============================ POOL MODE ============================
+
+    function test_PoolMode_FullCycle_RecipientsReceiveUnderlying() public {
+        CrowdStakeDeployer.Instance memory i = deployer.deploy(_params("pool-int", false));
+
+        // The yield surface is the pool (issueToken=false), and it exposes the pool probe.
+        assertTrue(IStakePool(i.token).isPool(), "instance.token is a pool");
+        // The distribution manager distributes the UNDERLYING, and reads yield from the pool.
+        assertEq(
+            address(AbstractDistributionManager(i.distributionManager).baseToken()), address(usdc), "baseToken=USDC"
+        );
+        assertEq(
+            address(AbstractDistributionManager(i.distributionManager).yieldModule()), i.token, "yieldModule=the pool"
+        );
+
+        _seedRecipients(i.registry);
+
+        // Deposits into the pool (ledger + auto self-delegated voting checkpoints).
+        uint256 startBlock = block.number;
+        vm.startPrank(alice);
+        usdc.approve(i.token, 600 * ONE);
+        IStakePool(i.token).mint(alice, 600 * ONE);
+        vm.stopPrank();
+        vm.startPrank(bob);
+        usdc.approve(i.token, 400 * ONE);
+        IStakePool(i.token).mint(bob, 400 * ONE);
+        vm.stopPrank();
+
+        // Advance so time-weighted voting power is non-zero within the cycle.
+        vm.roll(startBlock + 10);
+
+        // Votes: recipient order is the registry's ascending order. Alice all-in on r0, Bob on r1.
+        uint256[] memory aPts = new uint256[](2);
+        aPts[0] = 100;
+        aPts[1] = 0;
+        uint256[] memory bPts = new uint256[](2);
+        bPts[0] = 0;
+        bPts[1] = 100;
+        _vote(i.votingModule, alice, aliceKey, aPts, 1);
+        _vote(i.votingModule, bob, bobKey, bPts, 2);
+
+        // Vault appreciates 10% → 100 USDC of yield on 1000 USDC of backing.
+        vault.setRateBps(11_000);
+        usdc.mintTo(address(vault), 100 * ONE);
+        uint256 yield = IStakePool(i.token).yieldAccrued();
+        assertEq(yield, 100 * ONE, "100 USDC donated yield");
+
+        // Roll to cycle end and distribute.
+        vm.roll(startBlock + CYCLE);
+        assertTrue(BaseDistributionManager(i.distributionManager).isDistributionReady(), "ready");
+
+        (address r0, address r1) =
+            uint160(recipientA) < uint160(recipientB) ? (recipientA, recipientB) : (recipientB, recipientA);
+
+        // Distributed events for both recipients (values checked by balance below).
+        vm.recordLogs();
+        BaseDistributionManager(i.distributionManager).claimAndDistribute();
+
+        // Recipients received the UNDERLYING (USDC), proportional to time-weighted votes.
+        // Alice (600) voted r0, Bob (400) voted r1 → r0 gets 60%, r1 gets 40% of 100 USDC.
+        assertApproxEqAbs(usdc.balanceOf(r0), 60 * ONE, 2, "r0 got ~60 USDC");
+        assertApproxEqAbs(usdc.balanceOf(r1), 40 * ONE, 2, "r1 got ~40 USDC");
+        assertEq(usdc.balanceOf(r0) + usdc.balanceOf(r1), 100 * ONE, "full yield distributed in USDC");
+
+        // No pool ledger balance was minted to recipients (they are not depositors).
+        assertEq(IStakePool(i.token).balanceOf(r0), 0, "no ledger balance for recipient r0");
+        assertEq(IStakePool(i.token).balanceOf(r1), 0, "no ledger balance for recipient r1");
+
+        // Cycle advanced atomically.
+        assertEq(AbstractCycleModule(i.cycleModule).getCurrentCycle(), 2, "cycle advanced");
+
+        // A Distributed event was emitted for each recipient.
+        _assertDistributedEmittedFor(r0, r1);
+    }
+
+    function _assertDistributedEmittedFor(address r0, address r1) internal {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("Distributed(address,uint256)");
+        bool sawR0;
+        bool sawR1;
+        for (uint256 k = 0; k < logs.length; k++) {
+            if (logs[k].topics[0] != sig) continue;
+            // Distributed(address indexed recipient, uint256 amount): recipient is topics[1].
+            address rcpt = address(uint160(uint256(logs[k].topics[1])));
+            if (rcpt == r0) sawR0 = true;
+            if (rcpt == r1) sawR1 = true;
+        }
+        assertTrue(sawR0 && sawR1, "Distributed emitted for both recipients");
+    }
+
+    function test_PoolMode_WithdrawRedeemsUnderlying() public {
+        CrowdStakeDeployer.Instance memory i = deployer.deploy(_params("pool-wd", false));
+        vm.startPrank(alice);
+        usdc.approve(i.token, 100 * ONE);
+        IStakePool(i.token).mint(alice, 100 * ONE);
+        uint256 before = usdc.balanceOf(alice);
+        IStakePool(i.token).burn(30 * ONE, alice);
+        vm.stopPrank();
+        assertEq(IStakePool(i.token).balanceOf(alice), 70 * ONE, "ledger reduced");
+        assertEq(usdc.balanceOf(alice) - before, 30 * ONE, "principal redeemed in USDC");
+    }
+
+    // ============================ TOKEN MODE ============================
+    // Same flow with issueToken=true asserts the classic token behavior is unchanged: a real
+    // ERC-20 is minted, recipients receive the TOKEN, and it stays 1:1 redeemable for USDC.
+
+    function test_TokenMode_FullCycle_Unchanged() public {
+        CrowdStakeDeployer.Instance memory i = deployer.deploy(_params("token-int", true));
+
+        // The yield surface is a token: baseToken == token == yieldModule (classic wiring).
+        assertEq(address(AbstractDistributionManager(i.distributionManager).baseToken()), i.token, "baseToken=token");
+        assertEq(
+            address(AbstractDistributionManager(i.distributionManager).yieldModule()), i.token, "yieldModule=token"
+        );
+        // It is NOT a pool (no isPool()).
+        (bool ok,) = i.token.call(abi.encodeWithSignature("isPool()"));
+        assertFalse(ok, "token has no isPool() probe");
+
+        _seedRecipients(i.registry);
+
+        uint256 startBlock = block.number;
+        vm.startPrank(alice);
+        usdc.approve(i.token, 600 * ONE);
+        AbstractToken(i.token).mint(alice, 600 * ONE);
+        vm.stopPrank();
+        vm.startPrank(bob);
+        usdc.approve(i.token, 400 * ONE);
+        AbstractToken(i.token).mint(bob, 400 * ONE);
+        vm.stopPrank();
+
+        vm.roll(startBlock + 10);
+
+        uint256[] memory aPts = new uint256[](2);
+        aPts[0] = 100;
+        aPts[1] = 0;
+        uint256[] memory bPts = new uint256[](2);
+        bPts[0] = 0;
+        bPts[1] = 100;
+        _vote(i.votingModule, alice, aliceKey, aPts, 1);
+        _vote(i.votingModule, bob, bobKey, bPts, 2);
+
+        vault.setRateBps(11_000);
+        usdc.mintTo(address(vault), 100 * ONE);
+        assertEq(AbstractToken(i.token).yieldAccrued(), 100 * ONE, "100 USDC of donated yield");
+
+        vm.roll(startBlock + CYCLE);
+        BaseDistributionManager(i.distributionManager).claimAndDistribute();
+
+        (address r0, address r1) =
+            uint160(recipientA) < uint160(recipientB) ? (recipientA, recipientB) : (recipientB, recipientA);
+
+        // In token mode recipients receive the TOKEN (not USDC directly).
+        assertApproxEqAbs(AbstractToken(i.token).balanceOf(r0), 60 * ONE, 2, "r0 got ~60 tokens");
+        assertApproxEqAbs(AbstractToken(i.token).balanceOf(r1), 40 * ONE, 2, "r1 got ~40 tokens");
+        assertEq(usdc.balanceOf(r0), 0, "recipient holds tokens, not raw USDC yet");
+
+        // The token is redeemable 1:1 for the underlying.
+        uint256 bal = AbstractToken(i.token).balanceOf(r0);
+        vm.prank(r0);
+        AbstractToken(i.token).burn(bal, r0);
+        assertEq(usdc.balanceOf(r0), bal, "token redeemed 1:1 for USDC");
+
+        assertEq(AbstractCycleModule(i.cycleModule).getCurrentCycle(), 2, "cycle advanced");
+    }
+}

--- a/contracts/test/StakePool.t.sol
+++ b/contracts/test/StakePool.t.sol
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {AbstractStakePool} from "../src/implementation/pool/AbstractStakePool.sol";
+import {PoolStableYield} from "../src/implementation/pool/PoolStableYield.sol";
+import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
+import {MockUSDC, MockStableVault} from "./StableYield.t.sol";
+
+/// @dev Pool harness mirroring YieldSplit.t.sol's HarnessToken: `assets` moves exactly like a real
+///      pool's vault position — deposits/remits move it, and yield CLAIMS (which redeem the
+///      underlying) also move it down, exactly like a vault redemption. So raw yield =
+///      assets - totalSupply with no rounding, ideal for exact yield-split PARITY assertions
+///      against the token harness. Redeemed underlying is credited to a per-receiver ledger so
+///      tests can assert claims actually paid out.
+contract HarnessPool is AbstractStakePool {
+    uint256 public assets;
+    mapping(address => uint256) public underlyingPaid;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        string memory name_,
+        string memory,
+        /*symbol*/
+        address owner_
+    )
+        external
+        initializer
+    {
+        __AbstractStakePool_init(name_, owner_);
+    }
+
+    function symbol() external pure override returns (string memory) {
+        return "MOCK";
+    }
+
+    function decimals() external pure override returns (uint8) {
+        return 18;
+    }
+
+    function underlyingAsset() external pure returns (address) {
+        return address(0xDEAD);
+    }
+
+    function _deposit(uint256 amount_) internal override {
+        assets += amount_;
+    }
+
+    /// @dev Model a native deposit (wrap → vault) as just crediting the vault-backed assets.
+    function _depositNative(uint256 amount_) internal override {
+        assets += amount_;
+    }
+
+    function _remit(address receiver_, uint256 amount_) internal override {
+        assets -= amount_;
+        underlyingPaid[receiver_] += amount_;
+    }
+
+    /// @dev Yield claim redeems the underlying: vault-backed assets fall by the claimed amount,
+    ///      just as a real 4626 redemption reduces the pool's backing.
+    function _claimUnderlying(address receiver_, uint256 amount_) internal override {
+        assets -= amount_;
+        underlyingPaid[receiver_] += amount_;
+    }
+
+    function _yieldAccrued() internal view override returns (uint256) {
+        uint256 supply = totalSupply();
+        return assets > supply ? assets - supply : 0;
+    }
+
+    function addYield(uint256 amount_) external {
+        assets += amount_;
+    }
+
+    function slashAssets(uint256 amount_) external {
+        assets -= amount_;
+    }
+}
+
+/// @notice Pool unit tests: deposit/withdraw both variants, yield accrual, yield-split accumulator
+///         PARITY with the token, claimYield paying the underlying + gating + rotation timelock,
+///         checkpoints written correctly, and no ERC-20 transfer surface.
+contract StakePoolTest is Test {
+    HarnessPool pool;
+    address claimer = address(0xCAFE);
+    address alice = address(0xA11CE);
+    address bob = address(0xB0B);
+
+    uint16 constant BPS = 10_000;
+
+    function setUp() public {
+        HarnessPool impl = new HarnessPool();
+        bytes memory data = abi.encodeWithSelector(HarnessPool.initialize.selector, "Community Pool", "", address(this));
+        pool = HarnessPool(address(new ERC1967Proxy(address(impl), data)));
+        pool.setYieldClaimer(claimer);
+    }
+
+    function _depositFor(address who, uint256 amount) internal {
+        vm.prank(who);
+        pool.mint(who, amount);
+    }
+
+    /* --------------------------- ledger + probe --------------------------- */
+
+    function test_IsPoolProbeAndName() public view {
+        assertTrue(pool.isPool(), "isPool feature probe true");
+        assertEq(pool.name(), "Community Pool", "instance name");
+    }
+
+    function test_NoTransferSurface() public {
+        // The pool is NOT an ERC-20: it has no transfer/approve/allowance/transferFrom. A call to
+        // any of those selectors hits the fallback and reverts (no matching function).
+        (bool ok,) = address(pool).call(abi.encodeWithSignature("transfer(address,uint256)", bob, 1));
+        assertFalse(ok, "no transfer()");
+        (ok,) = address(pool).call(abi.encodeWithSignature("approve(address,uint256)", bob, 1));
+        assertFalse(ok, "no approve()");
+        (ok,) = address(pool).call(abi.encodeWithSignature("allowance(address,address)", alice, bob));
+        assertFalse(ok, "no allowance()");
+        (ok,) = address(pool).call(abi.encodeWithSignature("transferFrom(address,address,uint256)", alice, bob, 1));
+        assertFalse(ok, "no transferFrom()");
+    }
+
+    /* --------------------------- deposit / withdraw ----------------------- */
+
+    function test_DepositErc20Path_RecordsLedgerAndEmitsDeposited() public {
+        vm.expectEmit(true, false, false, true);
+        emit AbstractStakePool.Deposited(alice, 100 ether);
+        _depositFor(alice, 100 ether);
+
+        assertEq(pool.balanceOf(alice), 100 ether, "ledger balance");
+        assertEq(pool.totalSupply(), 100 ether, "supply");
+        assertEq(pool.getVotes(alice), 100 ether, "auto self-delegated voting weight");
+    }
+
+    function test_FrontendVotingReads_GetVotesAndDelegates() public {
+        // The live frontend reads getVotes/delegates directly on instance.token (portfolio voting
+        // power, admin delegation card, family stats), not only through the strategy.
+        assertEq(pool.getVotes(alice), 0, "no votes before deposit");
+        assertEq(pool.delegates(alice), alice, "auto self-delegated: delegate is the account itself");
+
+        _depositFor(alice, 100 ether);
+        assertEq(pool.getVotes(alice), 100 ether, "getVotes = current deposit balance");
+        assertEq(pool.delegates(alice), alice, "delegate stays the account itself");
+
+        vm.prank(alice);
+        pool.burn(40 ether, alice);
+        assertEq(pool.getVotes(alice), 60 ether, "getVotes tracks the balance down");
+    }
+
+    function test_DepositNativePath_RecordsLedger() public {
+        vm.deal(alice, 5 ether);
+        vm.prank(alice);
+        pool.mint{value: 3 ether}(alice);
+        assertEq(pool.balanceOf(alice), 3 ether, "native deposit ledgered");
+        assertEq(pool.totalSupply(), 3 ether, "supply from native path");
+    }
+
+    function test_Withdraw_BurnsLedgerPaysUnderlyingEmitsWithdrawn() public {
+        _depositFor(alice, 100 ether);
+        vm.expectEmit(true, false, false, true);
+        emit AbstractStakePool.Withdrawn(bob, 40 ether);
+        vm.prank(alice);
+        pool.burn(40 ether, bob);
+
+        assertEq(pool.balanceOf(alice), 60 ether, "ledger reduced");
+        assertEq(pool.totalSupply(), 60 ether, "supply reduced");
+        assertEq(pool.underlyingPaid(bob), 40 ether, "underlying remitted to receiver");
+    }
+
+    function test_Withdraw_RevertsOverBalance() public {
+        _depositFor(alice, 10 ether);
+        vm.prank(alice);
+        vm.expectRevert(AbstractStakePool.InsufficientBalance.selector);
+        pool.burn(11 ether, alice);
+    }
+
+    function test_MintZeroReverts() public {
+        vm.prank(alice);
+        vm.expectRevert(AbstractStakePool.MintZero.selector);
+        pool.mint(alice, 0);
+    }
+
+    /* ----------------------- yield accrual via vault ---------------------- */
+
+    function test_YieldAccrual() public {
+        _depositFor(alice, 100 ether);
+        assertEq(pool.totalYieldAccrued(), 0, "no yield yet");
+        pool.addYield(7 ether);
+        assertEq(pool.totalYieldAccrued(), 7 ether, "vault appreciation surfaces as yield");
+        assertEq(pool.yieldAccrued(), 7 ether, "all donated by default");
+    }
+
+    /* --------------------- claimYield pays underlying --------------------- */
+
+    function test_ClaimYield_PaysUnderlyingAndGated() public {
+        _depositFor(alice, 100 ether);
+        pool.addYield(10 ether);
+
+        // Gated to the yield claimer.
+        vm.prank(alice);
+        vm.expectRevert(AbstractStakePool.OnlyClaimer.selector);
+        pool.claimYield(1 ether, alice);
+
+        vm.prank(claimer);
+        pool.claimYield(10 ether, claimer);
+        assertEq(pool.underlyingPaid(claimer), 10 ether, "claimer received the UNDERLYING (not pool balance)");
+        assertEq(pool.balanceOf(claimer), 0, "no pool ledger balance minted for the claim");
+        assertEq(pool.yieldAccrued(), 0, "donated pool drained");
+    }
+
+    /* ---------------------- yield-claimer rotation ------------------------ */
+
+    function test_ClaimerRotation_Timelock() public {
+        address next = address(0xBEEF);
+
+        vm.expectRevert(AbstractStakePool.NoPendingClaimer.selector);
+        pool.finalizeNewYieldClaimer();
+
+        pool.prepareNewYieldClaimer(next);
+        assertEq(pool.pendingYieldClaimer(), next, "pending set");
+
+        vm.expectRevert(AbstractStakePool.TimelockNotElapsed.selector);
+        pool.finalizeNewYieldClaimer();
+
+        vm.warp(block.timestamp + 14 days);
+        pool.finalizeNewYieldClaimer();
+        assertEq(pool.yieldClaimer(), next, "claimer rotated after 14-day timelock");
+    }
+
+    function test_SetClaimer_OnlyOnce() public {
+        vm.expectRevert(AbstractStakePool.AlreadySetClaimer.selector);
+        pool.setYieldClaimer(address(0x1234));
+    }
+
+    /* -------------------------- checkpoints ------------------------------- */
+
+    function test_CheckpointsWrittenOnDepositAndWithdraw() public {
+        vm.roll(100);
+        _depositFor(alice, 100 ether);
+        assertEq(pool.numCheckpoints(alice), 1, "one checkpoint after first deposit");
+        Checkpoints.Checkpoint208 memory c0 = pool.checkpoints(alice, 0);
+        assertEq(uint256(c0._key), 100, "checkpoint keyed by block.number");
+        assertEq(uint256(c0._value), 100 ether, "checkpoint value = balance");
+
+        vm.roll(150);
+        _depositFor(alice, 50 ether);
+        assertEq(pool.numCheckpoints(alice), 2, "second checkpoint at new block");
+        Checkpoints.Checkpoint208 memory c1 = pool.checkpoints(alice, 1);
+        assertEq(uint256(c1._key), 150, "second key");
+        assertEq(uint256(c1._value), 150 ether, "cumulative balance");
+
+        vm.roll(200);
+        vm.prank(alice);
+        pool.burn(30 ether, alice);
+        Checkpoints.Checkpoint208 memory c2 = pool.checkpoints(alice, 2);
+        assertEq(uint256(c2._value), 120 ether, "withdraw checkpoints the reduced balance");
+    }
+
+    function test_SameBlockDepositOverwritesCheckpoint() public {
+        vm.roll(300);
+        _depositFor(alice, 10 ether);
+        _depositFor(alice, 5 ether); // same block
+        assertEq(pool.numCheckpoints(alice), 1, "same-block writes coalesce (OZ Checkpoints semantics)");
+        Checkpoints.Checkpoint208 memory c = pool.checkpoints(alice, 0);
+        assertEq(uint256(c._value), 15 ether, "coalesced to final balance");
+    }
+
+    /* ----------------- yield-split accumulator PARITY --------------------- */
+    // These mirror YieldSplit.t.sol's token tests 1:1 and assert IDENTICAL numbers, proving the
+    // 1e27 accumulator was ported faithfully (settlement points: deposit/withdraw/setYieldSplit/
+    // claimKeptYield — the pool has no transfers).
+
+    function test_Parity_DefaultDonatesEverything() public {
+        _depositFor(alice, 100 ether);
+        pool.addYield(10 ether);
+        assertEq(pool.yieldAccrued(), 10 ether, "all yield donated by default");
+        assertEq(pool.totalYieldAccrued(), 10 ether, "raw surplus");
+        assertEq(pool.keptYieldOf(alice), 0, "nothing kept by default");
+    }
+
+    function test_Parity_SplitAppliesOnlyGoingForward() public {
+        _depositFor(alice, 100 ether);
+        pool.addYield(10 ether);
+
+        vm.prank(alice);
+        pool.setYieldSplit(5000);
+        assertEq(pool.keptYieldOf(alice), 0, "past yield stays donated");
+        assertEq(pool.yieldAccrued(), 10 ether, "donated pool untouched");
+
+        pool.addYield(10 ether);
+        assertEq(pool.keptYieldOf(alice), 5 ether, "half of new yield kept");
+        assertEq(pool.yieldAccrued(), 15 ether, "old 10 + new donated 5");
+    }
+
+    function test_Parity_SingleHolderKeepsHalf_ClaimPaysUnderlying() public {
+        vm.prank(alice);
+        pool.setYieldSplit(5000);
+        _depositFor(alice, 100 ether);
+        pool.addYield(10 ether);
+
+        assertEq(pool.keptYieldOf(alice), 5 ether, "kept half");
+        assertEq(pool.yieldAccrued(), 5 ether, "donated half");
+        assertEq(pool.totalYieldAccrued(), 10 ether, "raw is the sum");
+
+        // The claimer cannot touch the kept share.
+        vm.prank(claimer);
+        vm.expectRevert(AbstractStakePool.YieldInsufficient.selector);
+        pool.claimYield(6 ether, claimer);
+
+        vm.prank(claimer);
+        pool.claimYield(5 ether, claimer);
+        assertEq(pool.underlyingPaid(claimer), 5 ether, "donated pool paid in underlying");
+
+        vm.prank(alice);
+        pool.claimKeptYield(alice);
+        assertEq(pool.underlyingPaid(alice), 5 ether, "kept yield paid in underlying (not minted)");
+        assertEq(pool.balanceOf(alice), 100 ether, "claim did NOT change the ledger balance");
+        assertEq(pool.keptYieldOf(alice), 0, "kept claimed");
+        assertEq(pool.totalYieldAccrued(), 0, "everything consumed");
+    }
+
+    function test_Parity_TwoHoldersDifferentSplits() public {
+        vm.prank(alice);
+        pool.setYieldSplit(BPS); // keeps everything
+        _depositFor(alice, 100 ether); // 25% of supply
+        _depositFor(bob, 300 ether); // donates everything
+
+        pool.addYield(40 ether);
+        assertEq(pool.keptYieldOf(alice), 10 ether, "alice keeps her quarter");
+        assertEq(pool.keptYieldOf(bob), 0, "bob donates");
+        assertEq(pool.yieldAccrued(), 30 ether, "bob's share is donated");
+    }
+
+    function test_Parity_ChangeSplitSettlesAtOldRate() public {
+        vm.prank(alice);
+        pool.setYieldSplit(BPS);
+        _depositFor(alice, 100 ether);
+        pool.addYield(10 ether);
+
+        vm.prank(alice);
+        pool.setYieldSplit(0); // stop keeping
+        assertEq(pool.keptYieldOf(alice), 10 ether, "pre-change yield kept at old split");
+
+        pool.addYield(10 ether);
+        assertEq(pool.keptYieldOf(alice), 10 ether, "new yield donated");
+        assertEq(pool.yieldAccrued(), 10 ether, "new yield in the pool");
+    }
+
+    function test_Parity_WithdrawSettlesAndKeptSurvivesExit() public {
+        vm.prank(alice);
+        pool.setYieldSplit(5000);
+        _depositFor(alice, 100 ether);
+        pool.addYield(10 ether);
+
+        vm.prank(alice);
+        pool.burn(100 ether, alice);
+        assertEq(pool.balanceOf(alice), 0, "fully exited");
+        assertEq(pool.keptYieldOf(alice), 5 ether, "kept yield survives exit");
+
+        vm.prank(alice);
+        pool.claimKeptYield(alice);
+        assertEq(pool.underlyingPaid(alice), 100 ether + 5 ether, "principal (withdraw) + kept yield paid out");
+        assertEq(pool.yieldAccrued(), 5 ether, "donated half still claimable");
+    }
+
+    /// Conservation fuzz mirroring YieldSplit.t.sol: attribution never exceeds the vault surplus.
+    function testFuzz_Parity_KeptPlusDonatedNeverExceedRaw(uint16 bpsA, uint16 bpsB, uint96 y1, uint96 y2) public {
+        bpsA = uint16(bound(bpsA, 0, BPS));
+        bpsB = uint16(bound(bpsB, 0, BPS));
+        y1 = uint96(bound(y1, 0, 1_000_000 ether));
+        y2 = uint96(bound(y2, 0, 1_000_000 ether));
+
+        vm.prank(alice);
+        pool.setYieldSplit(bpsA);
+        vm.prank(bob);
+        pool.setYieldSplit(bpsB);
+        _depositFor(alice, 100 ether);
+        _depositFor(bob, 200 ether);
+
+        pool.addYield(y1);
+        pool.addYield(y2);
+
+        uint256 raw = pool.totalYieldAccrued();
+        uint256 attributed = pool.keptYieldOf(alice) + pool.keptYieldOf(bob) + pool.yieldAccrued();
+        assertLe(attributed, raw, "attribution never exceeds the vault surplus");
+        assertApproxEqAbs(attributed, raw, 10, "nothing material leaks");
+    }
+}
+
+/// @notice End-to-end pool test on the real PoolStableYield impl + a 4626-style vault: verifies
+///         principal in/out, yield accrual via appreciation, and claims paying the UNDERLYING
+///         stablecoin (redeemed from the vault), all with NO token issued.
+contract PoolStableYieldTest is Test {
+    MockUSDC usdc;
+    MockStableVault vault;
+    PoolStableYield pool;
+    address claimer = address(0xCAFE);
+    address user = address(0xBEEF);
+    address recipient = address(0x9999);
+
+    uint256 constant ONE = 1e6; // 1 USDC
+
+    function setUp() public {
+        usdc = new MockUSDC();
+        vault = new MockStableVault(address(usdc));
+        PoolStableYield impl = new PoolStableYield(address(usdc), address(vault));
+        bytes memory data = abi.encodeWithSelector(PoolStableYield.initialize.selector, "USDC Pool", "", address(this));
+        pool = PoolStableYield(payable(address(new ERC1967Proxy(address(impl), data))));
+        pool.setYieldClaimer(claimer);
+        usdc.mintTo(user, 1_000 * ONE);
+    }
+
+    function test_SymbolIsUnderlyingsAndDecimalsMirror() public view {
+        assertEq(pool.symbol(), "USDC", "pool reports the UNDERLYING symbol, not a synthetic one");
+        assertEq(pool.decimals(), 6, "decimals mirror the underlying");
+        assertEq(pool.underlyingAsset(), address(usdc), "underlyingAsset() = the stablecoin");
+    }
+
+    function test_ConstructorRevertsOnAssetMismatch() public {
+        MockUSDC other = new MockUSDC();
+        MockStableVault wrong = new MockStableVault(address(other));
+        vm.expectRevert(PoolStableYield.VaultAssetMismatch.selector);
+        new PoolStableYield(address(usdc), address(wrong));
+    }
+
+    function test_NativeDepositReverts() public {
+        vm.deal(user, 1 ether);
+        vm.prank(user);
+        vm.expectRevert(PoolStableYield.NativeNotSupported.selector);
+        pool.mint{value: 1 ether}(user);
+    }
+
+    function test_DepositWithdraw_1to1_NoToken() public {
+        vm.startPrank(user);
+        usdc.approve(address(pool), 100 * ONE);
+        pool.mint(user, 100 * ONE);
+        vm.stopPrank();
+
+        assertEq(pool.balanceOf(user), 100 * ONE, "ledger 1:1 in 6dp");
+        assertEq(pool.totalSupply(), 100 * ONE, "supply");
+        assertEq(usdc.balanceOf(address(vault)), 100 * ONE, "vault holds the USDC");
+
+        uint256 before = usdc.balanceOf(user);
+        vm.prank(user);
+        pool.burn(40 * ONE, user);
+        assertEq(pool.balanceOf(user), 60 * ONE, "ledger reduced");
+        assertEq(usdc.balanceOf(user) - before, 40 * ONE, "USDC redeemed 1:1 to the withdrawer");
+    }
+
+    function test_YieldAccrual_ClaimPaysUnderlyingStablecoin() public {
+        vm.startPrank(user);
+        usdc.approve(address(pool), 100 * ONE);
+        pool.mint(user, 100 * ONE);
+        vm.stopPrank();
+
+        vault.setRateBps(10_500); // +5% appreciation
+        usdc.mintTo(address(vault), 5 * ONE); // back the appreciation with real USDC
+        assertEq(pool.totalYieldAccrued(), 5 * ONE, "5 USDC of yield");
+        assertEq(pool.yieldAccrued(), 5 * ONE, "all donated by default");
+
+        vm.prank(claimer);
+        pool.claimYield(5 * ONE, recipient);
+        assertEq(usdc.balanceOf(recipient), 5 * ONE, "yield claim paid the UNDERLYING USDC");
+        assertEq(pool.balanceOf(recipient), 0, "no pool ledger balance minted");
+        assertEq(pool.yieldAccrued(), 0, "drained");
+    }
+}


### PR DESCRIPTION
## Tokenless pool mode (`issueToken` toggle, default off)

Communities can now deploy an instance where **no token is issued**: deposits become ledger entries in a `StakePool` contract, while yield, voting, and distribution mechanics are byte-for-byte the same as the token path. The deployer toggle is `issueToken`, whose **zero value (`false`) = pool mode = default**.

### What pool mode is
A `StakePool` is ABI-compatible with the surface the rest of the system consumes from the token (deposit/withdraw entrypoints, the yield module, per-holder yield split, the yield-claimer role, and the voting-power source) **without being an ERC-20**. It has no `transfer`/`approve`/`allowance` and emits no `Transfer` events — that omission is what keeps a pool invisible to wallets/explorers as a token. Yield claims pay the **underlying asset** (redeemed from the vault) rather than minting balance, so recipients receive the real asset (WXDAI/USDC).

### New / changed contracts
- **`src/implementation/pool/AbstractStakePool.sol`** (new) — the tokenless counterpart of `AbstractToken`. Ports the 1e27 yield-split accumulator faithfully (cited against `AbstractToken.sol` line refs), the yield-claimer role + 14-day timelocked rotation, and implements `IVotesCheckpoints` over the ledger (a checkpoint written on every deposit/withdraw, auto self-delegated) so the **existing** `TimeWeightedVotingPower` strategy is deployed against the pool unchanged.
- **`src/implementation/pool/PoolNativeYield.sol`** (new) — pool variant mirroring `SexyDaiYield` (native xDAI → wxDAI → sDAI). Principal withdrawals unwrap to native; yield claims pay the underlying wxDAI ERC-20.
- **`src/implementation/pool/PoolStableYield.sol`** (new) — pool variant mirroring `StableYield` (ERC-20 stablecoin → ERC-4626). No native path; principal + yield claims both redeem the stablecoin.
- **`src/interfaces/IStakePool.sol`** (new) — the pool's consumed surface.
- **`src/CrowdStakeDeployer.sol`** — appended `bool issueToken` to `Params`; branches `deploy()` (pool → `StakePool` via a new `POOL_BEACON` + `DM.baseToken = underlying` + `DM.yieldModule = pool`; token → today's path byte-identical). Added `supportsPoolMode()` probe and a backward-compat 13-field `deploy(LegacyParams)` overload (old selector). `familyId` derivation is intentionally NOT a function of `issueToken` (mode consistency is the deploy wizard's job — commented).
- **`src/abstract/AbstractDistributionManager.sol`** — added owner-only `setYieldModule()` so pool mode can point the yield module at the pool while `baseToken` stays the underlying. Token mode leaves `yieldModule == baseToken` (unchanged).
- **`script/DeployCrowdStakeDeployer.s.sol`** — deploys a matching pool impl + `POOL_BEACON` (native/stable per `YIELD_KIND`).

### Exact new/changed ABIs

**`CrowdStakeDeployer.Params`** (appended one field; new `deploy` selector `0x1be9a993`):
```
struct Params {
  address owner; uint256 cycleLength; string tokenName; string tokenSymbol;
  uint256 maxVotingPoints; bytes32 salt; uint8 registryKind;
  address[] initialRecipients; uint256 proposalExpiry; uint8 distributionKind;
  string tokenImageURI; string bannerImageURI; bool crossChain;
  bool issueToken;   // NEW — false (zero value) = POOL MODE = default; true = classic token
}
```
- `deploy(Params)` → `0x1be9a993`; `deploy(LegacyParams)` (the pre-pool-mode 13-field struct) → `0xfd759538` (byte-identical to the historical selector; fills `issueToken = true`, delegates internally so family scoping stays on the original caller).
- `supportsPoolMode() external pure returns (bool)` → `0xc477fd77` (on-chain capability probe for the wizard).
- Constructor gains a `poolBeacon` argument; deployer exposes `POOL_BEACON`.
- `AbstractDistributionManager.setYieldModule(address)` (owner-only) + `YieldModuleSet(address)` event.

**`StakePool` surface** (`IStakePool` + `IVotesCheckpoints`):
- Ledger reads: `balanceOf(address)`, `totalSupply()`, `name()` (instance name), `symbol()` (= the UNDERLYING's symbol), `decimals()` (= underlying's), `underlyingAsset()`, `isPool() pure returns(true)`.
- Deposit/withdraw (signatures identical to the token): `mint(address,uint256)`, `mint(address) payable`, `burn(uint256,address)`. Emits `Deposited`/`Withdrawn` — no `Transfer`.
- Yield module: `yieldAccrued()` (donated-only), `totalYieldAccrued()`, `claimYield(uint256,address)` (pays underlying).
- Yield-claimer role: `yieldClaimer()`, `setYieldClaimer(address)`, `prepareNewYieldClaimer(address)`, `finalizeNewYieldClaimer()`, `pendingYieldClaimer()`, `pendingFinishedAt()`.
- Yield split: `setYieldSplit(uint16)`, `yieldSplitOf(address)`, `keptYieldOf(address)`, `claimKeptYield(address)` (pays underlying), `YIELD_SPLIT_BPS`.
- Voting power (frontend reads these directly on `instance.token`): `getVotes(address)` (= current deposit balance, auto self-delegated), `delegates(address)` (= the account), `numCheckpoints(address)`, `checkpoints(address,uint32)`, `getPastVotes`. (`delegate`/`delegateBySig`/`getPastTotalSupply` revert — delegation is fixed.)

### Tests
- **`test/StakePool.t.sol`** (26): deposit/withdraw both variants; yield accrual; **yield-split accumulator PARITY** (ported token split tests asserting identical numbers + a conservation fuzz); `claimYield`/`claimKeptYield` pay the **underlying** + claimer gating + 14-day rotation timelock; checkpoints written on deposit/withdraw (block-keyed, same-block coalesce); `getVotes`/`delegates` frontend reads; **no transfer surface** (transfer/approve/allowance/transferFrom all revert). Includes real-impl `PoolStableYield` end-to-end.
- **`test/PoolModeIntegration.t.sol`** (3): full pool-mode instance via the deployer → deposit → vault appreciation → vote through the **real** voting module + `TimeWeightedVotingPower` strategy → `claimAndDistribute` → recipients received the **UNDERLYING** per allocations, `Distributed` events, cycle advanced; the **same flow in token mode** (`issueToken=true`) asserting unchanged behavior (recipients get the token, redeemable 1:1); plus a pool withdraw-redeems-underlying case.
- **`test/CrowdStakeDeployer.t.sol`** (+5): `supportsPoolMode()` probe; pool-mode deploy wiring (baseToken=underlying, yieldModule=pool); zero-value `issueToken` defaults to pool mode; legacy-selector (`0xfd759538`) still deploys a classic token; legacy cross-chain scopes the family to the original caller.

**`forge build` + `forge fmt --check` clean; `forge test` = 442 passed / 0 failed** (fork tests run with `ETH_RPC_URL=https://gnosis-rpc.publicnode.com`). The 4 fork-based tests that require the RPC are pre-existing.

### Notes / deviations
- **`setYieldModule` on the DM** was added (owner-only) because pool mode needs `yieldModule = pool` while `baseToken = underlying`; the DM's initializer hard-wires `yieldModule = baseToken`. Token mode never calls it → byte-identical.
- **`_deploy(Params memory, address creator)`** internal refactor: the primary `deploy` and the legacy overload both forward `msg.sender` as `creator`, so family scoping/salt/events use the original caller (never a `this.deploy` self-call). Behavior for direct `deploy(Params)` is unchanged.
- **Native pool `_claimUnderlying` pays wxDAI (the ERC-20), not native** — because the DM's `baseToken` in native pool mode is wxDAI (the wrapped-native the vault is denominated in), which is what the strategy moves to recipients. Principal withdrawals still unwrap to native, matching `SexyDaiYield`.
- Existing token-mode deployer tests were updated to set `issueToken: true` in the shared helpers (so they keep asserting classic token behavior); all pass unchanged otherwise.

### Unverified
- Not run against a live Gnosis/L2 fork with real WXDAI/sDAI or a real Morpho USDC vault (integration uses the repo's mock USDC + 4626-style vault, same mocks the token suites use). Beacon-upgrade/storage-layout of a *pre-existing* live instance is out of scope — pool mode is a fresh deploy path.
