### PR TITLE
fix(portfolio): show actual voting power instead of raw token balance

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -10,11 +10,11 @@ import { InstanceHeader } from "@/components/dapp/instance-header";
 import { OnboardingBanner } from "@/components/dapp/onboarding-banner";
 import {
   useTokenBalance,
-  useVotes,
   useNativeBalance,
   useInstanceToken,
   useYieldSplit,
 } from "@/hooks/use-token";
+import { useCurrentVotingPower } from "@/hooks/use-voting";
 import { useFamily } from "@/hooks/use-family";
 import {
   scaleTo18,
@@ -42,7 +42,7 @@ import {
 export default function PortfolioPage() {
   const { isConnected } = useAccount();
   const balance = useTokenBalance();
-  const votes = useVotes();
+  const votingPower = useCurrentVotingPower();
   const native = useNativeBalance();
   const cycle = useCycle();
   const { isReady } = useDistributionReady();
@@ -151,7 +151,7 @@ export default function PortfolioPage() {
           label={
             familyMode ? "Your voting power · all chains" : "Your voting power"
           }
-          value={familyMode ? fmt18(fpos.votes18) : fmt(votes.data)}
+          value={familyMode ? fmt18(fpos.votes18) : fmt(votingPower.data)}
           sub="Delegated automatically on deposit"
         />
         <StatCard

--- a/src/hooks/use-family-stats.ts
+++ b/src/hooks/use-family-stats.ts
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { erc20Abi, type Address } from "viem";
 import { useAccount } from "wagmi";
-import { tokenAbi } from "@/lib/abis";
+import { tokenAbi, votingPowerAbi } from "@/lib/abis";
 import { publicClientFor } from "@/lib/instance";
 import type { FamilyState } from "@/hooks/use-family";
 
@@ -165,11 +165,39 @@ export function useFamilyStats(family: FamilyState): FamilyStats {
 export interface FamilyPosition {
   /** Σ balanceOf across siblings, normalized to 18 decimals. */
   balance18?: bigint;
-  /** Σ getVotes across siblings, normalized to 18 decimals. */
+  /**
+   * Σ Voting Power Strategy `getCurrentVotingPower` across siblings,
+   * normalized to 18 decimals. This is the weight the Voting Module uses —
+   * not raw `getVotes` (which can diverge while a cycle sits undistributed).
+   */
   votes18?: bigint;
   /** Per-chain balances (18-dp), for the "0.5 on Arbitrum" breakdown. */
   perChain: { chainId: number; balance18: bigint }[];
   partial: boolean;
+}
+
+/** chainId:token:votingPowerStrategy — position reads need the strategy address. */
+function familyPositionMemberKey(family: FamilyState): string {
+  if (!family.isFamily) return "";
+  return family.perChain
+    .filter((c) => c.instance)
+    .map(
+      (c) =>
+        `${c.chainId}:${c.instance!.token.toLowerCase()}:${c.instance!.votingPowerStrategy.toLowerCase()}`,
+    )
+    .sort()
+    .join(",");
+}
+
+function parsePositionMembers(memberKey: string) {
+  return memberKey.split(",").map((m) => {
+    const [chainId, token, votingPowerStrategy] = m.split(":");
+    return {
+      chainId: Number(chainId),
+      token: token as Address,
+      votingPowerStrategy: votingPowerStrategy as Address,
+    };
+  });
 }
 
 /**
@@ -185,7 +213,7 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
   });
   const decimalsCache = useRef(new Map<string, number>());
 
-  const memberKey = familyMemberKey(family);
+  const memberKey = familyPositionMemberKey(family);
   const account = address?.toLowerCase() ?? "";
 
   useEffect(() => {
@@ -193,7 +221,7 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
       setPos({ perChain: [], partial: false });
       return;
     }
-    const members = parseMembers(memberKey);
+    const members = parsePositionMembers(memberKey);
 
     let cancelled = false;
     const load = async () => {
@@ -211,7 +239,7 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
               });
               decimalsCache.current.set(key, decimals);
             }
-            const [balance, votes] = await Promise.all([
+            const [balance, votingPower] = await Promise.all([
               client.readContract({
                 address: m.token,
                 abi: erc20Abi,
@@ -220,9 +248,9 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
               }),
               client
                 .readContract({
-                  address: m.token,
-                  abi: tokenAbi,
-                  functionName: "getVotes",
+                  address: m.votingPowerStrategy,
+                  abi: votingPowerAbi,
+                  functionName: "getCurrentVotingPower",
                   args: [account as Address],
                 })
                 .catch(() => 0n) as Promise<bigint>,
@@ -230,7 +258,7 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
             return {
               chainId: m.chainId,
               balance18: scaleTo18(balance, decimals),
-              votes18: scaleTo18(votes, decimals),
+              votes18: scaleTo18(votingPower, decimals),
             };
           } catch {
             return null;

--- a/src/hooks/use-voting.ts
+++ b/src/hooks/use-voting.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { BaseError, ContractFunctionRevertedError } from "viem";
+import { type Address, BaseError, ContractFunctionRevertedError } from "viem";
 import { useAccount, useReadContract, useSignTypedData } from "wagmi";
 import { votingModuleAbi, votingPowerAbi } from "@/lib/abis";
 import { useActiveChainId, useInstance } from "@/components/instance-provider";
@@ -75,6 +75,26 @@ export function useVotingState() {
       void power.refetch();
     },
   };
+}
+
+/**
+ * The connected account's actual voting power for the current cycle — the
+ * value the Voting Power Strategy computes and the Voting Module uses to
+ * weight votes.
+ */
+export function useCurrentVotingPower(account?: Address) {
+  const a = useInstance();
+  const chainId = useActiveChainId();
+  const { address } = useAccount();
+  const owner = account ?? address;
+  return useReadContract({
+    address: a.votingPowerStrategy,
+    abi: votingPowerAbi,
+    functionName: "getCurrentVotingPower",
+    args: owner ? [owner] : undefined,
+    chainId,
+    query: { enabled: Boolean(owner), ...LIVE },
+  });
 }
 
 /**


### PR DESCRIPTION
Closes #193

## Problem

The "Your voting power" stat on the Portfolio page showed `getVotes()` —
the raw self-delegated ERC20Votes balance right now — instead of the value
actually used to weight votes, `getCurrentVotingPower()` from the Voting
Power Strategy (already used correctly on the Vote page).

The two can diverge significantly: voting power is a time-weighted average
over the current cycle's period, so it dilutes the longer a completed cycle
goes without being distributed (in testing, 250 vs 0.0429 for the same
account).

## Fix

- Added `useCurrentVotingPower()` in `use-voting.ts`, reusing the same
  `getCurrentVotingPower()` read already used by the Vote page.
- Portfolio now uses it instead of `useVotes()` for this stat.

Note: the family-mode aggregate (`use-family-stats.ts`) sums raw
`getVotes()` per sibling chain too, so it has the same underlying issue —
left out of this PR to keep it scoped; happy to file separately.

## Verification

No frontend test suite exists in this repo, so verified manually on a
local Anvil fork of Gnosis: deposited into the existing `CSTAKE (default)`
instance, confirmed Portfolio and Vote show the same voting power
immediately after deposit (0) and after mining blocks (0.0429) — see GIF
below.

<img width="1536" height="674" alt="voting-power-fix-portfolio-vs-vote" src="https://github.com/user-attachments/assets/0ffb93ed-bf02-4537-8a5f-82b502709c0a" />

cc @RonTuretzky 

