### PR TITLE
chore: point deployer fallbacks at the pool-capable v3 deployers

### DIFF
--- a/contracts/deployments/l2-deployers.json
+++ b/contracts/deployments/l2-deployers.json
@@ -4,8 +4,8 @@
     "42161": {
       "name": "Arbitrum One",
       "yieldKind": "stable",
-      "deployer": "0x4480909dD3fC3ADE8586Dd3758F628A7c9B38A30",
-      "factory": "0xAbC995e02a22AE7134fdAd95bEF0A28505976134",
+      "deployer": "0xbde69CD8cbA0d15942111e51AF13bf9685FDBC33",
+      "factory": "0x85aB847D76378B5B63A79dB9C9c83ea2Cc5B867A",
       "asset": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "assetSymbol": "USDC",
       "yieldVault": "0x5c0C306Aaa9F877de636f4d5822cA9F2E81563BA",
@@ -14,8 +14,8 @@
     "10": {
       "name": "OP Mainnet",
       "yieldKind": "stable",
-      "deployer": "0xCf1Fe91A1946E56D12c2B685a18Cc3d7c1F0c361",
-      "factory": "0xbD01a0F13d06227cF0c1752E685d1ee3281FE908",
+      "deployer": "0x914b0Ac88384A9Ccb7D0d61d35e5EDee60860900",
+      "factory": "0xD4184F7084bC27c645713631241e16500511F429",
       "asset": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
       "assetSymbol": "USDC",
       "yieldVault": "0xC30ce6A5758786e0F640cC5f881Dd96e9a1C5C59",

--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -106,7 +106,7 @@ export const CHAINS: Record<number, ChainConfig> = {
     rpcUrl: or(process.env.NEXT_PUBLIC_RPC_URL, "https://rpc.gnosischain.com"),
     deployer: or(
       process.env.NEXT_PUBLIC_DEPLOYER_ADDRESS,
-      "0xD9dbc941C5e66D1cC67C6612d221263eD1A27C55", // v2 (family-aware), 2026-07-11
+      "0x47Ca7c1CDa33D72cF94Fd27444900B97D2D8F11c", // v3 (pool-capable), 2026-07-12
     ) as Address,
     defaultInstance: GNOSIS_INSTANCE,
     wrappedToken: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d" as Address, // WXDAI
@@ -126,7 +126,7 @@ export const CHAINS: Record<number, ChainConfig> = {
     // address manifest supersedes this fallback on redeploys.
     deployer: or(
       process.env.NEXT_PUBLIC_DEPLOYER_42161,
-      "0x4480909dD3fC3ADE8586Dd3758F628A7c9B38A30", // v2 (family-aware), 2026-07-11
+      "0xbde69CD8cbA0d15942111e51AF13bf9685FDBC33", // v3 (pool-capable), 2026-07-12
     ) as Address,
     defaultInstance: null,
     wrappedToken: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831" as Address, // native USDC
@@ -146,7 +146,7 @@ export const CHAINS: Record<number, ChainConfig> = {
     // address manifest supersedes this fallback on redeploys.
     deployer: or(
       process.env.NEXT_PUBLIC_DEPLOYER_10,
-      "0xCf1Fe91A1946E56D12c2B685a18Cc3d7c1F0c361", // v2 (family-aware), 2026-07-11
+      "0x914b0Ac88384A9Ccb7D0d61d35e5EDee60860900", // v3 (pool-capable), 2026-07-12
     ) as Address,
     defaultInstance: null,
     wrappedToken: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" as Address, // native USDC


### PR DESCRIPTION
Companion to the pool-mode deployer redeploys (all three chains, manifest + mirror auto-updated; `supportsPoolMode()` verified true on each; Gnosis + Arbitrum Blockscout-verified by the fixed CI step — Optimism verification hit a host quirk, queued separately). Updates `chains.ts` + `l2-deployers.json` fallbacks: Gnosis `0x47Ca…F11c`, Arbitrum `0xbde6…BC33`, Optimism `0x914b…0900`.