### PR TITLE
fix: show strategy voting power on Portfolio

### DIFF
--- a/contracts/test/StakePool.t.sol
+++ b/contracts/test/StakePool.t.sol
@@ -137,8 +137,9 @@ contract StakePoolTest is Test {
     }
 
     function test_FrontendVotingReads_GetVotesAndDelegates() public {
-        // The live frontend reads getVotes/delegates directly on instance.token (portfolio voting
-        // power, admin delegation card, family stats), not only through the strategy.
+        // Pool must expose getVotes/delegates on instance.token (auto self-delegate on
+        // deposit) so admin re-delegation and strategy inputs stay coherent. Portfolio
+        // "Your voting power" reads Voting Power Strategy getCurrentVotingPower instead.
         assertEq(pool.getVotes(alice), 0, "no votes before deposit");
         assertEq(pool.delegates(alice), alice, "auto self-delegated: delegate is the account itself");
 

--- a/e2e/verify-pool-mode.ts
+++ b/e2e/verify-pool-mode.ts
@@ -209,8 +209,9 @@ async function main(): Promise<void> {
   });
   ok(supply === depositWei, `totalSupply == deposit (${supply})`);
   // Voting-power surface: a pool self-delegates on deposit (no transfer
-  // surface, so votes can't be moved), exactly like the token instance — the
-  // app reads getVotes/delegates on instance.token to show voting power.
+  // surface, so votes can't be moved), exactly like the token instance —
+  // getVotes/delegates remain the token-level inputs the strategy reads.
+  // Portfolio / Vote UI weight uses strategy getCurrentVotingPower, not getVotes.
   const votes = await pub.readContract({
     address: pool,
     abi: tokenAbi,

--- a/e2e/verify-portfolio-voting-power.ts
+++ b/e2e/verify-portfolio-voting-power.ts
@@ -1,0 +1,382 @@
+/*
+ * Focused verification for issue #193 / Portfolio voting-power fix.
+ *
+ * Proves:
+ *   1. Source wiring: Portfolio single-chain uses useCurrentVotingPower
+ *      (strategy getCurrentVotingPower), not token getVotes; family mode
+ *      fans out getCurrentVotingPower on each sibling strategy.
+ *   2. On anvil fork: after mint + long undistributed completed cycle,
+ *      getVotes stays at raw delegated balance while getCurrentVotingPower
+ *      dilutes (the divergence that made Portfolio misleading).
+ *   3. Family-mode aggregate semantics: Σ getCurrentVotingPower equals the
+ *      sum of per-sibling strategy reads (not Σ getVotes).
+ *
+ *   anvil --fork-url https://gnosis-rpc.publicnode.com --chain-id 100 --port 8547
+ *   RPC_URL=http://localhost:8547 npx tsx e2e/verify-portfolio-voting-power.ts
+ */
+import {
+  createPublicClient,
+  createWalletClient,
+  decodeEventLog,
+  encodePacked,
+  http,
+  keccak256,
+  parseEther,
+  type Address,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { gnosis } from "viem/chains";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { votingPowerAbi } from "../src/lib/abis/voting-power";
+import { tokenAbi } from "../src/lib/abis/token";
+import { recipientRegistryAbi } from "../src/lib/abis/recipient-registry";
+import { cycleModuleAbi } from "../src/lib/abis/cycle-module";
+import { deployerAbi } from "../src/lib/abis/crowdstake-deployer";
+
+const RPC = process.env.RPC_URL ?? "http://localhost:8547";
+// Live v3 (pool-capable) deployer on Gnosis — matches src/lib/chains.ts.
+const DEPLOYER: Address = "0x47Ca7c1CDa33D72cF94Fd27444900B97D2D8F11c";
+const account = privateKeyToAccount(
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+);
+const R1: Address = "0x1111111111111111111111111111111111111111";
+const R2: Address = "0x2222222222222222222222222222222222222222";
+
+const pub = createPublicClient({ chain: gnosis, transport: http(RPC) });
+const wallet = createWalletClient({
+  account,
+  chain: gnosis,
+  transport: http(RPC),
+});
+
+let failures = 0;
+function ok(cond: boolean, label: string): void {
+  console.log(`${cond ? "  ✔" : "  ✘ FAIL"} ${label}`);
+  if (!cond) failures += 1;
+}
+
+async function mine(blocks: number): Promise<void> {
+  await fetch(RPC, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "anvil_mine",
+      params: ["0x" + blocks.toString(16)],
+    }),
+  });
+}
+
+function assertSourceWiring(): void {
+  console.log("\n== Source wiring (issue #193) ==");
+  const root = join(__dirname, "..");
+  const page = readFileSync(join(root, "src/app/app/page.tsx"), "utf8");
+  const voting = readFileSync(join(root, "src/hooks/use-voting.ts"), "utf8");
+  const family = readFileSync(
+    join(root, "src/hooks/use-family-stats.ts"),
+    "utf8",
+  );
+
+  ok(
+    page.includes("useCurrentVotingPower") &&
+      page.includes('from "@/hooks/use-voting"'),
+    "Portfolio page imports useCurrentVotingPower from use-voting",
+  );
+  ok(!/\buseVotes\b/.test(page), "Portfolio page does not reference useVotes");
+  ok(
+    page.includes("Strategy weight used on the Vote page"),
+    'Portfolio copy says "Strategy weight used on the Vote page"',
+  );
+  ok(
+    /export function useCurrentVotingPower/.test(voting) &&
+      voting.includes("getCurrentVotingPower") &&
+      voting.includes("votingPowerStrategy"),
+    "useCurrentVotingPower reads strategy getCurrentVotingPower",
+  );
+  ok(
+    family.includes("getCurrentVotingPower") &&
+      family.includes("votingPowerStrategy") &&
+      family.includes("votingPowerAbi"),
+    "useFamilyPosition fans out getCurrentVotingPower on strategy",
+  );
+  ok(
+    !/functionName:\s*"getVotes"/.test(family),
+    "use-family-stats no longer calls token getVotes for votes18",
+  );
+  // Vote page still uses strategy power via useVotingState
+  const votePage = readFileSync(
+    join(root, "src/app/app/vote/page.tsx"),
+    "utf8",
+  );
+  ok(
+    votePage.includes("useVotingState") || votePage.includes("votingPower"),
+    "Vote page still surfaces strategy voting power",
+  );
+}
+
+type Deployed = {
+  token: Address;
+  votingPowerStrategy: Address;
+  cycleModule: Address;
+  registry: Address;
+};
+
+async function deployInstance(
+  tag: string,
+  cycleLength: bigint,
+): Promise<Deployed> {
+  const salt = keccak256(
+    encodePacked(["string"], [`portfolio-vp-${tag}-${Date.now()}`]),
+  );
+  const deployHash = await wallet.writeContract({
+    address: DEPLOYER,
+    abi: deployerAbi,
+    functionName: "deploy",
+    args: [
+      {
+        owner: account.address,
+        cycleLength,
+        tokenName: `VPTest-${tag}`,
+        tokenSymbol: "VPT",
+        maxVotingPoints: 10_000n,
+        salt,
+        registryKind: 0,
+        initialRecipients: [R1, R2],
+        proposalExpiry: 0n,
+        distributionKind: 0,
+        tokenImageURI: "",
+        bannerImageURI: "",
+        crossChain: false,
+        issueToken: true,
+      },
+    ],
+  });
+  const receipt = await pub.waitForTransactionReceipt({ hash: deployHash });
+  ok(receipt.status === "success", `deploy(${tag}) succeeded`);
+
+  let token: Address | undefined;
+  let votingPowerStrategy: Address | undefined;
+  let cycleModule: Address | undefined;
+  let registry: Address | undefined;
+  for (const log of receipt.logs) {
+    try {
+      const ev = decodeEventLog({
+        abi: deployerAbi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (ev.eventName === "SystemDeployed") {
+        token = ev.args.instance.token;
+        votingPowerStrategy = ev.args.instance.votingPowerStrategy;
+        cycleModule = ev.args.instance.cycleModule;
+        registry = ev.args.instance.registry;
+      }
+    } catch {
+      /* not our event */
+    }
+  }
+  if (!token || !votingPowerStrategy || !cycleModule || !registry) {
+    throw new Error(`SystemDeployed missing for ${tag}`);
+  }
+
+  const queueHash = await wallet.writeContract({
+    address: registry,
+    abi: recipientRegistryAbi,
+    functionName: "queueRecipientsAddition",
+    args: [[R1, R2]],
+  });
+  await pub.waitForTransactionReceipt({ hash: queueHash });
+  const processHash = await wallet.writeContract({
+    address: registry,
+    abi: recipientRegistryAbi,
+    functionName: "processQueue",
+  });
+  await pub.waitForTransactionReceipt({ hash: processHash });
+
+  return { token, votingPowerStrategy, cycleModule, registry };
+}
+
+async function mintAndRead(
+  inst: Deployed,
+  value: bigint,
+): Promise<{ votes: bigint; power: bigint }> {
+  const mintHash = await wallet.writeContract({
+    address: inst.token,
+    abi: tokenAbi,
+    functionName: "mint",
+    args: [account.address],
+    value,
+  });
+  await pub.waitForTransactionReceipt({ hash: mintHash });
+  const votes = (await pub.readContract({
+    address: inst.token,
+    abi: tokenAbi,
+    functionName: "getVotes",
+    args: [account.address],
+  })) as bigint;
+  const power = (await pub.readContract({
+    address: inst.votingPowerStrategy,
+    abi: votingPowerAbi,
+    functionName: "getCurrentVotingPower",
+    args: [account.address],
+  })) as bigint;
+  return { votes, power };
+}
+
+async function onChainDivergence(): Promise<void> {
+  console.log("\n== On-chain: getVotes vs getCurrentVotingPower ==");
+  // Short cycle so we can complete it; mint late then extend the window
+  // far past cycle end without startNewCycle (undistributed complete).
+  const cycleLength = 100n;
+  const inst = await deployInstance("single", cycleLength);
+
+  // Burn most of the cycle with zero balance so late mint dilutes hard.
+  await mine(80);
+  const afterMint = await mintAndRead(inst, parseEther("100"));
+  console.log(
+    `  right after mint: getVotes=${afterMint.votes} power=${afterMint.power}`,
+  );
+  ok(afterMint.votes > 0n, `getVotes non-zero after mint (${afterMint.votes})`);
+  ok(
+    afterMint.power < afterMint.votes / 5n,
+    `late mint already dilutes strategy power (${afterMint.power} << ${afterMint.votes})`,
+  );
+
+  // Finish the cycle and keep the period growing without distributing.
+  await mine(50);
+  const complete = await pub.readContract({
+    address: inst.cycleModule,
+    abi: cycleModuleAbi,
+    functionName: "isCycleComplete",
+  });
+  ok(complete === true, "cycle is complete (undistributed)");
+
+  // Grow the lookback past cycle end without startNewCycle (issue #193).
+  await mine(500);
+  const votes = (await pub.readContract({
+    address: inst.token,
+    abi: tokenAbi,
+    functionName: "getVotes",
+    args: [account.address],
+  })) as bigint;
+  const power = (await pub.readContract({
+    address: inst.votingPowerStrategy,
+    abi: votingPowerAbi,
+    functionName: "getCurrentVotingPower",
+    args: [account.address],
+  })) as bigint;
+
+  console.log(
+    `  after undistributed completed cycle: getVotes=${votes} getCurrentVotingPower=${power}`,
+  );
+  ok(votes === afterMint.votes, "getVotes unchanged (raw delegated balance)");
+  ok(
+    power !== votes,
+    `divergence persists after complete cycle (power=${power} != votes=${votes})`,
+  );
+  // Late-mint into a long lookback: strategy power is strictly below raw
+  // delegated balance (this is the Portfolio vs Vote mismatch in #193).
+  ok(
+    power < votes,
+    `strategy power below getVotes (power=${power} < votes=${votes})`,
+  );
+
+  console.log(
+    `  OLD Portfolio (getVotes): ${votes}\n  NEW Portfolio / Vote (getCurrentVotingPower): ${power}`,
+  );
+}
+
+async function familyAggregateSemantics(): Promise<void> {
+  console.log("\n== Family-mode aggregate (Σ strategy power) ==");
+  // Two independent classic instances stand in for family siblings —
+  // the app sums getCurrentVotingPower per sibling strategy.
+  const a = await deployInstance("fam-a", 200_000n);
+  const b = await deployInstance("fam-b", 200_000n);
+
+  await mine(5);
+  const mintA = await wallet.writeContract({
+    address: a.token,
+    abi: tokenAbi,
+    functionName: "mint",
+    args: [account.address],
+    value: parseEther("40"),
+  });
+  await pub.waitForTransactionReceipt({ hash: mintA });
+  const mintB = await wallet.writeContract({
+    address: b.token,
+    abi: tokenAbi,
+    functionName: "mint",
+    args: [account.address],
+    value: parseEther("60"),
+  });
+  await pub.waitForTransactionReceipt({ hash: mintB });
+  await mine(30);
+
+  const powerA = (await pub.readContract({
+    address: a.votingPowerStrategy,
+    abi: votingPowerAbi,
+    functionName: "getCurrentVotingPower",
+    args: [account.address],
+  })) as bigint;
+  const powerB = (await pub.readContract({
+    address: b.votingPowerStrategy,
+    abi: votingPowerAbi,
+    functionName: "getCurrentVotingPower",
+    args: [account.address],
+  })) as bigint;
+  const votesA = (await pub.readContract({
+    address: a.token,
+    abi: tokenAbi,
+    functionName: "getVotes",
+    args: [account.address],
+  })) as bigint;
+  const votesB = (await pub.readContract({
+    address: b.token,
+    abi: tokenAbi,
+    functionName: "getVotes",
+    args: [account.address],
+  })) as bigint;
+
+  const familyStrategySum = powerA + powerB;
+  const familyVotesSum = votesA + votesB;
+  console.log(
+    `  sibling A: getVotes=${votesA} power=${powerA}\n  sibling B: getVotes=${votesB} power=${powerB}`,
+  );
+  console.log(
+    `  family FIXED sum (Σ getCurrentVotingPower)=${familyStrategySum}\n  family OLD sum (Σ getVotes)=${familyVotesSum}`,
+  );
+  ok(powerA > 0n && powerB > 0n, "both siblings have strategy power");
+  ok(
+    familyStrategySum === powerA + powerB,
+    "family aggregate is sum of per-sibling getCurrentVotingPower",
+  );
+  // With short hold on long cycle they may already differ; if not, still
+  // prove the code path uses strategy addresses (source check) and that
+  // the sum is constructed from strategy reads.
+  ok(
+    familyStrategySum > 0n,
+    `fixed family voting power headline would show ${familyStrategySum}`,
+  );
+}
+
+async function main(): Promise<void> {
+  console.log(`voter: ${account.address}`);
+  console.log(`rpc: ${RPC}`);
+  assertSourceWiring();
+  await onChainDivergence();
+  await familyAggregateSemantics();
+
+  console.log(
+    failures === 0
+      ? "\nAll portfolio voting-power checks passed."
+      : `\n${failures} check(s) failed.`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -10,11 +10,11 @@ import { InstanceHeader } from "@/components/dapp/instance-header";
 import { OnboardingBanner } from "@/components/dapp/onboarding-banner";
 import {
   useTokenBalance,
-  useVotes,
   useNativeBalance,
   useInstanceToken,
   useYieldSplit,
 } from "@/hooks/use-token";
+import { useCurrentVotingPower } from "@/hooks/use-voting";
 import { useFamily } from "@/hooks/use-family";
 import {
   scaleTo18,
@@ -42,7 +42,7 @@ import {
 export default function PortfolioPage() {
   const { isConnected } = useAccount();
   const balance = useTokenBalance();
-  const votes = useVotes();
+  const votingPower = useCurrentVotingPower();
   const native = useNativeBalance();
   const cycle = useCycle();
   const { isReady } = useDistributionReady();
@@ -151,8 +151,10 @@ export default function PortfolioPage() {
           label={
             familyMode ? "Your voting power · all chains" : "Your voting power"
           }
-          value={familyMode ? fmt18(fpos.votes18) : fmt(votes.data)}
-          sub="Delegated automatically on deposit"
+          value={
+            familyMode ? fmt18(fpos.votes18) : fmt(votingPower.data)
+          }
+          sub="Strategy weight used on the Vote page"
         />
         <StatCard
           label={`Wallet ${nativeSym}`}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -151,9 +151,7 @@ export default function PortfolioPage() {
           label={
             familyMode ? "Your voting power · all chains" : "Your voting power"
           }
-          value={
-            familyMode ? fmt18(fpos.votes18) : fmt(votingPower.data)
-          }
+          value={familyMode ? fmt18(fpos.votes18) : fmt(votingPower.data)}
           sub="Strategy weight used on the Vote page"
         />
         <StatCard

--- a/src/hooks/use-family-stats.ts
+++ b/src/hooks/use-family-stats.ts
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { erc20Abi, type Address } from "viem";
 import { useAccount } from "wagmi";
-import { tokenAbi } from "@/lib/abis";
+import { tokenAbi, votingPowerAbi } from "@/lib/abis";
 import { publicClientFor } from "@/lib/instance";
 import type { FamilyState } from "@/hooks/use-family";
 
@@ -165,11 +165,39 @@ export function useFamilyStats(family: FamilyState): FamilyStats {
 export interface FamilyPosition {
   /** Σ balanceOf across siblings, normalized to 18 decimals. */
   balance18?: bigint;
-  /** Σ getVotes across siblings, normalized to 18 decimals. */
+  /**
+   * Σ Voting Power Strategy `getCurrentVotingPower` across siblings,
+   * normalized to 18 decimals. This is the weight the Voting Module uses —
+   * not raw `getVotes` (which can diverge while a cycle sits undistributed).
+   */
   votes18?: bigint;
   /** Per-chain balances (18-dp), for the "0.5 on Arbitrum" breakdown. */
   perChain: { chainId: number; balance18: bigint }[];
   partial: boolean;
+}
+
+/** chainId:token:votingPowerStrategy — position reads need the strategy address. */
+function familyPositionMemberKey(family: FamilyState): string {
+  if (!family.isFamily) return "";
+  return family.perChain
+    .filter((c) => c.instance)
+    .map(
+      (c) =>
+        `${c.chainId}:${c.instance!.token.toLowerCase()}:${c.instance!.votingPowerStrategy.toLowerCase()}`,
+    )
+    .sort()
+    .join(",");
+}
+
+function parsePositionMembers(memberKey: string) {
+  return memberKey.split(",").map((m) => {
+    const [chainId, token, votingPowerStrategy] = m.split(":");
+    return {
+      chainId: Number(chainId),
+      token: token as Address,
+      votingPowerStrategy: votingPowerStrategy as Address,
+    };
+  });
 }
 
 /**
@@ -185,7 +213,7 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
   });
   const decimalsCache = useRef(new Map<string, number>());
 
-  const memberKey = familyMemberKey(family);
+  const memberKey = familyPositionMemberKey(family);
   const account = address?.toLowerCase() ?? "";
 
   useEffect(() => {
@@ -193,7 +221,7 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
       setPos({ perChain: [], partial: false });
       return;
     }
-    const members = parseMembers(memberKey);
+    const members = parsePositionMembers(memberKey);
 
     let cancelled = false;
     const load = async () => {
@@ -211,7 +239,7 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
               });
               decimalsCache.current.set(key, decimals);
             }
-            const [balance, votes] = await Promise.all([
+            const [balance, votingPower] = await Promise.all([
               client.readContract({
                 address: m.token,
                 abi: erc20Abi,
@@ -220,9 +248,9 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
               }),
               client
                 .readContract({
-                  address: m.token,
-                  abi: tokenAbi,
-                  functionName: "getVotes",
+                  address: m.votingPowerStrategy,
+                  abi: votingPowerAbi,
+                  functionName: "getCurrentVotingPower",
                   args: [account as Address],
                 })
                 .catch(() => 0n) as Promise<bigint>,
@@ -230,7 +258,7 @@ export function useFamilyPosition(family: FamilyState): FamilyPosition {
             return {
               chainId: m.chainId,
               balance18: scaleTo18(balance, decimals),
-              votes18: scaleTo18(votes, decimals),
+              votes18: scaleTo18(votingPower, decimals),
             };
           } catch {
             return null;

--- a/src/hooks/use-voting.ts
+++ b/src/hooks/use-voting.ts
@@ -1,11 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import {
-  type Address,
-  BaseError,
-  ContractFunctionRevertedError,
-} from "viem";
+import { type Address, BaseError, ContractFunctionRevertedError } from "viem";
 import { useAccount, useReadContract, useSignTypedData } from "wagmi";
 import { votingModuleAbi, votingPowerAbi } from "@/lib/abis";
 import { useActiveChainId, useInstance } from "@/components/instance-provider";

--- a/src/hooks/use-voting.ts
+++ b/src/hooks/use-voting.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { BaseError, ContractFunctionRevertedError } from "viem";
+import {
+  type Address,
+  BaseError,
+  ContractFunctionRevertedError,
+} from "viem";
 import { useAccount, useReadContract, useSignTypedData } from "wagmi";
 import { votingModuleAbi, votingPowerAbi } from "@/lib/abis";
 import { useActiveChainId, useInstance } from "@/components/instance-provider";
@@ -14,6 +18,26 @@ import {
 } from "@/lib/vote-signature";
 
 const LIVE = { refetchInterval: 12_000 } as const;
+
+/**
+ * The connected account's actual voting power for the current cycle — the
+ * value the Voting Power Strategy computes and the Voting Module uses to
+ * weight votes (not raw token `getVotes`).
+ */
+export function useCurrentVotingPower(account?: Address) {
+  const a = useInstance();
+  const chainId = useActiveChainId();
+  const { address } = useAccount();
+  const owner = account ?? address;
+  return useReadContract({
+    address: a.votingPowerStrategy,
+    abi: votingPowerAbi,
+    functionName: "getCurrentVotingPower",
+    args: owner ? [owner] : undefined,
+    chainId,
+    query: { enabled: Boolean(owner), ...LIVE },
+  });
+}
 
 /**
  * Everything the vote page needs: current per-recipient vote distribution,


### PR DESCRIPTION
## Summary
- Fixes #193: Portfolio \"Your voting power\" now shows Voting Power Strategy `getCurrentVotingPower`, the same weight the Vote page uses.
- Also fixes the family-mode aggregate, which summed raw `getVotes` across siblings (called out as a follow-up in the issue).

## Root cause
`useVotes()` reads token `getVotes` (self-delegated balance). Time-weighted strategy power dilutes while a completed cycle sits undistributed, so the Portfolio number could read ~100 while Vote showed ~0.0265.

## Changes
- `useCurrentVotingPower()` hook (shared with Vote semantics)
- Portfolio single-chain stat uses strategy power
- `useFamilyPosition` fans out `getCurrentVotingPower` per sibling strategy address

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Wallet on an instance with an undistributed completed cycle: Portfolio VP matches Vote page
- [ ] Family mode: multi-chain sum reflects strategy power, not raw votes

Note: #195 from @llvcianov fixes the single-chain path only. This PR covers single-chain **and** family mode. Happy to close either if preferred.