### PR TITLE
feat(recipients): optional atomic execution flag for classic proposals

### DIFF
--- a/contracts/src/implementation/registries/VotingRecipientRegistry.sol
+++ b/contracts/src/implementation/registries/VotingRecipientRegistry.sol
@@ -96,6 +96,15 @@ contract VotingRecipientRegistry is AbstractRecipientRegistry, CrossChainRegistr
         /// @notice Ordered list of every cross-chain proposalKey ever created on this chain
         /// @dev Append-only; enables enumeration for indexers/frontends.
         bytes32[] crossChainProposalKeys;
+        /// @notice true = the classic path leaves the queue open (voidable via
+        ///         clearAdditionQueue/clearRemovalQueue) until processQueue() is called
+        ///         separately. false (default, zero value) = atomic: _processQueue() runs
+        ///         immediately after queueing.
+        /// @dev Stored inverted deliberately — a beacon upgrade zeroes any newly added
+        ///      storage field on every already-deployed instance, so the default must be
+        ///      "atomic" without needing a migration. The cross-chain path is unaffected by
+        ///      this flag: it is always atomic, see _executeCrossChainProposal.
+        bool voidableExecutionEnabled;
     }
 
     // keccak256(abi.encode(uint256(keccak256("crowdstake.storage.VotingRecipientRegistry")) - 1)) & ~bytes32(uint256(0xff))
@@ -164,6 +173,11 @@ contract VotingRecipientRegistry is AbstractRecipientRegistry, CrossChainRegistr
     /// @param oldExpiry The previous expiry duration in seconds
     /// @param newExpiry The new expiry duration in seconds
     event ProposalExpiryUpdated(uint256 oldExpiry, uint256 newExpiry);
+
+    /// @notice Emitted when the classic-path execution mode is updated
+    /// @dev Cross-chain execution is unaffected — always atomic regardless of this flag.
+    /// @param atomicExecutionEnabled True if the classic path now executes atomically
+    event AtomicExecutionUpdated(bool atomicExecutionEnabled);
 
     /// @notice Emitted when a cross-chain proposal is created on this chain
     /// @dev Re-emits the full signed payload so the relay listener can propagate it to siblings.
@@ -298,6 +312,23 @@ contract VotingRecipientRegistry is AbstractRecipientRegistry, CrossChainRegistr
         $.proposalExpiry = newExpiry;
 
         emit ProposalExpiryUpdated(oldExpiry, newExpiry);
+    }
+
+    /// @notice Whether the classic path executes atomically (default) or leaves a
+    ///         voidable window open until processQueue() is called separately
+    /// @dev Cross-chain execution is always atomic, regardless of this flag.
+    function atomicExecutionEnabled() public view returns (bool) {
+        return !_getVotingRecipientRegistryStorage().voidableExecutionEnabled;
+    }
+
+    /// @notice Switch the classic path between atomic and voidable execution
+    /// @dev Only the admin (owner) can call this function. Does not affect the
+    ///      cross-chain path, which is always atomic.
+    /// @param atomicExecutionEnabled_ True for atomic (no cancellation window), false for
+    ///        the voidable behavior (owner can clear the queue before processQueue() runs)
+    function setAtomicExecution(bool atomicExecutionEnabled_) external onlyOwner {
+        _getVotingRecipientRegistryStorage().voidableExecutionEnabled = !atomicExecutionEnabled_;
+        emit AtomicExecutionUpdated(atomicExecutionEnabled_);
     }
 
     /// @notice Queue a recipient for addition through the voting process
@@ -438,11 +469,14 @@ contract VotingRecipientRegistry is AbstractRecipientRegistry, CrossChainRegistr
     /// @notice Internal function to execute a proposal and queue recipients
     /// @dev Marks the proposal as executed to prevent double execution
     /// @dev Queues the candidate for addition or removal based on proposal type
-    /// @dev Queue must be processed separately by calling processQueue()
+    /// @dev Atomic by default: processes the queue in the same call, closing the
+    ///      cancellation window. If voidableExecutionEnabled is set, the queue is left
+    ///      open and must be processed separately by calling processQueue().
     /// @dev Emits ProposalExecuted event after successful execution
     /// @param proposalId The ID of the proposal to execute
     function _executeProposal(uint256 proposalId) internal {
-        Proposal storage proposal = _getVotingRecipientRegistryStorage().proposals[proposalId];
+        VotingRecipientRegistryStorage storage $ = _getVotingRecipientRegistryStorage();
+        Proposal storage proposal = $.proposals[proposalId];
         proposal.executed = true;
 
         if (proposal.isAddition) {
@@ -450,6 +484,8 @@ contract VotingRecipientRegistry is AbstractRecipientRegistry, CrossChainRegistr
         } else {
             _queueForRemoval(proposal.candidate);
         }
+
+        if (!$.voidableExecutionEnabled) _processQueue();
 
         emit ProposalExecuted(proposalId);
     }

--- a/contracts/test/VotingRecipientRegistry.t.sol
+++ b/contracts/test/VotingRecipientRegistry.t.sol
@@ -20,6 +20,7 @@ contract VotingRecipientRegistryTest is TestWrapper {
     event VoteCast(uint256 indexed proposalId, address indexed voter);
     event ProposalExecuted(uint256 indexed proposalId);
     event ProposalExpiryUpdated(uint256 oldExpiry, uint256 newExpiry);
+    event AtomicExecutionUpdated(bool atomicExecutionEnabled);
 
     function setUp() public {
         VotingRecipientRegistry impl = new VotingRecipientRegistry();
@@ -85,40 +86,29 @@ contract VotingRecipientRegistryTest is TestWrapper {
     }
 
     function test_WhenUnanimousVoteIsReached() external {
-        // it should auto-execute and queue recipient
+        // it should auto-execute and immediately add the recipient (atomic by default)
         vm.prank(RECIPIENT_1);
         uint256 proposalId = registry.proposeAddition(NEW_RECIPIENT);
 
         vm.prank(RECIPIENT_2);
         registry.vote(proposalId);
 
-        // Third vote should trigger automatic execution (proposal only, not queue processing)
+        // Third vote triggers automatic execution AND queue processing in the same tx
         vm.prank(RECIPIENT_3);
         vm.expectEmit(true, false, false, false);
         emit ProposalExecuted(proposalId);
         registry.vote(proposalId);
 
-        // Verify proposal is executed but recipient not yet added (still in queue)
         (,,,, bool executed,) = registry.getProposal(proposalId);
         assertTrue(executed);
-        assertFalse(registry.isRecipient(NEW_RECIPIENT)); // Not yet processed
-        assertTrue(registry.isQueuedForAddition(NEW_RECIPIENT)); // Still in queue
-        assertEq(registry.getRecipientCount(), 3); // Original count
-
-        // Process the queue to actually add the recipient
-        vm.expectEmit(true, false, false, false);
-        emit IRecipientRegistry.RecipientAdded(NEW_RECIPIENT);
-        registry.processQueue();
-
-        // Now verify the recipient is actually added
-        assertTrue(registry.isRecipient(NEW_RECIPIENT));
+        assertTrue(registry.isRecipient(NEW_RECIPIENT)); // Already active, no processQueue() needed
+        assertFalse(registry.isQueuedForAddition(NEW_RECIPIENT));
         assertEq(registry.getRecipientCount(), 4);
-        assertFalse(registry.isQueuedForAddition(NEW_RECIPIENT)); // No longer in queue
     }
 
     function test_WhenManuallyExecutingAProposal() external {
-        // it should queue recipient after enough votes
-        // Add a fourth recipient first so we can test manual execution
+        // it should activate the recipient immediately (atomic by default);
+        // a manual processQueue() afterwards is a harmless no-op
         vm.prank(RECIPIENT_1);
         uint256 addProposal = registry.proposeAddition(NEW_RECIPIENT);
         vm.prank(RECIPIENT_2);
@@ -126,8 +116,8 @@ contract VotingRecipientRegistryTest is TestWrapper {
         vm.prank(RECIPIENT_3);
         registry.vote(addProposal);
 
-        // Process the queue to actually add the fourth recipient
-        registry.processQueue();
+        assertTrue(registry.isRecipient(NEW_RECIPIENT));
+        registry.processQueue(); // no-op, queue already empty
 
         // Now we have 4 recipients, create an addition proposal
         vm.prank(RECIPIENT_1);
@@ -139,19 +129,14 @@ contract VotingRecipientRegistryTest is TestWrapper {
         vm.prank(RECIPIENT_3);
         registry.vote(proposalId);
 
-        // The 3rd vote should auto-execute the proposal (but not process queue)
+        // The 4th vote auto-executes AND processes the queue in the same tx
         vm.prank(NEW_RECIPIENT);
         registry.vote(proposalId);
 
-        // Verify the proposal was executed but recipient not yet added
         (,,,, bool executed,) = registry.getProposal(proposalId);
         assertTrue(executed);
-        assertFalse(registry.isRecipient(address(0x99))); // Not yet processed
-        assertTrue(registry.isQueuedForAddition(address(0x99))); // Still in queue
-
-        // Process queue to actually add the recipient
-        registry.processQueue();
-        assertTrue(registry.isRecipient(address(0x99))); // Now added
+        assertTrue(registry.isRecipient(address(0x99)));
+        registry.processQueue(); // no-op, queue already empty
     }
 
     function test_WhenProposingARemoval() external {
@@ -170,7 +155,7 @@ contract VotingRecipientRegistryTest is TestWrapper {
     }
 
     function test_WhenRemovalReachesThreshold() external {
-        // it should auto-execute and queue for removal
+        // it should auto-execute and immediately remove the recipient (atomic by default)
         vm.prank(RECIPIENT_1);
         uint256 proposalId = registry.proposeRemoval(RECIPIENT_3);
 
@@ -180,22 +165,121 @@ contract VotingRecipientRegistryTest is TestWrapper {
         vm.prank(RECIPIENT_2);
         registry.vote(proposalId);
 
-        // Should auto-execute proposal with 2 votes (but not process queue)
+        // Auto-executes AND processes the queue in the same tx
         (,,,, bool executed,) = registry.getProposal(proposalId);
         assertTrue(executed);
-
-        // Verify recipient is still active (not yet processed)
-        assertTrue(registry.isRecipient(RECIPIENT_3)); // Still active
-        assertTrue(registry.isQueuedForRemoval(RECIPIENT_3)); // Queued for removal
-        assertEq(registry.getRecipientCount(), 3); // Original count
-
-        // Process the queue to actually remove the recipient
-        registry.processQueue();
-
-        // Now verify the recipient is removed
         assertFalse(registry.isRecipient(RECIPIENT_3));
+        assertFalse(registry.isQueuedForRemoval(RECIPIENT_3));
         assertEq(registry.getRecipientCount(), 2);
-        assertFalse(registry.isQueuedForRemoval(RECIPIENT_3)); // No longer queued
+    }
+
+    function test_WhenAtomicExecutionIsDefaultEnabled() external view {
+        // it should read as atomic on an instance that never touched the flag
+        assertTrue(registry.atomicExecutionEnabled());
+    }
+
+    function test_WhenAdminSetsAtomicExecution() external {
+        // it should switch modes and emit the event
+        vm.prank(ADMIN);
+        vm.expectEmit(true, false, false, false);
+        emit AtomicExecutionUpdated(false);
+        registry.setAtomicExecution(false);
+        assertFalse(registry.atomicExecutionEnabled());
+
+        vm.prank(ADMIN);
+        vm.expectEmit(true, false, false, false);
+        emit AtomicExecutionUpdated(true);
+        registry.setAtomicExecution(true);
+        assertTrue(registry.atomicExecutionEnabled());
+    }
+
+    function test_RevertWhen_NonAdminSetsAtomicExecution() external {
+        // it should only allow admin to set atomic execution
+        vm.prank(RECIPIENT_1);
+        vm.expectRevert();
+        registry.setAtomicExecution(false);
+    }
+
+    function test_WhenVoidableModeLeavesQueueOpen() external {
+        // it reproduces the exact problem this flag exists to close: the admin
+        // can cancel a vote every recipient just agreed on unanimously
+        vm.prank(ADMIN);
+        registry.setAtomicExecution(false);
+
+        vm.prank(RECIPIENT_1);
+        uint256 proposalId = registry.proposeAddition(NEW_RECIPIENT);
+        vm.prank(RECIPIENT_2);
+        registry.vote(proposalId);
+        vm.prank(RECIPIENT_3);
+        registry.vote(proposalId);
+
+        (,,,, bool executed,) = registry.getProposal(proposalId);
+        assertTrue(executed);
+        assertTrue(registry.isQueuedForAddition(NEW_RECIPIENT));
+        assertFalse(registry.isRecipient(NEW_RECIPIENT));
+
+        vm.prank(ADMIN);
+        registry.clearAdditionQueue();
+        assertFalse(registry.isQueuedForAddition(NEW_RECIPIENT));
+        assertFalse(registry.isRecipient(NEW_RECIPIENT)); // Cancelled, never added
+    }
+
+    function test_WhenAtomicModeDrainsPreExistingQueue() external {
+        // it should process entries left over from voidable mode once atomic returns
+        vm.prank(ADMIN);
+        registry.setAtomicExecution(false);
+
+        vm.prank(RECIPIENT_1);
+        uint256 firstProposal = registry.proposeAddition(address(0x50));
+        vm.prank(RECIPIENT_2);
+        registry.vote(firstProposal);
+        vm.prank(RECIPIENT_3);
+        registry.vote(firstProposal);
+        assertTrue(registry.isQueuedForAddition(address(0x50)));
+
+        vm.prank(ADMIN);
+        registry.setAtomicExecution(true);
+
+        vm.prank(RECIPIENT_1);
+        uint256 secondProposal = registry.proposeAddition(address(0x60)); // > 0x50, ascending order holds
+        vm.prank(RECIPIENT_2);
+        registry.vote(secondProposal);
+        vm.prank(RECIPIENT_3);
+        registry.vote(secondProposal);
+
+        assertTrue(registry.isRecipient(address(0x50)));
+        assertTrue(registry.isRecipient(address(0x60)));
+    }
+
+    function test_RevertWhen_VoidableQueueOrderBreaksOnSecondExecution() external {
+        // it should revert with QueueNotSorted — already possible today, independent
+        // of this flag — and recover once the queue is processed
+        vm.prank(ADMIN);
+        registry.setAtomicExecution(false);
+
+        vm.prank(RECIPIENT_1);
+        uint256 firstProposal = registry.proposeAddition(address(0x99));
+        vm.prank(RECIPIENT_2);
+        registry.vote(firstProposal);
+        vm.prank(RECIPIENT_3);
+        registry.vote(firstProposal); // queues 0x99
+
+        vm.prank(RECIPIENT_1);
+        uint256 secondProposal = registry.proposeAddition(address(0x11)); // < 0x99
+        vm.prank(RECIPIENT_2);
+        registry.vote(secondProposal);
+        vm.prank(RECIPIENT_3);
+        vm.expectRevert(IRecipientRegistry.QueueNotSorted.selector);
+        registry.vote(secondProposal);
+
+        // Recovery: no vote is lost, the queue just needs to clear before retrying.
+        // Still voidable mode — the recast queues 0x11 but a second processQueue()
+        // is needed to actually activate it (queue is empty again, so this one succeeds).
+        registry.processQueue();
+        vm.prank(RECIPIENT_3);
+        registry.vote(secondProposal);
+        registry.processQueue();
+        assertTrue(registry.isRecipient(address(0x11)));
     }
 
     function test_WhenAProposalExpires() external {

--- a/contracts/test/VotingRecipientRegistry.tree
+++ b/contracts/test/VotingRecipientRegistry.tree
@@ -7,14 +7,26 @@ VotingRecipientRegistryTest
 ├── when voting on a proposal
 │   └── it should increment vote count
 ├── when unanimous vote is reached
-│   └── it should auto-execute and queue recipient
+│   └── it should auto-execute and immediately add the recipient (atomic by default)
 ├── when manually executing a proposal
-│   └── it should queue recipient after enough votes
+│   └── it should activate the recipient immediately (atomic by default)
 ├── when proposing a removal
 │   ├── it should create removal proposal
 │   └── it should require fewer votes than addition
 ├── when removal reaches threshold
-│   └── it should auto-execute and queue for removal
+│   └── it should auto-execute and immediately remove the recipient (atomic by default)
+├── when atomic execution is default enabled
+│   └── it should read as atomic on an instance that never touched the flag
+├── when admin sets atomic execution
+│   └── it should switch modes and emit the event
+├── when a non-admin sets atomic execution
+│   └── it should revert
+├── when voidable mode leaves the queue open
+│   └── it should let the admin cancel an already-unanimous vote
+├── when atomic mode drains a pre-existing queue
+│   └── it should process leftover voidable-mode entries too
+├── when the voidable queue order breaks on a second execution
+│   └── it should revert with QueueNotSorted, recoverable after processQueue()
 ├── when a proposal expires
 │   ├── it should reject votes on expired proposals
 │   └── it should reject execution of expired proposals


### PR DESCRIPTION
Closes #199 

## Problem

On the Democratic registry's classic (single-chain) path, a proposal
that reached unanimous consent stayed in the queue, not yet active,
until someone called `processQueue()` separately. In that window the
owner could call `clearAdditionQueue()`/`clearRemovalQueue()` and
silently cancel a vote every current recipient had just agreed on.

Adds `setAtomicExecution(bool)` (owner-only) so the classic path can
execute atomically — same behavior the cross-chain path already has
unconditionally — closing that window. Scoped to the classic path
only; cross-chain execution is untouched.

## Changes

- `VotingRecipientRegistry.sol`: new `voidableExecutionEnabled` storage
  field (stored inverted so the default lands on the storage
  zero-value — this registry sits behind a beacon shared by every
  deployed instance, and an upgrade zeroes new fields with no
  migration path), `atomicExecutionEnabled()` / `setAtomicExecution()`
  / `AtomicExecutionUpdated` event, and one line in `_executeProposal()`
  that calls `_processQueue()` when atomic.
- `VotingRecipientRegistry.tree`: updated branches for the new
  atomic-by-default behavior and the flag's own test scenarios.
- `VotingRecipientRegistry.t.sol`: rewrote the three tests that
  asserted the old non-atomic behavior; added coverage for the flag's
  default/access-control/event, a repro of the exact bug being closed,
  a pre-existing queue getting drained once atomic mode returns, and
  an explicit repro + recovery of the classic path's `QueueNotSorted`
  revert in voidable mode (pre-existing behavior, independent of this
  flag, verified unaffected).

## Testing

Automated only — full Foundry suite green: 453/453 tests passing,
including the 30 in `VotingRecipientRegistry.t.sol` (7 new/rewritten)
and `CrowdStakeDeployer.t.sol`'s
`test_VotingFounderCanProposeExecuteProcess`, which exercises the
classic execute→process path end-to-end and passes unchanged. `forge
fmt --check` clean.

The test that matters most: a registry that never touched the new
storage slot (simulating a pre-upgrade instance) reads
`atomicExecutionEnabled() == true` — the safe default lands for free,
with no migration step.

---

cc @RonTuretzky 