### PR TITLE
fix(cycle): defer cycle length changes to the next cycle

### DIFF
--- a/contracts/src/abstract/AbstractCycleModule.sol
+++ b/contracts/src/abstract/AbstractCycleModule.sol
@@ -170,6 +170,15 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
         }
 
         AbstractCycleModuleStorage storage $ = _getAbstractCycleModuleStorage();
+
+        uint256 pending = $.pendingCycleLength;
+        if (pending != 0) {
+            uint256 oldLength = $.cycleLength;
+            $.cycleLength = pending;
+            $.pendingCycleLength = 0;
+            emit CycleLengthUpdated(oldLength, pending);
+        }
+
         $.currentCycle++;
         $.lastCycleStartBlock = block.number;
 
@@ -207,11 +216,9 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
             revert InvalidCycleLength();
         }
 
-        AbstractCycleModuleStorage storage $ = _getAbstractCycleModuleStorage();
-        uint256 oldLength = $.cycleLength;
-        $.cycleLength = newCycleLength;
+        _getAbstractCycleModuleStorage().pendingCycleLength = newCycleLength;
 
-        emit CycleLengthUpdated(oldLength, newCycleLength);
+        emit CycleLengthUpdatePending(newCycleLength);
     }
 
     /// @notice Sets the distribution manager address authorized to call startNewCycle()

--- a/contracts/src/abstract/AbstractCycleModule.sol
+++ b/contracts/src/abstract/AbstractCycleModule.sol
@@ -22,6 +22,8 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
         uint256 lastCycleStartBlock;
         /// @notice The address authorized to call startNewCycle()
         address distributionManager;
+        /// @notice Cycle length staged for the next cycle (0 = none pending)
+        uint256 pendingCycleLength;
     }
 
     // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.AbstractCycleModule")) - 1)) & ~bytes32(uint256(0xff))
@@ -54,6 +56,11 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
     /// @notice The address authorized to call startNewCycle()
     function distributionManager() public view returns (address) {
         return _getAbstractCycleModuleStorage().distributionManager;
+    }
+
+    /// @notice The cycle length staged for the next cycle (0 = none pending)
+    function pendingCycleLength() public view returns (uint256) {
+        return _getAbstractCycleModuleStorage().pendingCycleLength;
     }
 
     // ============ Errors ============
@@ -92,6 +99,10 @@ abstract contract AbstractCycleModule is ICycleModule, OwnableUpgradeable {
     /// @param oldLength The previous cycle length
     /// @param newLength The new cycle length
     event CycleLengthUpdated(uint256 oldLength, uint256 newLength);
+
+    /// @notice Emitted when a new cycle length is staged for the next cycle
+    /// @param pendingLength The cycle length that will apply once the next cycle starts
+    event CycleLengthUpdatePending(uint256 pendingLength);
 
     /// @notice Emitted when the module is initialized
     /// @param cycleLength The cycle length in blocks

--- a/contracts/src/interfaces/ICycleModule.sol
+++ b/contracts/src/interfaces/ICycleModule.sol
@@ -37,6 +37,10 @@ interface ICycleModule {
     /// @return The cycle length in blocks
     function cycleLength() external view returns (uint256);
 
+    /// @notice Gets the cycle length staged for the next cycle (0 = none pending)
+    /// @return The pending cycle length in blocks
+    function pendingCycleLength() external view returns (uint256);
+
     /// @notice Gets the address authorized to call startNewCycle()
     /// @return The distribution manager address
     function distributionManager() external view returns (address);

--- a/contracts/test/CycleModule.t.sol
+++ b/contracts/test/CycleModule.t.sol
@@ -141,6 +141,21 @@ contract CycleModuleTest is Test {
         freshModule.startNewCycle();
     }
 
+    // ============ when starting a new cycle with a pending cycle length ============
+
+    function test_WhenStartingNewCycleWithPendingLength_ItShouldApplyTheLength() public {
+        vm.roll(START_BLOCK + CYCLE_LENGTH);
+        cycleModule.updateCycleLength(50);
+
+        uint256 currentBlock = block.number;
+        vm.prank(distManager);
+        cycleModule.startNewCycle();
+
+        assertEq(cycleModule.cycleLength(), 50);
+        assertEq(cycleModule.pendingCycleLength(), 0);
+        assertEq(cycleModule.lastCycleStartBlock(), currentBlock);
+    }
+
     // ============ when querying blocks until next cycle ============
 
     function test_WhenQueryingBlocksUntilNextCycle_ItShouldReturnFullCycleLengthAtStart() public view {
@@ -175,10 +190,18 @@ contract CycleModuleTest is Test {
 
     // ============ when updating cycle length as owner ============
 
-    function test_WhenUpdatingCycleLengthAsOwner_ItShouldUpdateTheCycleLength() public {
+    function test_WhenUpdatingCycleLengthAsOwner_ItShouldStageThePendingLength() public {
         uint256 newLength = 200;
         cycleModule.updateCycleLength(newLength);
-        assertEq(cycleModule.cycleLength(), newLength);
+        assertEq(cycleModule.pendingCycleLength(), newLength);
+        assertEq(cycleModule.cycleLength(), CYCLE_LENGTH);
+    }
+
+    function test_WhenUpdatingCycleLengthAsOwner_ItShouldNotAffectTheInProgressCycle() public {
+        // One block before the original cycle would complete
+        vm.roll(START_BLOCK + CYCLE_LENGTH - 1);
+        cycleModule.updateCycleLength(1);
+        assertFalse(cycleModule.isCycleComplete());
     }
 
     // ============ when updating cycle length to zero ============

--- a/contracts/test/CycleModule.tree
+++ b/contracts/test/CycleModule.tree
@@ -18,6 +18,8 @@ CycleModuleTest
 │   └── it should revert with OnlyDistributionManager
 ├── when starting a new cycle without distribution manager set
 │   └── it should revert with DistributionManagerNotSet
+├── when starting a new cycle with a pending cycle length
+│   └── it should apply the pending length and clear it
 ├── when querying blocks until next cycle
 │   ├── it should return full cycle length at start
 │   ├── it should return remaining blocks partway
@@ -27,7 +29,8 @@ CycleModuleTest
 │   ├── it should return 50 halfway
 │   └── it should return 100 when complete
 ├── when updating cycle length as owner
-│   └── it should update the cycle length
+│   ├── it should stage the pending length
+│   └── it should not affect the in-progress cycle
 ├── when updating cycle length to zero
 │   └── it should revert with InvalidCycleLength
 ├── when updating cycle length as non owner

--- a/contracts/test/DistributionStrategies.t.sol
+++ b/contracts/test/DistributionStrategies.t.sol
@@ -140,6 +140,10 @@ contract MockCycleModule is ICycleModule {
     function cycleLength() external pure override returns (uint256) {
         return 200;
     }
+
+    function pendingCycleLength() external pure override returns (uint256) {
+        return 0;
+    }
 }
 
 // ============ Mock Yield Token (ERC20 + IYieldModule combined) ============

--- a/contracts/test/fuzz/CycleFuzz.t.sol
+++ b/contracts/test/fuzz/CycleFuzz.t.sol
@@ -119,7 +119,8 @@ contract CycleFuzz is Test {
         } else {
             vm.prank(owner);
             cycleModule.updateCycleLength(newLen);
-            assertEq(cycleModule.cycleLength(), newLen);
+            assertEq(cycleModule.pendingCycleLength(), newLen);
+            assertEq(cycleModule.cycleLength(), 100);
         }
     }
 

--- a/contracts/test/mocks/MockCycleModule.sol
+++ b/contracts/test/mocks/MockCycleModule.sol
@@ -41,6 +41,10 @@ contract MockCycleModule is ICycleModule {
         return 1;
     }
 
+    function pendingCycleLength() external view override returns (uint256) {
+        return 0;
+    }
+
     function distributionManager() external view override returns (address) {
         return address(0);
     }

--- a/src/app/app/admin/page.tsx
+++ b/src/app/app/admin/page.tsx
@@ -323,7 +323,7 @@ function CycleLength() {
         status={tx.status}
         hash={tx.hash}
         error={tx.error}
-        successLabel="Cycle length updated"
+        successLabel="Cycle length update staged"
       />
     </Card>
   );

--- a/src/app/app/admin/page.tsx
+++ b/src/app/app/admin/page.tsx
@@ -291,6 +291,13 @@ function CycleLength() {
             : "—"}
         </span>
       </Body>
+      {cycle.pendingCycleLength !== undefined &&
+        cycle.pendingCycleLength > 0n && (
+          <Caption className="text-system-warning mt-1 block">
+            Pending: {blocksToDuration(cycle.pendingCycleLength, blockTimeSeconds)}{" "}
+            — applies at the start of the next cycle.
+          </Caption>
+        )}
       <div className="mt-3">
         <DurationInput onChange={setSeconds} disabled={tx.isBusy} />
       </div>
@@ -310,7 +317,7 @@ function CycleLength() {
         Update
       </Button>
       <Caption className="text-surface-grey mt-1 block">
-        Applies immediately — it changes when the current cycle ends.
+        Applies to the next cycle — the current cycle is unaffected.
       </Caption>
       <TxStatus
         status={tx.status}

--- a/src/hooks/use-cycle.ts
+++ b/src/hooks/use-cycle.ts
@@ -81,6 +81,9 @@ export function useCycle() {
     isLoading: cycle.isLoading || length.isLoading,
     refetch: () => {
       void cycle.refetch();
+      // startNewCycle() applies any pending length, so a distribution changes
+      // cycleLength too — without this the UI keeps a stale length (and progress).
+      void length.refetch();
       void complete.refetch();
       void lastStart.refetch();
       void blocksLeft.refetch();

--- a/src/hooks/use-cycle.ts
+++ b/src/hooks/use-cycle.ts
@@ -49,6 +49,13 @@ export function useCycle() {
     chainId,
     query: LIVE,
   });
+  const pending = useReadContract({
+    address: a.cycleModule,
+    abi: cycleModuleAbi,
+    functionName: "pendingCycleLength",
+    chainId,
+    query: LIVE,
+  });
 
   const cycleLength = length.data;
   const lastStartBlock = lastStart.data;
@@ -65,6 +72,7 @@ export function useCycle() {
   return {
     cycleNumber: cycle.data,
     cycleLength,
+    pendingCycleLength: pending.data,
     lastStartBlock,
     blockNumber,
     isComplete: complete.data ?? false,
@@ -76,6 +84,7 @@ export function useCycle() {
       void complete.refetch();
       void lastStart.refetch();
       void blocksLeft.refetch();
+      void pending.refetch();
     },
   };
 }

--- a/src/lib/abis/cycle-module.ts
+++ b/src/lib/abis/cycle-module.ts
@@ -75,6 +75,13 @@ export const cycleModuleAbi = [
   },
   {
     type: "function",
+    name: "pendingCycleLength",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "renounceOwnership",
     inputs: [],
     outputs: [],
@@ -128,6 +135,19 @@ export const cycleModuleAbi = [
       },
       {
         name: "newLength",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "CycleLengthUpdatePending",
+    inputs: [
+      {
+        name: "pendingLength",
         type: "uint256",
         indexed: false,
         internalType: "uint256",


### PR DESCRIPTION
Closes #194

## Problem

`updateCycleLength()` is documented as changing the length "for future
cycles", but it wrote directly to the same `cycleLength` storage slot
that `isCycleComplete()` reads for the cycle currently in progress —
shortening the length could make an in-progress cycle read as
"complete" instantly, with no timelock at all (unlike the yield-claimer
rotation, which has an explicit 14-day delay for a comparably sensitive
change).

## Fix

- `AbstractCycleModule.sol`: new `pendingCycleLength` storage field —
  `updateCycleLength()` now stages it instead of writing `cycleLength`
  directly; `startNewCycle()` applies (and clears) any pending length
  exactly when the next cycle actually begins. No timelock needed here,
  just deferred application matching the doc comment's original intent.
- Updated the two hand-rolled `ICycleModule` test mocks and the
  existing/fuzzed tests that assumed the old immediate-effect behavior;
  added a direct regression test for the in-progress-cycle case.
- Frontend: `useCycle()` now exposes `pendingCycleLength`; the Admin
  page's Cycle length card surfaces a "Pending: … — applies at the
  start of the next cycle" line, and the previously-incorrect
  "Applies immediately" caption is fixed. Also updated the (manually
  maintained) cycle-module ABI, which was missing the new
  function/event.

## Verification

Full Foundry suite passes (449 tests). Manually verified on a local
fork by redeploying the patched contracts..

<img width="1568" height="688" alt="cycle-length-fix-working" src="https://github.com/user-attachments/assets/a5a856aa-1b15-443f-848e-a2261dec65fc" />


cc @RonTuretzky